### PR TITLE
fix: wrong configuration properties if no Configuration-Properties-Prefix provided in manifest

### DIFF
--- a/app/src/main/java/ch/sbb/polarion/extension/generic/util/ContextUtils.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/util/ContextUtils.java
@@ -44,9 +44,8 @@ public class ContextUtils {
     public static String getConfigurationPropertiesPrefix() {
         String configurationPropertiesPrefix = ManifestUtils.getManifestAttributes().getValue(CONFIGURATION_PROPERTIES_PREFIX);
         if (configurationPropertiesPrefix == null || configurationPropertiesPrefix.isBlank()) {
-            return CH_SBB_POLARION_EXTENSION + ContextUtils.getContext().getExtensionContext();
-        } else {
-            return configurationPropertiesPrefix.endsWith(".") ? configurationPropertiesPrefix : configurationPropertiesPrefix + ".";
+            configurationPropertiesPrefix = CH_SBB_POLARION_EXTENSION + ContextUtils.getContext().getExtensionContext() + ".";
         }
+        return configurationPropertiesPrefix.endsWith(".") ? configurationPropertiesPrefix : configurationPropertiesPrefix + ".";
     }
 }

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/util/ContextUtilsTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/util/ContextUtilsTest.java
@@ -20,11 +20,11 @@ class ContextUtilsTest {
                 // configurationPropertiesPrefix is not provided
                 Arguments.of(null, null, null),
                 Arguments.of(null, "", null),
-                Arguments.of(null, "extension-name", ContextUtils.CH_SBB_POLARION_EXTENSION + "extension-name"),
+                Arguments.of(null, "extension-name", ContextUtils.CH_SBB_POLARION_EXTENSION + "extension-name."),
                 // configurationPropertiesPrefix is empty
                 Arguments.of("", null, null),
                 Arguments.of("", "", null),
-                Arguments.of("", "extension-name", ContextUtils.CH_SBB_POLARION_EXTENSION + "extension-name"),
+                Arguments.of("", "extension-name", ContextUtils.CH_SBB_POLARION_EXTENSION + "extension-name."),
                 // configurationPropertiesPrefix is provided without ending dot
                 Arguments.of("com.name.test.without.dot", null, "com.name.test.without.dot."),
                 Arguments.of("com.name.test.without.dot", "", "com.name.test.without.dot."),


### PR DESCRIPTION
Refs: #186
