### PR TITLE
fix: unable to initialize extension without declared ExtensionBundleA…

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,14 +148,10 @@ Require-Bundle: com.polarion.portal.tomcat,
  org.springframework.spring-web
 ```
 
-* If the bundle has a form extension, it must contain `ExtensionBundleActivator` in the root package containing an implementation
-of `org.osgi.framework.BundleActivator` (or `ch.sbb.polarion.extension.generic.GenericBundleActivator` for convenience)
-which registers `IFormExtension` using `FormExtensionsRegistry`.
-Also in this case the manifest must contain `org.osgi.framework` entry in the `Import-Package` property:
-
-```properties
-Import-Package: org.osgi.framework
-```
+* If the bundle has a form extension, it can be registered either using custom `org.osgi.framework.BundleActivator` or implement `ch.sbb.polarion.extension.generic.GenericBundleActivator`.
+In both cases the manifest must contain:
+  - activator class in the `Bundle-Activator` entry
+  - `Import-Package: org.osgi.framework` + `Bundle-ActivationPolicy: lazy` entries
 
 ### Setting classes
 

--- a/pom.xml
+++ b/pom.xml
@@ -111,11 +111,8 @@
         <maven-jar-plugin.Bundle-Version>${project.artifact.selectedVersion.majorVersion}.${project.artifact.selectedVersion.minorVersion}.${project.artifact.selectedVersion.incrementalVersion}</maven-jar-plugin.Bundle-Version>
         <maven-jar-plugin.Extension-Context/>
         <maven-jar-plugin.Discover-Base-Package>${project.artifactId}</maven-jar-plugin.Discover-Base-Package>
-        <maven-jar-plugin.BundleActivatorClass>${maven-jar-plugin.Automatic-Module-Name}.ExtensionBundleActivator</maven-jar-plugin.BundleActivatorClass>
-        <maven-jar-plugin.BundleActivationPolicy>lazy</maven-jar-plugin.BundleActivationPolicy>
         <maven-jar-plugin.Configuration-Properties-Prefix/>
         <maven-jar-plugin.Project-URL>${project.scm.url}</maven-jar-plugin.Project-URL>
-        <maven-jar-plugin.ImportPackage>org.osgi.framework</maven-jar-plugin.ImportPackage>
 
         <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
         <nexus-staging-maven-plugin.autoReleaseAfterClose>true</nexus-staging-maven-plugin.autoReleaseAfterClose>
@@ -661,8 +658,6 @@
                             <manifestFile>src/main/resources/META-INF/MANIFEST.MF</manifestFile>
                             <manifestEntries>
                                 <Manifest-Version>${maven-jar-plugin.Manifest-Version}</Manifest-Version>
-                                <Bundle-Activator>${maven-jar-plugin.BundleActivatorClass}</Bundle-Activator>
-                                <Bundle-ActivationPolicy>${maven-jar-plugin.BundleActivationPolicy}</Bundle-ActivationPolicy>
                                 <Bundle-ManifestVersion>${maven-jar-plugin.Bundle-ManifestVersion}</Bundle-ManifestVersion>
                                 <Bundle-Vendor>${maven-jar-plugin.Bundle-Vendor}</Bundle-Vendor>
                                 <Automatic-Module-Name>${maven-jar-plugin.Automatic-Module-Name}</Automatic-Module-Name>
@@ -674,7 +669,6 @@
                                 <Discover-Base-Package>${maven-jar-plugin.Discover-Base-Package}</Discover-Base-Package>
                                 <Configuration-Properties-Prefix>${maven-jar-plugin.Configuration-Properties-Prefix}</Configuration-Properties-Prefix>
                                 <Project-URL>${maven-jar-plugin.Project-URL}</Project-URL>
-                                <Import-Package>${maven-jar-plugin.ImportPackage}</Import-Package>
                             </manifestEntries>
                         </archive>
                     </configuration>


### PR DESCRIPTION
…ctivator

Refs: #267

### Proposed changes

Generic shouldn't enforce extensions to declare ExtensionBundleActivator if it doesn't need it.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
