### PR TITLE
fix: fields data ignored on new style package creation

### DIFF
--- a/app/src/main/resources/META-INF/resources/common/jsp/buttons.jsp
+++ b/app/src/main/resources/META-INF/resources/common/jsp/buttons.jsp
@@ -4,7 +4,7 @@
 
 <%! Version version = ExtensionInfo.getInstance().getVersion();%>
 
-<div class="actions-pane">
+<div class="actions-pane hide-on-edit-configuration">
     <div id="revisions-expand-container">
         <table id="revisions-table">
             <thead>

--- a/app/src/main/resources/META-INF/resources/common/jsp/configurations.jsp
+++ b/app/src/main/resources/META-INF/resources/common/jsp/configurations.jsp
@@ -2,7 +2,7 @@
 
 <p>There can be multiple named <span class="configuration-label">configuration</span>s. Please, chose one you would like to modify in dropdown below.
     Be aware that "Default" <span class="configuration-label">configuration</span> on global scope can't be deleted or renamed.</p>
-<div class="input-group">
+<div class="input-group common-configuration-panel">
     <div id="configurations-pane">
         <label id="configurations-label"><span class="configuration-label-capitalized">Configuration</span>:</label>
         <div id="configurations-select"></div>

--- a/app/src/main/resources/css/configurations.css
+++ b/app/src/main/resources/css/configurations.css
@@ -44,3 +44,6 @@
 .configuration-error {
     color: red;
 }
+.hidden-on-edit-configuration {
+    display: none !important;
+}

--- a/app/src/main/resources/js/configurations.js
+++ b/app/src/main/resources/js/configurations.js
@@ -1,16 +1,18 @@
 const SELECTED_CONFIGURATION_COOKIE = 'selected-configuration-';
 
 const Configurations = {
-    setConfigurationContentCallback: () => {},
-    setContentAreaEnabledCallback: null,
-    preDeleteCallback: null, // It should return Promise
-    newConfigurationCallback: () => {},
     configurationsPane: document.getElementById("configurations-pane"),
     editConfigurationPane: document.getElementById("edit-configuration-pane"),
     newConfigurationInput: document.getElementById("new-configuration-input"),
     editConfigurationInput: document.getElementById("edit-configuration-input"),
 
-    init: function ({label, setConfigurationContentCallback, setContentAreaEnabledCallback, preDeleteCallback, newConfigurationCallback}) {
+    init: function ({
+                        label,
+                        setConfigurationContentCallback = () => {},
+                        setContentAreaEnabledCallback = null,
+                        preDeleteCallback = null, // It should return Promise
+                        newConfigurationCallback = () => {}
+                    }) {
         if (label) {
             document.querySelectorAll('span.configuration-label').forEach(labelSpan => {
                 labelSpan.innerText = label;
@@ -263,6 +265,23 @@ const Configurations = {
         document.querySelectorAll('.save-area .toolbar-button').forEach(inputContainer => {
             inputContainer.disabled = !enabled;
         });
+        if (!enabled) {
+            // hide all children of 'standard-admin-page' below configuration div
+            let foundConfigurationElement = false;
+            Array.from(document.querySelector('.standard-admin-page').children).forEach(item => {
+                if (item.classList.contains('common-configuration-panel')) {
+                    foundConfigurationElement = true;
+                } else if (foundConfigurationElement && !item.classList.contains('skip-hide-on-edit-configuration')) {
+                    item.classList.add("hidden-on-edit-configuration");
+                }
+            });
+            // also hide all components, explicitly marked with 'hide-on-edit-configuration'
+            document.querySelectorAll('.hide-on-edit-configuration')
+                .forEach(item => item.classList.add("hidden-on-edit-configuration"));
+        } else {
+            document.querySelectorAll('.hidden-on-edit-configuration')
+                .forEach(item => item.classList.remove("hidden-on-edit-configuration"));
+        }
         if (this.setContentAreaEnabledCallback) {
             this.setContentAreaEnabledCallback(enabled);
         }


### PR DESCRIPTION
Refs: SchweizerischeBundesbahnen/ch.sbb.polarion.extension.pdf-exporter#247

### Proposed changes

Admin pages, which have configuration functionality, must hide configuration-unrelated inputs when user creates a new package or edits its name.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
