### PR TITLE
feat: allowed resource file types set expanded (woff/woff2/ico)

### DIFF
--- a/app/src/main/java/ch/sbb/polarion/extension/generic/GenericUiServlet.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/GenericUiServlet.java
@@ -30,7 +30,10 @@ public abstract class GenericUiServlet extends HttpServlet {
             Pair.of(".css", "text/css"),
             Pair.of(".png", "image/png"),
             Pair.of(".svg", "image/svg+xml"),
-            Pair.of(".gif", "image/gif")
+            Pair.of(".gif", "image/gif"),
+            Pair.of(".woff", "application/font-woff"),
+            Pair.of(".woff2", "application/font-woff2"),
+            Pair.of(".ico", "image/x-icon")
     );
 
     private static final Logger logger = Logger.getLogger(GenericUiServlet.class);

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/GenericUiServletTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/GenericUiServletTest.java
@@ -42,6 +42,18 @@ class GenericUiServletTest {
         GenericUiServlet.setContentType("/img.gif", response);
         verify(response, times(1)).setContentType("image/gif");
 
+        response = mock(HttpServletResponse.class);
+        GenericUiServlet.setContentType("/somFont.woff", response);
+        verify(response, times(1)).setContentType("application/font-woff");
+
+        response = mock(HttpServletResponse.class);
+        GenericUiServlet.setContentType("/somFont.woff2", response);
+        verify(response, times(1)).setContentType("application/font-woff2");
+
+        response = mock(HttpServletResponse.class);
+        GenericUiServlet.setContentType("/img.ico", response);
+        verify(response, times(1)).setContentType("image/x-icon");
+
         HttpServletResponse servletResponse = mock(HttpServletResponse.class);
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> GenericUiServlet.setContentType("unknown_file.xml", servletResponse));
         assertEquals("Unsupported file type", exception.getMessage());


### PR DESCRIPTION
Refs: #90

### Proposed changes

GenericUiServlet currently restricts some of the well-used file types which leads to resources loading errors in some derived plugins. Proposed changes will expand allowed resource file types set.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
