### PR TITLE
fix: show revision in the exception message if it was provided as a p…

### DIFF
--- a/app/src/main/java/ch/sbb/polarion/extension/generic/service/PolarionService.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/service/PolarionService.java
@@ -99,7 +99,7 @@ public class PolarionService {
 
         //Note: it seems that there is no way to get project for already deleted project (unlike workitems/modules & collections)
         //so method below will throw exception in this case
-        return getResolvableObjectOrThrow(projectService.getProject(projectId), revision, String.format("Project '%s' not found", projectId));
+        return getResolvableObjectOrThrow(projectService.getProject(projectId), revision, String.format("Project '%s'%s not found", projectId, getRevisionMessagePart(revision)));
     }
 
     @NotNull
@@ -120,7 +120,7 @@ public class PolarionService {
             throw new IllegalArgumentException("Parameter 'workItemId' should be provided");
         }
 
-        return getResolvableObjectOrThrow(trackerProject.getWorkItem(workItemId), revision, String.format("WorkItem '%s' not found in project '%s'", workItemId, projectId));
+        return getResolvableObjectOrThrow(trackerProject.getWorkItem(workItemId), revision, String.format("WorkItem '%s'%s not found in project '%s'", workItemId, getRevisionMessagePart(revision), projectId));
     }
 
     @NotNull
@@ -139,7 +139,7 @@ public class PolarionService {
         }
 
         ILocation location = Location.getLocation(spaceId + "/" + documentName);
-        return getResolvableObjectOrThrow(getModule(project, location), revision, String.format("Document '%s' not found in space '%s' of project '%s'", documentName, spaceId, projectId));
+        return getResolvableObjectOrThrow(getModule(project, location), revision, String.format("Document '%s'%s not found in space '%s' of project '%s'", documentName, getRevisionMessagePart(revision), spaceId, projectId));
     }
 
     @NotNull
@@ -166,7 +166,7 @@ public class PolarionService {
                                 .getOldApi()
                 )
         );
-        return getResolvableObjectOrThrow(collection, revision, String.format("Collection with id '%s' not found in project '%s'", collectionId, projectId));
+        return getResolvableObjectOrThrow(collection, revision, String.format("Collection with id '%s'%s not found in project '%s'", collectionId, getRevisionMessagePart(revision), projectId));
     }
 
     public <T extends IPObject> T getResolvableObjectOrThrow(@NotNull IPObject object, @Nullable String revision, @NotNull String notFoundMessage) {
@@ -292,5 +292,9 @@ public class PolarionService {
     @NotNull
     public IRepositoryReadOnlyConnection getReadOnlyConnection(@NotNull ILocation location) {
         return repositoryService.getReadOnlyConnection(location);
+    }
+
+    private String getRevisionMessagePart(String revision) {
+        return StringUtils.isEmpty(revision) ? "" : " (rev. %s)".formatted(revision);
     }
 }

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/service/PolarionServiceTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/service/PolarionServiceTest.java
@@ -87,7 +87,11 @@ public class PolarionServiceTest {
     void testGetNotExistentProject() {
         mockProject(Boolean.FALSE);
 
-        assertThrows(ObjectNotFoundException.class, () -> polarionService.getProject(PROJECT_ID, null));
+        ObjectNotFoundException exception = assertThrows(ObjectNotFoundException.class, () -> polarionService.getProject(PROJECT_ID, null));
+        assertEquals("Project 'project_id' not found", exception.getMessage());
+
+        exception = assertThrows(ObjectNotFoundException.class, () -> polarionService.getProject(PROJECT_ID, "123"));
+        assertEquals("Project 'project_id' (rev. 123) not found", exception.getMessage());
     }
 
     @Test
@@ -95,7 +99,11 @@ public class PolarionServiceTest {
         IProject project = mockProject(Boolean.TRUE);
         mockWorkItem(project, Boolean.FALSE);
 
-        assertThrows(ObjectNotFoundException.class, () -> polarionService.getWorkItem(PROJECT_ID, WI_ID));
+        ObjectNotFoundException exception = assertThrows(ObjectNotFoundException.class, () -> polarionService.getWorkItem(PROJECT_ID, WI_ID));
+        assertEquals("WorkItem 'wi_id' not found in project 'project_id'", exception.getMessage());
+
+        exception = assertThrows(ObjectNotFoundException.class, () -> polarionService.getWorkItem(PROJECT_ID, WI_ID, "123"));
+        assertEquals("WorkItem 'wi_id' (rev. 123) not found in project 'project_id'", exception.getMessage());
     }
 
     @Test
@@ -103,7 +111,11 @@ public class PolarionServiceTest {
         IProject project = mockProject(Boolean.TRUE);
         mockModule(project, Boolean.FALSE);
 
-        assertThrows(ObjectNotFoundException.class, () -> polarionService.getModule(PROJECT_ID, SPACE_ID, DOCUMENT_NAME));
+        ObjectNotFoundException exception = assertThrows(ObjectNotFoundException.class, () -> polarionService.getModule(PROJECT_ID, SPACE_ID, DOCUMENT_NAME));
+        assertEquals("Document 'document_name' not found in space 'space_id' of project 'project_id'", exception.getMessage());
+
+        exception = assertThrows(ObjectNotFoundException.class, () -> polarionService.getModule(PROJECT_ID, SPACE_ID, DOCUMENT_NAME, "123"));
+        assertEquals("Document 'document_name' (rev. 123) not found in space 'space_id' of project 'project_id'", exception.getMessage());
     }
 
     @Test
@@ -113,7 +125,11 @@ public class PolarionServiceTest {
             IBaselineCollection collection = mockCollection(Boolean.FALSE);
             transactionalExecutorMockedStatic.when(() -> TransactionalExecutor.executeSafelyInReadOnlyTransaction(any())).thenReturn(collection);
 
-            assertThrows(ObjectNotFoundException.class, () -> polarionService.getCollection(PROJECT_ID, COLLECTION_ID));
+            ObjectNotFoundException exception = assertThrows(ObjectNotFoundException.class, () -> polarionService.getCollection(PROJECT_ID, COLLECTION_ID));
+            assertEquals("Collection with id '1' not found in project 'project_id'", exception.getMessage());
+
+            exception = assertThrows(ObjectNotFoundException.class, () -> polarionService.getCollection(PROJECT_ID, COLLECTION_ID, "123"));
+            assertEquals("Collection with id '1' (rev. 123) not found in project 'project_id'", exception.getMessage());
         }
     }
 


### PR DESCRIPTION
…arameter for getting an entity

Refs: #127

### Proposed changes

ObjectNotFoundException which is thrown when entity was not found must contain revision if it was passed as an argument.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [ ] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
