### PR TITLE
chore: adapt configurations pane look consistent when no configuratio…

### DIFF
--- a/app/src/main/resources/META-INF/resources/common/jsp/configurations.jsp
+++ b/app/src/main/resources/META-INF/resources/common/jsp/configurations.jsp
@@ -1,7 +1,7 @@
 <%! String bundleTimestamp = ch.sbb.polarion.extension.generic.util.VersionUtils.getVersion().getBundleBuildTimestampDigitsOnly(); %>
 
-<p>There can be multiple named <span class="configuration-label">configuration</span>s. Please, chose one you would like to modify in dropdown below.
-    Be aware that "Default" <span class="configuration-label">configuration</span> on global scope can't be deleted or renamed.</p>
+<p>There can be multiple named <span class="configuration-label">configuration</span>s. Please, choose one you would like to modify in dropdown below.
+    <span id="default-cannot-be-deleted-note">Be aware that "Default" <span class="configuration-label">configuration</span> on global scope can't be deleted or renamed.</span></p>
 <div class="input-group common-configuration-panel">
     <div id="configurations-pane">
         <label id="configurations-label"><span class="configuration-label-capitalized">Configuration</span>:</label>

--- a/app/src/main/resources/js/configurations.js
+++ b/app/src/main/resources/js/configurations.js
@@ -49,7 +49,8 @@ const Configurations = {
                 const previouslySelectedValue = SbbCommon.getCookie(SELECTED_CONFIGURATION_COOKIE + SbbCommon.setting);
                 let preselectDefault = true;
                 let defaultValue = null;
-                for (let name of JSON.parse(responseText)) {
+                let names = JSON.parse(responseText);
+                for (let name of names) {
                     defaultValue = defaultValue || name.name; // Take first element from list as default
                     if (name.name === previouslySelectedValue) {
                         preselectDefault = false;
@@ -61,8 +62,13 @@ const Configurations = {
                     }
                 }
 
-                this.configurationsSelect.selectValue(previouslySelectedValue && !preselectDefault ? previouslySelectedValue : defaultValue);
-                this.setContentAreaEnabled(true);
+                const hasNames = names.length > 0
+                document.getElementById('configurations-button-edit').disabled = !hasNames;
+                document.getElementById('configurations-button-delete').disabled = !hasNames;
+                if (hasNames) {
+                    this.configurationsSelect.selectValue(previouslySelectedValue && !preselectDefault ? previouslySelectedValue : defaultValue);
+                    this.setContentAreaEnabled(true);
+                }
             },
             onError: () => document.getElementById("configurations-load-error").style.display = "block"
         });

--- a/app/src/main/resources/js/modules/ConfigurationsPane.js
+++ b/app/src/main/resources/js/modules/ConfigurationsPane.js
@@ -80,7 +80,8 @@ export default class ConfigurationsPane {
                 const previouslySelectedValue = this.ctx.getCookie(ConfigurationsPane.SELECTED_CONFIGURATION_COOKIE + this.ctx.setting);
                 let preselectDefault = true;
                 let defaultValue = null;
-                for (let name of JSON.parse(responseText)) {
+                let names = JSON.parse(responseText);
+                for (let name of names) {
                     defaultValue = defaultValue || name.name; // Take first element from list as default
                     if (name.name === previouslySelectedValue) {
                         preselectDefault = false;
@@ -92,8 +93,13 @@ export default class ConfigurationsPane {
                     }
                 }
 
-                this.configurationsSelect.selectValue(previouslySelectedValue && !preselectDefault ? previouslySelectedValue : defaultValue);
-                this.setContentAreaEnabled(true);
+                const hasNames = names.length > 0
+                this.ctx.disableIf('configurations-button-edit', !hasNames);
+                this.ctx.disableIf('configurations-button-delete', !hasNames);
+                if (hasNames) {
+                    this.configurationsSelect.selectValue(previouslySelectedValue && !preselectDefault ? previouslySelectedValue : defaultValue);
+                    this.setContentAreaEnabled(true);
+                }
             },
             onError: () => document.getElementById("configurations-load-error").style.display = "block"
         });

--- a/app/src/main/resources/js/modules/ExtensionContext.js
+++ b/app/src/main/resources/js/modules/ExtensionContext.js
@@ -87,6 +87,10 @@ export default class ExtensionContext {
         this.getElementById(elementId).style.visibility = condition ? "visible" : "hidden";
     }
 
+    disableIf(elementId, condition) {
+        this.getElementById(elementId).disabled = condition;
+    }
+
     containsOption(selectElement, option) {
         return [...selectElement.options].map(o => o.value).includes(option);
     }


### PR DESCRIPTION
…ns exist

### Proposed changes

We have to make configurations pane look consistent when no configurations returned by server

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
