### PR TITLE
chore: ability to set newConfigurationCallback

### DIFF
--- a/app/src/main/resources/js/configurations.js
+++ b/app/src/main/resources/js/configurations.js
@@ -4,12 +4,13 @@ const Configurations = {
     setConfigurationContentCallback: () => {},
     setContentAreaEnabledCallback: null,
     preDeleteCallback: null, // It should return Promise
+    newConfigurationCallback: null,
     configurationsPane: document.getElementById("configurations-pane"),
     editConfigurationPane: document.getElementById("edit-configuration-pane"),
     newConfigurationInput: document.getElementById("new-configuration-input"),
     editConfigurationInput: document.getElementById("edit-configuration-input"),
 
-    init: function ({label, setConfigurationContentCallback, setContentAreaEnabledCallback, preDeleteCallback}) {
+    init: function ({label, setConfigurationContentCallback, setContentAreaEnabledCallback, preDeleteCallback, newConfigurationCallback}) {
         if (label) {
             document.querySelectorAll('span.configuration-label').forEach(labelSpan => {
                 labelSpan.innerText = label;
@@ -24,6 +25,7 @@ const Configurations = {
         this.setConfigurationContentCallback = setConfigurationContentCallback;
         this.setContentAreaEnabledCallback = setContentAreaEnabledCallback;
         this.preDeleteCallback = preDeleteCallback;
+        this.newConfigurationCallback = newConfigurationCallback;
 
         this.configurationsSelect = new SbbCustomSelect({
             selectContainer: document.getElementById("configurations-select"),
@@ -74,6 +76,7 @@ const Configurations = {
         });
         this.editConfigurationPane.style.display = "block";
         this.setContentAreaEnabled(false);
+        this.newConfigurationCallback();
     },
 
     editConfiguration: function() {


### PR DESCRIPTION
### Proposed changes

We need a way to add some logic on creating new configuration

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [ ] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
