### PR TITLE
feat: Introduced new annotation based property mapping scanner

### DIFF
--- a/app/src/main/java/ch/sbb/polarion/extension/generic/properties/ExtensionConfiguration.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/properties/ExtensionConfiguration.java
@@ -1,5 +1,8 @@
 package ch.sbb.polarion.extension.generic.properties;
 
+import ch.sbb.polarion.extension.generic.properties.mappings.PropertyMapping;
+import ch.sbb.polarion.extension.generic.properties.mappings.PropertyMappingDefaultValue;
+import ch.sbb.polarion.extension.generic.properties.mappings.PropertyMappingDescription;
 import ch.sbb.polarion.extension.generic.util.ContextUtils;
 import com.polarion.core.config.impl.SystemValueReader;
 import lombok.Getter;
@@ -21,16 +24,19 @@ public class ExtensionConfiguration implements IExtensionConfiguration {
     protected final String propertyPrefix;
 
     @SuppressWarnings("unused")
+    @PropertyMapping(DEBUG)
     public boolean isDebug() {
         return SystemValueReader.getInstance().readBoolean(propertyPrefix + DEBUG, DEBUG_DEFAULT_VALUE);
     }
 
     @SuppressWarnings("unused")
+    @PropertyMappingDescription(DEBUG)
     public String getDebugDescription() {
         return DEBUG_DESCRIPTION;
     }
 
     @SuppressWarnings("unused")
+    @PropertyMappingDefaultValue(DEBUG)
     public String getDebugDefaultValue() {
         return String.valueOf(DEBUG_DEFAULT_VALUE);
     }
@@ -47,9 +53,10 @@ public class ExtensionConfiguration implements IExtensionConfiguration {
 
         for (String supportedProperty : supportedProperties) {
             @NotNull String key = getPropertyPrefix() + supportedProperty;
-            @Nullable String value = GetterFinder.getValue(extensionConfiguration, supportedProperty);
-            @Nullable String defaultValue = GetterFinder.getDefaultValue(extensionConfiguration, supportedProperty);
-            @Nullable String description = GetterFinder.getDescription(extensionConfiguration, supportedProperty);
+            PropertyMappingScanner<?> propertyMappingScanner = new PropertyMappingScanner<>(extensionConfiguration);
+            @Nullable String value = propertyMappingScanner.getValue(supportedProperty);
+            @Nullable String defaultValue = propertyMappingScanner.getDefaultValue(supportedProperty);
+            @Nullable String description = propertyMappingScanner.getDescription(supportedProperty);
             if (value != null) {
                 configurationProperties.setProperty(key, new ConfigurationProperties.Value(value, defaultValue, description));
             }

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/properties/PropertyMappingScanner.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/properties/PropertyMappingScanner.java
@@ -1,0 +1,101 @@
+package ch.sbb.polarion.extension.generic.properties;
+
+import ch.sbb.polarion.extension.generic.properties.mappings.PropertyMapping;
+import ch.sbb.polarion.extension.generic.properties.mappings.PropertyMappingDefaultValue;
+import ch.sbb.polarion.extension.generic.properties.mappings.PropertyMappingDescription;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiFunction;
+
+import static com.polarion.core.util.StringUtils.isEmpty;
+
+public class PropertyMappingScanner<T extends ExtensionConfiguration>  {
+
+    private final Map<String, PropertyInfo> properties = new ConcurrentHashMap<>();
+    private final T configInstance;
+
+    public PropertyMappingScanner(T configInstance) {
+        this.configInstance = configInstance;
+        if (configInstance == null) {
+            throw new IllegalArgumentException("Config instance cannot be null");
+        }
+        scan(configInstance);
+    }
+
+    public String getValue(String propertyName) {
+        PropertyInfo info = properties.get(propertyName);
+        return ((info != null) && (info.value != null))?
+                info.value : GetterFinder.getValue(configInstance, propertyName);
+    }
+
+    public String getDefaultValue(String propertyName) {
+        PropertyInfo info = properties.get(propertyName);
+        return ((info != null) && (info.defaultValue != null))?
+                info.defaultValue : GetterFinder.getDefaultValue(configInstance, propertyName);
+    }
+
+    public String getDescription(String propertyName) {
+        PropertyInfo info = properties.get(propertyName);
+        return ((info != null) && (info.description != null))?
+                info.description : GetterFinder.getDescription(configInstance, propertyName);
+    }
+
+    private void scan(Object configInstance) {
+        Class<?> clazz = configInstance.getClass();
+
+        for (Method method : clazz.getMethods()) {
+            processAnnotation(method, configInstance, PropertyMapping.class, PropertyInfo::withValue);
+            processAnnotation(method, configInstance, PropertyMappingDescription.class, PropertyInfo::withDescription);
+            processAnnotation(method, configInstance, PropertyMappingDefaultValue.class, PropertyInfo::withDefaultValue);
+        }
+    }
+
+    private <AType extends Annotation> void processAnnotation(
+            Method method,
+            Object instance,
+            Class<AType> annotationClass,
+            BiFunction<PropertyInfo, String, PropertyInfo> propertyInfoBuilder
+    ) {
+        if (method.isAnnotationPresent(annotationClass)) {
+            try {
+                AType annotation = method.getAnnotation(annotationClass);
+                String propertyKey = (String) annotationClass.getMethod("value").invoke(annotation);
+                if (isEmpty(propertyKey)) {
+                    throw new IllegalArgumentException("Property key cannot be empty");
+                }
+                String result = String.valueOf(method.invoke(instance));
+                properties.compute(propertyKey,
+                        (k, existingInfo) -> {
+                            PropertyInfo propertyInfo = Objects.requireNonNullElseGet(existingInfo, PropertyInfo::new);
+                            return propertyInfoBuilder.apply(propertyInfo, result);
+                        });
+            } catch (IllegalArgumentException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Failed to get value from annotation " + annotationClass.getSimpleName() + " : " + e.getMessage(), e);
+            }
+        }
+    }
+
+    record PropertyInfo(String value, String description, String defaultValue) {
+        public PropertyInfo() {
+            this(null, null, null);
+        }
+
+        public PropertyInfo withValue(String value) {
+            return new PropertyInfo(value, this.description, this.defaultValue);
+        }
+
+        public PropertyInfo withDescription(String description) {
+            return new PropertyInfo(this.value, description, this.defaultValue);
+        }
+
+        public PropertyInfo withDefaultValue(String defaultValue) {
+            return new PropertyInfo(this.value, this.description, defaultValue);
+        }
+    }
+}

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/properties/mappings/PropertyMapping.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/properties/mappings/PropertyMapping.java
@@ -1,0 +1,12 @@
+package ch.sbb.polarion.extension.generic.properties.mappings;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface PropertyMapping {
+    String value();
+}

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/properties/mappings/PropertyMappingDefaultValue.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/properties/mappings/PropertyMappingDefaultValue.java
@@ -1,0 +1,12 @@
+package ch.sbb.polarion.extension.generic.properties.mappings;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface PropertyMappingDefaultValue {
+    String value();
+}

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/properties/mappings/PropertyMappingDescription.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/properties/mappings/PropertyMappingDescription.java
@@ -1,0 +1,12 @@
+package ch.sbb.polarion.extension.generic.properties.mappings;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface PropertyMappingDescription {
+    String value();
+}

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/properties/PropertyMappingScannerTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/properties/PropertyMappingScannerTest.java
@@ -1,0 +1,144 @@
+package ch.sbb.polarion.extension.generic.properties;
+
+import ch.sbb.polarion.extension.generic.context.CurrentContextExtension;
+import ch.sbb.polarion.extension.generic.properties.mappings.PropertyMapping;
+import ch.sbb.polarion.extension.generic.properties.mappings.PropertyMappingDefaultValue;
+import ch.sbb.polarion.extension.generic.properties.mappings.PropertyMappingDescription;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ExtendWith({MockitoExtension.class, CurrentContextExtension.class})
+class PropertyMappingScannerTest {
+    private static PropertyMappingScanner<?> scanner;
+
+    @BeforeEach
+    void setUp() {
+        scanner = new PropertyMappingScanner<>(new TestConfig());
+    }
+
+    private static Stream<Arguments> existingPropertyValues() {
+        return Stream.of(
+                Arguments.of("test.mapping.key", "mapping value", (Function<String, String>) key -> scanner.getValue(key)),
+                Arguments.of("test.mapping.key", "default test value", (Function<String, String>) key -> scanner.getDefaultValue(key)),
+                Arguments.of("test.mapping.key", "test description", (Function<String, String>) key -> scanner.getDescription(key)),
+                Arguments.of("test.mapping.key.parent", "true", (Function<String, String>) key -> scanner.getValue(key)),
+                Arguments.of("test.mapping.key.parent", "false", (Function<String, String>) key -> scanner.getDefaultValue(key)),
+                Arguments.of("test.mapping.key.parent", "test parent description", (Function<String, String>) key -> scanner.getDescription(key)),
+                Arguments.of("testKey", "method convention value", (Function<String, String>) key -> scanner.getValue(key)),
+                Arguments.of("testKey", "method convention default value", (Function<String, String>) key -> scanner.getDefaultValue(key)),
+                Arguments.of("testKey", "method convention description", (Function<String, String>) key -> scanner.getDescription(key)),
+                Arguments.of("testParentKey", "parent annotation convention value", (Function<String, String>) key -> scanner.getValue(key)),
+                Arguments.of("testParentKey", "parent method convention default value", (Function<String, String>) key -> scanner.getDefaultValue(key)),
+                Arguments.of("testParentKey", "parent method convention description", (Function<String, String>) key -> scanner.getDescription(key))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("existingPropertyValues")
+    void shouldRetrieveAnnotationValues(String key, String expectedValue, Function<String, String> getMappingValue) {
+        assertThat(getMappingValue.apply(key)).isEqualTo(expectedValue);
+    }
+
+    private static Stream<Arguments> nonExistentPropertyKeys() {
+        return Stream.of(
+                Arguments.of("non.existent.key", (Function<String, String>) key -> scanner.getValue(key)),
+                Arguments.of("non.existent.key", (Function<String, String>) key -> scanner.getDefaultValue(key)),
+                Arguments.of("non.existent.key", (Function<String, String>) key -> scanner.getDescription(key))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonExistentPropertyKeys")
+    void shouldReturnNullForNonExistentValues(String key, Function<String, String> getMappingValue) {
+        assertThat(getMappingValue.apply(key)).isNull();
+    }
+
+    @Test
+    void shouldHandleBlankKey() {
+        assertThatThrownBy(() -> new PropertyMappingScanner<>(new TestConfigBlankKey()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Property key cannot be empty");
+    }
+
+    @SuppressWarnings("unused")
+    private static class TestConfig extends TestConfigParent {
+        @PropertyMapping("test.mapping.key")
+        public String anyMethodNameValue() {
+            return "mapping value";
+        }
+
+        @PropertyMappingDefaultValue("test.mapping.key")
+        public String anyMethodNameDefaultValue() {
+            return "default test value";
+        }
+
+        @PropertyMappingDescription("test.mapping.key")
+        public String anyMethodNameDescription() {
+            return "test description";
+        }
+
+        // old method naming convention
+        public String getTestKey() {
+            return "method convention value";
+        }
+
+        public String getTestKeyDefaultValue() {
+            return "method convention default value";
+        }
+
+        public String getTestKeyDescription() {
+            return "method convention description";
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class TestConfigParent extends ExtensionConfiguration {
+        @PropertyMapping("test.mapping.key.parent")
+        public boolean anyMethodNameValueParent() {
+            return true;
+        }
+
+        @PropertyMappingDefaultValue("test.mapping.key.parent")
+        public boolean anyMethodNameDefaultValueParent() {
+            return false;
+        }
+
+        @PropertyMappingDescription("test.mapping.key.parent")
+        public String anyMethodNameDescriptionParent() {
+            return "test parent description";
+        }
+
+        // mixed new annotation and old method naming convention
+        @PropertyMapping("testParentKey")
+        public String anyMethodNameInParent() {
+            return "parent annotation convention value";
+        }
+
+        public String getTestParentKeyDefaultValue() {
+            return "parent method convention default value";
+        }
+
+        public String getTestParentKeyDescription() {
+            return "parent method convention description";
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class TestConfigBlankKey extends ExtensionConfiguration {
+        @PropertyMapping("")
+        public String getMappingValue() {
+            return "mapping value";
+        }
+    }
+}


### PR DESCRIPTION
Refs: #266

### Proposed changes

Introduced new annotation based property mapping scanner, that uses annotations to detect value, defaultValue, and description getter methods in extensions. The old method naming convention is still supported, but now treated with lower priority.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
