### PR TITLE
fix: Sort rows in Extension configuration status table by configuration name

### DIFF
--- a/app/src/main/java/ch/sbb/polarion/extension/generic/configuration/ConfigurationStatus.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/configuration/ConfigurationStatus.java
@@ -10,12 +10,17 @@ import org.jetbrains.annotations.NotNull;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ConfigurationStatus {
+public class ConfigurationStatus implements Comparable<ConfigurationStatus> {
     private @NotNull String name;
     private @NotNull Status status;
     private @NotNull String details;
 
     public ConfigurationStatus(@NotNull String name, @NotNull Status status) {
         this(name, status, "");
+    }
+
+    @Override
+    public int compareTo(@NotNull ConfigurationStatus o) {
+        return name.compareTo(o.name);
     }
 }

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/configuration/ConfigurationStatusProvider.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/configuration/ConfigurationStatusProvider.java
@@ -8,18 +8,19 @@ import lombok.SneakyThrows;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 
 @SuppressWarnings("unused")
 public abstract class ConfigurationStatusProvider {
 
     @SneakyThrows
-    public static List<ConfigurationStatus> getAllStatuses(String scope) {
+    public static Collection<ConfigurationStatus> getAllStatuses(String scope) {
         Context context = new Context(scope);
         Set<Class<? extends ConfigurationStatusProvider>> subTypes = ContextUtils.findSubTypes(ConfigurationStatusProvider.class);
-        List<ConfigurationStatus> statuses = new ArrayList<>();
+        Collection<ConfigurationStatus> statuses = new TreeSet<>();
         for (Class<? extends ConfigurationStatusProvider> subType : subTypes) {
             ConfigurationStatusProvider provider = subType.getConstructor().newInstance();
             statuses.addAll(provider.getStatuses(context));
@@ -27,7 +28,7 @@ public abstract class ConfigurationStatusProvider {
         return statuses;
     }
 
-    public @NotNull List<ConfigurationStatus> getStatuses(@NotNull Context context) {
+    public @NotNull Collection<ConfigurationStatus> getStatuses(@NotNull Context context) {
         return List.of(getStatus(context));
     }
 

--- a/app/src/main/resources/META-INF/resources/common/jsp/about.jsp
+++ b/app/src/main/resources/META-INF/resources/common/jsp/about.jsp
@@ -12,6 +12,7 @@
 <%@ page import="ch.sbb.polarion.extension.generic.rest.model.Context" %>
 <%@ page import="ch.sbb.polarion.extension.generic.configuration.ConfigurationStatus" %>
 <%@ page import="ch.sbb.polarion.extension.generic.configuration.ConfigurationStatusProvider" %>
+<%@ page import="java.util.Collection" %>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
@@ -91,7 +92,7 @@
             </tbody>
         </table>
 
-        <% List<ConfigurationStatus> configurationStatuses = ConfigurationStatusProvider.getAllStatuses(request.getParameter("scope")); %>
+        <% Collection<ConfigurationStatus> configurationStatuses = ConfigurationStatusProvider.getAllStatuses(request.getParameter("scope")); %>
         <% if (!configurationStatuses.isEmpty()) { %>
         <h3>Extension configuration status</h3>
 

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/configuration/ConfigurationStatusProviderTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/configuration/ConfigurationStatusProviderTest.java
@@ -5,6 +5,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -19,13 +20,15 @@ class ConfigurationStatusProviderTest {
     void testGetAllStatuses() {
         try (MockedStatic<ContextUtils> contextUtilsMockedStatic = mockStatic(ContextUtils.class)) {
             contextUtilsMockedStatic.when(() -> ContextUtils.findSubTypes(any())).thenReturn(Set.of(TestSingleProvider.class, TestMultipleProvider.class));
-            List<ConfigurationStatus> statuses = ConfigurationStatusProvider.getAllStatuses("some scope");
+            Collection<ConfigurationStatus> statuses = ConfigurationStatusProvider.getAllStatuses("some scope");
+
             assertEquals(3, statuses.size());
-            assertTrue(statuses.containsAll(List.of(
-                    new ConfigurationStatus("single", Status.OK, "single details"),
-                    new ConfigurationStatus("multiple 1", Status.WARNING, "multiple 1 details"),
-                    new ConfigurationStatus("multiple 2", Status.ERROR, "multiple 2 details")
-            )));
+
+            // Check alphabetical order of configurations
+            ConfigurationStatus[] statusesArray = statuses.toArray(new ConfigurationStatus[0]);
+            assertEquals(statusesArray[0], new ConfigurationStatus("multiple 1", Status.WARNING, "multiple 1 details"));
+            assertEquals(statusesArray[1], new ConfigurationStatus("multiple 2", Status.ERROR, "multiple 2 details"));
+            assertEquals(statusesArray[2], new ConfigurationStatus("single", Status.OK, "single details"));
         }
     }
 


### PR DESCRIPTION
Sort rows in Extension configuration status table by configuration name

Refs: #148

### Proposed changes

Sort rows in Extension configuration status table by configuration name

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
