### PR TITLE
fix: exclude extra mappers registration in JacksonFeature

### DIFF
--- a/app/src/main/java/ch/sbb/polarion/extension/generic/rest/GenericRestApplication.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/rest/GenericRestApplication.java
@@ -37,6 +37,7 @@ public class GenericRestApplication extends Application {
     @NotNull
     public Set<Object> getSingletons() {
         Set<Object> singletons = new HashSet<>();
+        singletons.add(JacksonFeature.withoutExceptionMappers());
         singletons.addAll(getAllExceptionMapperSingletons());
         singletons.addAll(getAllFilterSingletons());
         singletons.addAll(getAllControllerSingletons());
@@ -50,7 +51,6 @@ public class GenericRestApplication extends Application {
         classes.addAll(getAllExceptionMapperClasses());
         classes.addAll(getAllFilterClasses());
         classes.addAll(getAllControllerClasses());
-        classes.add(JacksonFeature.class);
         return classes;
     }
 


### PR DESCRIPTION
Refs: #173

### Proposed changes

JacksonFeature registers JsonParseExceptionMapper and JsonMappingExceptionMapper which returns 400 Bad Request as plain/text and does not allow to override them to return application/json.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [ ] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
