### PR TITLE
fix: proper error message on attempt to set single value into multi-v…

### DIFF
--- a/app/src/test/java/ch/sbb/polarion/extension/generic/service/PolarionServiceTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/service/PolarionServiceTest.java
@@ -324,14 +324,20 @@ public class PolarionServiceTest {
             List<String> listValue = List.of("value1", "value2");
 
             // primitive fields cannot receive lists
-            assertThrows(ClassCastException.class,
+            IllegalArgumentException multiValueException = assertThrows(IllegalArgumentException.class,
                     () -> polarionService.setFieldValue(workItem, "genericFieldId", listValue, enumsMapping));
+            assertEquals("Cannot set multi-value into field 'genericFieldId'", multiValueException.getMessage());
 
             // lists must be supported
             genericFieldMetadata.setType(new ListType("listTypeId", FieldType.STRING.getType()));
             polarionService.setFieldValue(workItem, "genericFieldId", listValue, enumsMapping);
             verify(workItem, times(3)).setValue(anyString(), any());
             verify(workItem, times(1)).setCustomField(anyString(), any());
+
+            // multi fields cannot receive single values
+            IllegalArgumentException singleValueException = assertThrows(IllegalArgumentException.class,
+                    () -> polarionService.setFieldValue(workItem, "genericFieldId", 42, enumsMapping));
+            assertEquals("Cannot set single value to the multi-value field 'genericFieldId'", singleValueException.getMessage());
 
             // nulls for list-typed fields must be converted to an empty list
             polarionService.setFieldValue(workItem, "genericFieldId", null, enumsMapping);


### PR DESCRIPTION
…alue field and vice-versa

Refs: SchweizerischeBundesbahnen/ch.sbb.polarion.extension.diff-tool#83

### Proposed changes

Throw more convenient exception when user attempts to merge multi-value to a single-value field and vice-versa

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
