### PR TITLE
feat!: additional block for internal extension information on the abo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ Maven's `pom.xml` should contain following content:
 </parent>
 ```
 
-* Specify extension context, automatic module name and web application name in POM's properties:
+* Specify extension context, automatic module name, discover base package and web application name in POM's properties:
 
 ```xml
 <properties>
     <maven-jar-plugin.Extension-Context>pdf-exporter</maven-jar-plugin.Extension-Context>
     <maven-jar-plugin.Automatic-Module-Name>ch.sbb.polarion.extension.pdf_exporter</maven-jar-plugin.Automatic-Module-Name>
+    <maven-jar-plugin.Discover-Base-Package>ch.sbb.polarion.extension.pdf.exporter</maven-jar-plugin.Discover-Base-Package>
     <web.app.name>${maven-jar-plugin.Extension-Context}</web.app.name>
 </properties>
 ```

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/configuration/ConfigurationStatus.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/configuration/ConfigurationStatus.java
@@ -1,0 +1,21 @@
+package ch.sbb.polarion.extension.generic.configuration;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConfigurationStatus {
+    private @NotNull String name;
+    private @NotNull Status status;
+    private @NotNull String details;
+
+    public ConfigurationStatus(@NotNull String name, @NotNull Status status) {
+        this(name, status, "");
+    }
+}

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/configuration/ConfigurationStatusProvider.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/configuration/ConfigurationStatusProvider.java
@@ -1,0 +1,59 @@
+package ch.sbb.polarion.extension.generic.configuration;
+
+import ch.sbb.polarion.extension.generic.regex.RegexMatcher;
+import ch.sbb.polarion.extension.generic.util.ContextUtils;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.SneakyThrows;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+@SuppressWarnings("unused")
+public abstract class ConfigurationStatusProvider {
+
+    @SneakyThrows
+    public static List<ConfigurationStatus> getAllStatuses(String scope) {
+        Context context = new Context(scope);
+        Set<Class<? extends ConfigurationStatusProvider>> subTypes = ContextUtils.findSubTypes(ConfigurationStatusProvider.class);
+        List<ConfigurationStatus> statuses = new ArrayList<>();
+        for (Class<? extends ConfigurationStatusProvider> subType : subTypes) {
+            ConfigurationStatusProvider provider = subType.getConstructor().newInstance();
+            statuses.addAll(provider.getStatuses(context));
+        }
+        return statuses;
+    }
+
+    public @NotNull List<ConfigurationStatus> getStatuses(@NotNull Context context) {
+        return List.of(getStatus(context));
+    }
+
+    public @NotNull ConfigurationStatus getStatus(@NotNull Context context) {
+        throw new IllegalStateException("Either must be implemented by a subclass or shouldn't be called");
+    }
+
+    protected @NotNull ConfigurationStatus getConfigurationStatus(@NotNull String name, @Nullable String content, @NotNull String regex) {
+        return getConfigurationStatus(name, content, regex, new ConfigurationStatus(name, Status.WARNING, "Not configured"));
+    }
+
+    protected @NotNull ConfigurationStatus getConfigurationStatus(@NotNull String name, @Nullable String content, @NotNull String regex, @NotNull ConfigurationStatus notOkStatus) {
+        if (content != null && contains(content, regex)) {
+            return new ConfigurationStatus(name, Status.OK);
+        } else {
+            return notOkStatus;
+        }
+    }
+
+    private static boolean contains(@NotNull String input, @NotNull String regex) {
+        return RegexMatcher.get(regex).anyMatch(input);
+    }
+
+    @Getter
+    @Builder
+    public static class Context {
+        private String scope;
+    }
+}

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/configuration/Status.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/configuration/Status.java
@@ -1,0 +1,16 @@
+package ch.sbb.polarion.extension.generic.configuration;
+
+public enum Status {
+    OK,
+    WARNING,
+    ERROR;
+
+    public String toHtml() {
+        String color = switch (this) {
+            case OK -> "green";
+            case WARNING -> "gray";
+            case ERROR -> "red";
+        };
+        return String.format("<span style='color: %s;'>%s</span>", color, this.name());
+    }
+}

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/configuration/Status.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/configuration/Status.java
@@ -8,7 +8,7 @@ public enum Status {
     public String toHtml() {
         String color = switch (this) {
             case OK -> "green";
-            case WARNING -> "gray";
+            case WARNING -> "orange";
             case ERROR -> "red";
         };
         return String.format("<span style='color: %s;'>%s</span>", color, this.name());

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/properties/CurrentExtensionConfiguration.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/properties/CurrentExtensionConfiguration.java
@@ -1,16 +1,26 @@
 package ch.sbb.polarion.extension.generic.properties;
 
-import lombok.Setter;
+import ch.sbb.polarion.extension.generic.util.ContextUtils;
+import lombok.SneakyThrows;
 import org.jetbrains.annotations.NotNull;
 
-@Setter
+import java.util.Set;
+
 public class CurrentExtensionConfiguration {
 
     private ExtensionConfiguration extensionConfiguration;
 
-    public @NotNull ExtensionConfiguration getExtensionConfiguration() {
+    @SneakyThrows
+    public synchronized @NotNull ExtensionConfiguration getExtensionConfiguration() {
         if (extensionConfiguration == null) {
-            extensionConfiguration = new ExtensionConfiguration();
+            Set<Class<? extends ExtensionConfiguration>> configurationTypes = ContextUtils.findSubTypes(ExtensionConfiguration.class);
+            if (configurationTypes.isEmpty()) {
+                extensionConfiguration = new ExtensionConfiguration();
+            } else if (configurationTypes.size() == 1) {
+                extensionConfiguration = configurationTypes.iterator().next().getConstructor().newInstance();
+            } else {
+                throw new IllegalStateException("Multiple extension configurations found");
+            }
         }
         return extensionConfiguration;
     }

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/properties/ExtensionConfiguration.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/properties/ExtensionConfiguration.java
@@ -11,7 +11,6 @@ import java.util.Properties;
 @Getter
 public class ExtensionConfiguration implements IExtensionConfiguration {
 
-    private static final String CH_SBB_POLARION_EXTENSION = "ch.sbb.polarion.extension";
     private static final String DEBUG = "debug";
 
     @NotNull
@@ -24,7 +23,7 @@ public class ExtensionConfiguration implements IExtensionConfiguration {
 
     protected ExtensionConfiguration() {
         String extensionContext = ContextUtils.getContext().getExtensionContext();
-        this.propertyPrefix = CH_SBB_POLARION_EXTENSION + "." + extensionContext + ".";
+        this.propertyPrefix = ContextUtils.CH_SBB_POLARION_EXTENSION + "." + extensionContext + ".";
     }
 
     @Override

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/regex/IRegexEngine.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/regex/IRegexEngine.java
@@ -1,0 +1,25 @@
+package ch.sbb.polarion.extension.generic.regex;
+
+import java.util.Map;
+
+public interface IRegexEngine {
+
+    Map<String, Class<? extends IRegexEngine>> IMPLEMENTATIONS = Map.of(
+            RegexEngineJavaUtilImpl.NAME, RegexEngineJavaUtilImpl.class,
+            RegexEngineRE2JImpl.NAME, RegexEngineRE2JImpl.class
+    );
+
+    boolean find();
+
+    String group();
+
+    String group(int group);
+
+    String group(String name);
+
+    void appendReplacement(StringBuilder sb, String replacement);
+
+    void appendTail(StringBuilder sb);
+
+    String quoteReplacement(String input);
+}

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/regex/RegexEngineJavaUtilImpl.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/regex/RegexEngineJavaUtilImpl.java
@@ -1,0 +1,52 @@
+package ch.sbb.polarion.extension.generic.regex;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * {@link IRegexEngine} implementation based on standard Java regex engine.
+ */
+public class RegexEngineJavaUtilImpl implements IRegexEngine {
+
+    public static final String NAME = "java.util.regex";
+    private final Matcher matcher;
+
+    public RegexEngineJavaUtilImpl(String regex, int flags, String input) {
+        matcher = Pattern.compile(regex, flags).matcher(input);
+    }
+
+    @Override
+    public boolean find() {
+        return matcher.find();
+    }
+
+    @Override
+    public String group() {
+        return matcher.group();
+    }
+
+    @Override
+    public String group(int group) {
+        return matcher.group(group);
+    }
+
+    @Override
+    public String group(String name) {
+        return matcher.group(name);
+    }
+
+    @Override
+    public void appendReplacement(StringBuilder sb, String replacement) {
+        matcher.appendReplacement(sb, replacement);
+    }
+
+    @Override
+    public void appendTail(StringBuilder sb) {
+        matcher.appendTail(sb);
+    }
+
+    @Override
+    public String quoteReplacement(String input) {
+        return Matcher.quoteReplacement(input);
+    }
+}

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/regex/RegexEngineRE2JImpl.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/regex/RegexEngineRE2JImpl.java
@@ -1,0 +1,62 @@
+package ch.sbb.polarion.extension.generic.regex;
+
+import com.google.re2j.Matcher;
+import com.google.re2j.Pattern;
+
+/**
+ * {@link IRegexEngine} implementation based on RE2J.
+ * RE2J is a regular expression engine that runs in time linear in the size of the input. RE2J is a port
+ * of C++ library RE2 to pure Java.
+ * Java's standard regular expression package, java.util.regex, and many other widely used regular expression
+ * packages such as PCRE, Perl and Python use a backtracking implementation strategy: when a pattern presents two
+ * alternatives such as a|b, the engine will try to match subpattern a first, and if that yields no match,
+ * it will reset the input stream and try to match b instead.
+ */
+public class RegexEngineRE2JImpl implements IRegexEngine {
+
+    public static final String NAME = "re2j";
+    private final Matcher matcher;
+
+    public RegexEngineRE2JImpl(String regex, int flags, String input) {
+
+        // RE2J uses slightly different syntax for named groups
+        regex = regex.replace("(?<", "(?P<");
+
+        matcher = Pattern.compile(regex, flags).matcher(input);
+    }
+
+    @Override
+    public boolean find() {
+        return matcher.find();
+    }
+
+    @Override
+    public String group() {
+        return matcher.group();
+    }
+
+    @Override
+    public String group(int group) {
+        return matcher.group(group);
+    }
+
+    @Override
+    public String group(String name) {
+        return matcher.group(name);
+    }
+
+    @Override
+    public void appendReplacement(StringBuilder sb, String replacement) {
+        matcher.appendReplacement(sb, replacement);
+    }
+
+    @Override
+    public void appendTail(StringBuilder sb) {
+        matcher.appendTail(sb);
+    }
+
+    @Override
+    public String quoteReplacement(String input) {
+        return Matcher.quoteReplacement(input);
+    }
+}

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/regex/RegexEngineRE2JImpl.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/regex/RegexEngineRE2JImpl.java
@@ -31,13 +31,13 @@ public class RegexEngineRE2JImpl implements IRegexEngine {
     }
 
     @Override
-    public String group() {
-        return matcher.group();
+    public String group(int group) {
+        return matcher.group(group);
     }
 
     @Override
-    public String group(int group) {
-        return matcher.group(group);
+    public String group() {
+        return matcher.group();
     }
 
     @Override
@@ -46,13 +46,13 @@ public class RegexEngineRE2JImpl implements IRegexEngine {
     }
 
     @Override
-    public void appendReplacement(StringBuilder sb, String replacement) {
-        matcher.appendReplacement(sb, replacement);
+    public void appendTail(StringBuilder sb) {
+        matcher.appendTail(sb);
     }
 
     @Override
-    public void appendTail(StringBuilder sb) {
-        matcher.appendTail(sb);
+    public void appendReplacement(StringBuilder sb, String replacement) {
+        matcher.appendReplacement(sb, replacement);
     }
 
     @Override

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/regex/RegexMatcher.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/regex/RegexMatcher.java
@@ -1,0 +1,117 @@
+package ch.sbb.polarion.extension.generic.regex;
+
+import lombok.SneakyThrows;
+
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+
+/**
+ * Provides simplified way for string replacements/operations using regex.
+ * Also allows to easily switch underlined regex engine: by default it uses RE2J implementation which is a preferable way because
+ * in theory it works faster and guarantees linear time execution, but user can switch implementation to the java.util.regex-based
+ * in case if there is need to use some features which is unsupported by RE2J - e.g. <code>(?=</code>, <code>(?></code> etc.,
+ * full list of (un)supported features may be found <a href="https://github.com/google/re2/wiki/Syntax">here</a>).
+ */
+@SuppressWarnings("unused")
+public class RegexMatcher {
+
+    public static final int CASE_INSENSITIVE = 1;
+    public static final int DOTALL = 2;
+
+    private final String regex;
+    private final int flags;
+    private String impl = RegexEngineRE2JImpl.NAME;
+
+    private RegexMatcher(String regex, int flags) {
+        this.regex = regex;
+        this.flags = flags;
+    }
+
+    public static RegexMatcher get(String regex) {
+        return get(regex, 0);
+    }
+
+    public static RegexMatcher get(String regex, int flags) {
+        return new RegexMatcher(regex, flags);
+    }
+
+    public static String quote(String s) {
+        return Pattern.quote(s);
+    }
+
+    /**
+     * Forces to use java.util.regex-based engine.
+     * NOTE: this isn't a preferable way, please consider rewriting regex to not use
+     * unsupported syntax and switch back to RE2J implementation.
+     */
+    public RegexMatcher useJavaUtil() {
+        this.impl = RegexEngineJavaUtilImpl.NAME;
+        return this;
+    }
+
+    public String replace(String input, IReplacementCalculator replacementCalculator) {
+        return replace(input, true, replacementCalculator);
+    }
+
+    public String replace(String input, boolean quoteReplacement, IReplacementCalculator replacementCalculator) {
+        IRegexEngine regexEngine = createEngine(input);
+        StringBuilder resultBuilder = new StringBuilder();
+        while (regexEngine.find()) {
+            String replacement = replacementCalculator.calculateReplacement(regexEngine);
+            if (replacement != null) {
+                regexEngine.appendReplacement(resultBuilder, quoteReplacement ? regexEngine.quoteReplacement(replacement) : replacement);
+            }
+        }
+        regexEngine.appendTail(resultBuilder);
+        return resultBuilder.toString();
+    }
+
+    public String replaceAll(String input, String replacementString) {
+        return replace(input, regexEngine -> replacementString);
+    }
+
+    public void processEntry(String input, IEntryProcessor entryProcessor) {
+        IRegexEngine regexEngine = createEngine(input);
+        while (regexEngine.find()) {
+            entryProcessor.processEntry(regexEngine);
+        }
+    }
+
+    public Optional<String> findFirst(String input) {
+        return findFirst(input, IRegexEngine::group);
+    }
+
+    public Optional<String> findFirst(String input, Function<IRegexEngine, String> entryCalculator) {
+        IRegexEngine regexEngine = createEngine(input);
+        return regexEngine.find() ? Optional.of(entryCalculator.apply(regexEngine)) : Optional.empty();
+    }
+
+    public boolean anyMatch(String input) {
+        return createEngine(input).find();
+    }
+
+    public boolean noneMatch(String input) {
+        return !createEngine(input).find();
+    }
+
+    public String removeAll(String input) {
+        return replace(input, regexEngine -> "");
+    }
+
+    @SneakyThrows
+    public IRegexEngine createEngine(String input) {
+        return IRegexEngine.IMPLEMENTATIONS.get(impl)
+                .getDeclaredConstructor(String.class, int.class, String.class)
+                .newInstance(regex, flags, input);
+    }
+
+    public interface IReplacementCalculator {
+        String calculateReplacement(IRegexEngine regexEngine);
+    }
+
+    public interface IEntryProcessor {
+        void processEntry(IRegexEngine regexEngine);
+    }
+
+}

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/util/ContextUtils.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/util/ContextUtils.java
@@ -1,21 +1,36 @@
 package ch.sbb.polarion.extension.generic.util;
 
-import java.util.jar.Attributes;
-
-import org.jetbrains.annotations.NotNull;
-
 import ch.sbb.polarion.extension.generic.rest.model.Context;
 import lombok.experimental.UtilityClass;
+import org.jetbrains.annotations.NotNull;
+import org.reflections.Reflections;
+import org.reflections.util.ConfigurationBuilder;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.jar.Attributes;
+import java.util.stream.Collectors;
 
 @UtilityClass
 public class ContextUtils {
 
+    public static final String CH_SBB_POLARION_EXTENSION = "ch.sbb.polarion.extension";
     public static final String EXTENSION_CONTEXT = "Extension-Context";
+    public static final String DISCOVER_BASE_PACKAGE = "Discover-Base-Package";
+    private static final Reflections REFLECTIONS_INSTANCE = new Reflections(new ConfigurationBuilder().forPackage(getBasePackage()));
 
     @NotNull
     public static Context getContext() {
         final Attributes attributes = ManifestUtils.getManifestAttributes();
         String extensionContext = attributes.getValue(EXTENSION_CONTEXT);
         return new Context(extensionContext);
+    }
+
+    public <T> Set<Class<? extends T>> findSubTypes(Class<T> type) {
+        return REFLECTIONS_INSTANCE.getSubTypesOf(type).stream().filter(c -> c.isAnnotationPresent(Discoverable.class)).collect(Collectors.toSet());
+    }
+
+    private static String getBasePackage() {
+        return Optional.ofNullable(ManifestUtils.getManifestAttributes().getValue(DISCOVER_BASE_PACKAGE)).orElse(CH_SBB_POLARION_EXTENSION);
     }
 }

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/util/Discoverable.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/util/Discoverable.java
@@ -1,0 +1,17 @@
+package ch.sbb.polarion.extension.generic.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Class marked by this annotation will be eligible to be discovered dynamically by generic.
+ *
+ * @see ch.sbb.polarion.extension.generic.util.ContextUtils
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@SuppressWarnings("unused")
+public @interface Discoverable {
+}

--- a/app/src/main/resources/META-INF/resources/common/jsp/about.jsp
+++ b/app/src/main/resources/META-INF/resources/common/jsp/about.jsp
@@ -10,6 +10,8 @@
 <%@ page import="java.util.Set" %>
 <%@ page import="java.util.ArrayList" %>
 <%@ page import="ch.sbb.polarion.extension.generic.rest.model.Context" %>
+<%@ page import="ch.sbb.polarion.extension.generic.configuration.ConfigurationStatus" %>
+<%@ page import="ch.sbb.polarion.extension.generic.configuration.ConfigurationStatusProvider" %>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
@@ -17,6 +19,7 @@
 <%!
     private static final String ABOUT_TABLE_ROW = "<tr><td>%s</td><td>%s</td></tr>";
     private static final String CONFIGURATION_PROPERTIES_TABLE_ROW = "<tr><td>%s</td><td>%s</td></tr>";
+    private static final String CHECK_CONFIGURATION_TABLE_ROW = "<tr><td>%s</td><td>%s</td><td>%s</td></tr>";
 
     Context context = ExtensionInfo.getInstance().getContext();
     Version version = ExtensionInfo.getInstance().getVersion();
@@ -87,6 +90,29 @@
             %>
             </tbody>
         </table>
+
+        <% List<ConfigurationStatus> configurationStatuses = ConfigurationStatusProvider.getAllStatuses(request.getParameter("scope")); %>
+        <% if (!configurationStatuses.isEmpty()) { %>
+        <h3>Extension configuration status</h3>
+
+        <table>
+            <thead>
+            <tr>
+                <th>Configuration</th>
+                <th>Status</th>
+                <th>Info</th>
+            </tr>
+            </thead>
+            <tbody>
+            <%
+                for (ConfigurationStatus configurationStatus : configurationStatuses) {
+                    String row = CHECK_CONFIGURATION_TABLE_ROW.formatted(configurationStatus.getName(), configurationStatus.getStatus().toHtml(), configurationStatus.getDetails());
+                    out.println(row);
+                }
+            %>
+            </tbody>
+        </table>
+        <% } %>
 
         <input id="scope" type="hidden" value="<%= request.getParameter("scope")%>"/>
 

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/configuration/ConfigurationStatusProviderTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/configuration/ConfigurationStatusProviderTest.java
@@ -1,0 +1,54 @@
+package ch.sbb.polarion.extension.generic.configuration;
+
+import ch.sbb.polarion.extension.generic.util.ContextUtils;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+
+class ConfigurationStatusProviderTest {
+
+    @Test
+    void testGetAllStatuses() {
+        try (MockedStatic<ContextUtils> contextUtilsMockedStatic = mockStatic(ContextUtils.class)) {
+            contextUtilsMockedStatic.when(() -> ContextUtils.findSubTypes(any())).thenReturn(Set.of(TestSingleProvider.class, TestMultipleProvider.class));
+            List<ConfigurationStatus> statuses = ConfigurationStatusProvider.getAllStatuses("some scope");
+            assertEquals(3, statuses.size());
+            assertTrue(statuses.containsAll(List.of(
+                    new ConfigurationStatus("single", Status.OK, "single details"),
+                    new ConfigurationStatus("multiple 1", Status.WARNING, "multiple 1 details"),
+                    new ConfigurationStatus("multiple 2", Status.ERROR, "multiple 2 details")
+            )));
+        }
+    }
+
+    @Test
+    void testGetConfigurationStatus() {
+        assertEquals(new ConfigurationStatus("test ok", Status.OK, ""), new TestSingleProvider().getConfigurationStatus("test ok", "some content", "content"));
+        assertEquals(new ConfigurationStatus("test warning", Status.WARNING, "Not configured"), new TestSingleProvider().getConfigurationStatus("test warning", "some content", "another text"));
+    }
+
+    public static class TestSingleProvider extends ConfigurationStatusProvider {
+        @Override
+        public @NotNull ConfigurationStatus getStatus(@NotNull Context context) {
+            return new ConfigurationStatus("single", Status.OK, "single details");
+        }
+    }
+
+    public static class TestMultipleProvider extends ConfigurationStatusProvider {
+        @Override
+        public @NotNull List<ConfigurationStatus> getStatuses(@NotNull Context context) {
+            return List.of(
+                    new ConfigurationStatus("multiple 1", Status.WARNING, "multiple 1 details"),
+                    new ConfigurationStatus("multiple 2", Status.ERROR, "multiple 2 details")
+            );
+        }
+    }
+}

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/configuration/StatusTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/configuration/StatusTest.java
@@ -1,0 +1,14 @@
+package ch.sbb.polarion.extension.generic.configuration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StatusTest {
+    @Test
+    void testColors() {
+        assertEquals("<span style='color: green;'>OK</span>", Status.OK.toHtml());
+        assertEquals("<span style='color: orange;'>WARNING</span>", Status.WARNING.toHtml());
+        assertEquals("<span style='color: red;'>ERROR</span>", Status.ERROR.toHtml());
+    }
+}

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/regex/RegexMatcherTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/regex/RegexMatcherTest.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(MockitoExtension.class)
-public class RegexMatcherTest {
+class RegexMatcherTest {
 
     private static final String REGEX_TAG = "<(?<tagName>[a-z]+)>";
 

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/regex/RegexMatcherTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/regex/RegexMatcherTest.java
@@ -1,0 +1,106 @@
+package ch.sbb.polarion.extension.generic.regex;
+
+import com.google.re2j.PatternSyntaxException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+public class RegexMatcherTest {
+
+    private static final String REGEX_TAG = "<(?<tagName>[a-z]+)>";
+
+    @Test
+    void flagsTest() {
+        String input = "Text with <SPAN>tag</SPAN> inside";
+        assertNull(RegexMatcher.get(REGEX_TAG).findFirst(input).orElse(null));
+        assertEquals("<SPAN>", RegexMatcher.get(REGEX_TAG, RegexMatcher.CASE_INSENSITIVE).findFirst(input).orElse(null));
+    }
+
+    @Test
+    void unsupportedRE2JSyntaxTest() {
+        RegexMatcher simpleBackreferenceMatcher = RegexMatcher.get("(')[a-zA-Z]+\\1");
+
+        // backreferences not supported in RE2J
+        PatternSyntaxException exception = (PatternSyntaxException) assertThrows(InvocationTargetException.class,
+                () -> simpleBackreferenceMatcher.findFirst("Text with 'quotedText' inside")).getCause();
+        assertEquals("error parsing regexp: invalid escape sequence: `\\1`", exception.getMessage());
+        // but standard java regex does support them
+        assertEquals("'quotedText'", simpleBackreferenceMatcher.useJavaUtil().findFirst("Text with 'quotedText' inside").orElse(null));
+
+        // same for positive lookaheads (?=
+        RegexMatcher positiveLookaheadMatcher = RegexMatcher.get("[a-z]+(?=\\d)");
+        exception = (PatternSyntaxException) assertThrows(InvocationTargetException.class,
+                () -> positiveLookaheadMatcher.replaceAll("a1 b2 c d4", "beep")).getCause();
+        assertEquals("error parsing regexp: invalid or unsupported Perl syntax: `(?=`", exception.getMessage());
+        assertEquals("beep1 beep2 c beep4", positiveLookaheadMatcher.useJavaUtil().replaceAll("a1 b2 c d4", "beep"));
+
+        // and atomic groups
+        RegexMatcher atomicGroupsMatcher = RegexMatcher.get("a(?>bc|b)c");
+        exception = (PatternSyntaxException) assertThrows(InvocationTargetException.class,
+                () -> atomicGroupsMatcher.anyMatch("abc")).getCause();
+        assertEquals("error parsing regexp: invalid or unsupported Perl syntax: `(?>`", exception.getMessage());
+        assertFalse(atomicGroupsMatcher.useJavaUtil().anyMatch("abc"));
+    }
+
+    @Test
+    void findFirstTest() {
+        RegexMatcher matcher = RegexMatcher.get(REGEX_TAG);
+        String twoEntriesInput = "Text with <i>two</i> <b>tag</b> inside";
+        assertEquals("<i>", matcher.findFirst(twoEntriesInput).orElse(null));
+        assertEquals("i", matcher.findFirst(twoEntriesInput,
+                regexEngine -> regexEngine.group("tagName")).orElse(null));
+        assertEquals(Optional.empty(), matcher.findFirst("Text without tags inside"));
+    }
+
+    @Test
+    void anyAndNoneMatchTest() {
+        RegexMatcher matcher = RegexMatcher.get(REGEX_TAG);
+        assertTrue(matcher.anyMatch("Text with <br> tags inside"));
+        assertFalse(matcher.anyMatch("Text without tags inside"));
+        assertFalse(matcher.noneMatch("Text with <br> tags inside"));
+        assertTrue(matcher.noneMatch("Text without tags inside"));
+    }
+
+    @Test
+    void removeAllTest() {
+        assertEquals("Text with tags inside </br>", RegexMatcher.get(REGEX_TAG).removeAll("Text with <some><random>tags inside </br>"));
+    }
+
+    @Test
+    void processEntryTest() {
+        List<String> tags = new ArrayList<>();
+        RegexMatcher.get(REGEX_TAG).processEntry("Text with <a><few><random> tags inside",
+                regexEngine -> tags.add(regexEngine.group("tagName")));
+        assertEquals("a", tags.get(0));
+        assertEquals("few", tags.get(1));
+        assertEquals("random", tags.get(2));
+    }
+
+    @Test
+    void replaceTest() {
+        assertEquals("Text with {two}{random} tags inside plus one more at the {end}", RegexMatcher.get(REGEX_TAG)
+                .replace("Text with <two><random> tags inside plus one more at the <end>",
+                        regexEngine -> "{%s}".formatted(regexEngine.group("tagName"))));
+
+        // by default quoteReplacement = true
+        assertEquals("Text with $100 tag inside", RegexMatcher.get(REGEX_TAG)
+                .replace("Text with <br> tag inside",
+                        regexEngine -> "$100"));
+
+        assertEquals("Text with br00 tag inside", RegexMatcher.get(REGEX_TAG)
+                .replace("Text with <br> tag inside", false,
+                        regexEngine -> "$100"));
+
+        assertEquals("Text with 4242 tags inside plus one more at the 42", RegexMatcher.get(REGEX_TAG)
+                .replaceAll("Text with <two><random> tags inside plus one more at the <end>", "42"));
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,8 @@
         <google.guice.version>7.0.0</google.guice.version>
         <gwt-servlet.version>2.9.0</gwt-servlet.version>
         <jsp-api.version>2.2</jsp-api.version>
+        <re2j.version>1.7</re2j.version>
+        <reflections.version>0.10.2</reflections.version>
 
         <!-- Manifest entries -->
         <maven-jar-plugin.Manifest-Version>1.0</maven-jar-plugin.Manifest-Version>
@@ -107,6 +109,7 @@
         <!--suppress UnresolvedMavenProperty -->
         <maven-jar-plugin.Bundle-Version>${project.artifact.selectedVersion.majorVersion}.${project.artifact.selectedVersion.minorVersion}.${project.artifact.selectedVersion.incrementalVersion}</maven-jar-plugin.Bundle-Version>
         <maven-jar-plugin.Extension-Context/>
+        <maven-jar-plugin.Discover-Base-Package>${project.artifactId}</maven-jar-plugin.Discover-Base-Package>
         <maven-jar-plugin.Project-URL>${project.scm.url}</maven-jar-plugin.Project-URL>
 
         <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
@@ -495,6 +498,18 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Will be packaged to final extensions jars -->
+        <dependency>
+            <groupId>com.google.re2j</groupId>
+            <artifactId>re2j</artifactId>
+            <version>${re2j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+            <version>${reflections.version}</version>
+        </dependency>
+
         <!-- Polarion UI dependency -->
         <dependency>
             <groupId>com.google.gwt</groupId>
@@ -632,6 +647,7 @@
                                 <Bundle-Build-Timestamp>${maven-jar-plugin.Bundle-Build-Timestamp}</Bundle-Build-Timestamp>
                                 <Bundle-ClassPath>.,${maven-jar-plugin.Bundle-ClassPath}</Bundle-ClassPath>
                                 <Extension-Context>${maven-jar-plugin.Extension-Context}</Extension-Context>
+                                <Discover-Base-Package>${maven-jar-plugin.Discover-Base-Package}</Discover-Base-Package>
                                 <Project-URL>${maven-jar-plugin.Project-URL}</Project-URL>
                             </manifestEntries>
                         </archive>


### PR DESCRIPTION
…ut page, regex engine moved to generic from pdf exporter

Refs: #138

### Proposed changes

Add one more block to the about jsp ('Extension configuration status') which will display additional internal extension information.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
