### PR TITLE
fix: Sort rows in Extension configuration status table by configuration name

### DIFF
--- a/app/src/main/java/ch/sbb/polarion/extension/generic/configuration/ConfigurationStatus.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/configuration/ConfigurationStatus.java
@@ -10,12 +10,17 @@ import org.jetbrains.annotations.NotNull;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ConfigurationStatus {
+public class ConfigurationStatus implements Comparable<ConfigurationStatus> {
     private @NotNull String name;
     private @NotNull Status status;
     private @NotNull String details;
 
     public ConfigurationStatus(@NotNull String name, @NotNull Status status) {
         this(name, status, "");
+    }
+
+    @Override
+    public int compareTo(@NotNull ConfigurationStatus o) {
+        return name.compareTo(o.name);
     }
 }

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/configuration/ConfigurationStatusProvider.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/configuration/ConfigurationStatusProvider.java
@@ -8,18 +8,19 @@ import lombok.SneakyThrows;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 
 @SuppressWarnings("unused")
 public abstract class ConfigurationStatusProvider {
 
     @SneakyThrows
-    public static List<ConfigurationStatus> getAllStatuses(String scope) {
+    public static Collection<ConfigurationStatus> getAllStatuses(String scope) {
         Context context = new Context(scope);
         Set<Class<? extends ConfigurationStatusProvider>> subTypes = ContextUtils.findSubTypes(ConfigurationStatusProvider.class);
-        List<ConfigurationStatus> statuses = new ArrayList<>();
+        Collection<ConfigurationStatus> statuses = new TreeSet<>();
         for (Class<? extends ConfigurationStatusProvider> subType : subTypes) {
             ConfigurationStatusProvider provider = subType.getConstructor().newInstance();
             statuses.addAll(provider.getStatuses(context));
@@ -27,7 +28,7 @@ public abstract class ConfigurationStatusProvider {
         return statuses;
     }
 
-    public @NotNull List<ConfigurationStatus> getStatuses(@NotNull Context context) {
+    public @NotNull Collection<ConfigurationStatus> getStatuses(@NotNull Context context) {
         return List.of(getStatus(context));
     }
 

--- a/app/src/main/resources/META-INF/resources/common/jsp/about.jsp
+++ b/app/src/main/resources/META-INF/resources/common/jsp/about.jsp
@@ -12,6 +12,7 @@
 <%@ page import="ch.sbb.polarion.extension.generic.rest.model.Context" %>
 <%@ page import="ch.sbb.polarion.extension.generic.configuration.ConfigurationStatus" %>
 <%@ page import="ch.sbb.polarion.extension.generic.configuration.ConfigurationStatusProvider" %>
+<%@ page import="java.util.Collection" %>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
@@ -91,7 +92,7 @@
             </tbody>
         </table>
 
-        <% List<ConfigurationStatus> configurationStatuses = ConfigurationStatusProvider.getAllStatuses(request.getParameter("scope")); %>
+        <% Collection<ConfigurationStatus> configurationStatuses = ConfigurationStatusProvider.getAllStatuses(request.getParameter("scope")); %>
         <% if (!configurationStatuses.isEmpty()) { %>
         <h3>Extension configuration status</h3>
 

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/configuration/ConfigurationStatusProviderTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/configuration/ConfigurationStatusProviderTest.java
@@ -5,6 +5,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -19,7 +20,7 @@ class ConfigurationStatusProviderTest {
     void testGetAllStatuses() {
         try (MockedStatic<ContextUtils> contextUtilsMockedStatic = mockStatic(ContextUtils.class)) {
             contextUtilsMockedStatic.when(() -> ContextUtils.findSubTypes(any())).thenReturn(Set.of(TestSingleProvider.class, TestMultipleProvider.class));
-            List<ConfigurationStatus> statuses = ConfigurationStatusProvider.getAllStatuses("some scope");
+            Collection<ConfigurationStatus> statuses = ConfigurationStatusProvider.getAllStatuses("some scope");
             assertEquals(3, statuses.size());
             assertTrue(statuses.containsAll(List.of(
                     new ConfigurationStatus("single", Status.OK, "single details"),


### PR DESCRIPTION
Sort rows in Extension configuration status table by configuration name

Refs: #148

### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) here in this description (not in the title of the PR).

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
