### PR TITLE
feat: do not implicitly persist Default settings during read operations

### DIFF
--- a/app/src/main/java/ch/sbb/polarion/extension/generic/settings/GenericNamedSettings.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/settings/GenericNamedSettings.java
@@ -78,17 +78,7 @@ public abstract class GenericNamedSettings<T extends SettingsModel> implements N
             names.addAll(getSettingNamesFromLocation(DEFAULT_SCOPE));
         }
 
-        if (names.isEmpty()) {
-            // If there are no settings persisted - try to create default one
-            try {
-                saveDefaultSettingsInGlobalScope();
-            } catch (Exception e) { // If it's not possible to create the settings in read only transaction, so just ignore it
-                logger.warn("Cannot create the settings in read only transaction, creation will be skipped: " + e.getMessage(), e);
-            }
-
-            names.add(SettingName.builder().id(DEFAULT_NAME).name(DEFAULT_NAME).scope(DEFAULT_SCOPE).build());
-        }
-
+        names.add(SettingName.builder().id(DEFAULT_NAME).name(DEFAULT_NAME).scope(DEFAULT_SCOPE).build());
         return names.stream().sorted(namesComparator).toList();
     }
 
@@ -101,7 +91,7 @@ public abstract class GenericNamedSettings<T extends SettingsModel> implements N
             value = readFileContent(DEFAULT_SCOPE, fileName, null);
         }
 
-        return value == null ? handleMissingValue(id) : fromString(value);
+        return value == null ? defaultValues() : fromString(value);
     }
 
     private @Nullable String readFileContent(@NotNull String scope, @Nullable String fileName, @Nullable String revisionName) {
@@ -111,18 +101,6 @@ public abstract class GenericNamedSettings<T extends SettingsModel> implements N
         String settingPath = String.format(LOCATION_MASK, settingsFolder, fileName, SETTINGS_FILE_EXTENSION);
         ILocation location = ScopeUtils.getContextLocation(scope).append(settingPath);
         return settingsService.read(location, revisionName);
-    }
-
-    private @NotNull T handleMissingValue(@NotNull SettingId id) {
-        if (DEFAULT_NAME.equals(id.getIdentifier())) {
-            try {
-                return saveDefaultSettingsInGlobalScope();
-            } catch (Exception e) {
-                logger.warn("Cannot create the settings in read-only transaction, default values will be used: " + e.getMessage(), e);
-                return defaultValues();
-            }
-        }
-        throw new ObjectNotFoundException("Setting '%s' not found".formatted(id.getIdentifier()));
     }
 
     @Override
@@ -232,9 +210,4 @@ public abstract class GenericNamedSettings<T extends SettingsModel> implements N
                 .build();
     }
 
-    private @NotNull T saveDefaultSettingsInGlobalScope() {
-        @NotNull T defaultModel = defaultValues();
-        defaultModel.setName(DEFAULT_NAME);
-        return save(DEFAULT_SCOPE, SettingId.fromId(DEFAULT_NAME), defaultModel);
-    }
 }

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/settings/SettingsService.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/settings/SettingsService.java
@@ -105,7 +105,6 @@ public class SettingsService {
         return TransactionalExecutor.executeSafelyInReadOnlyTransaction(transaction -> {
             IRepositoryReadOnlyConnection readOnlyConnection = repositoryService.getReadOnlyConnection(location);
             if (!readOnlyConnection.exists(location)) {
-                logNotExistingLocation(location);
                 return null;
             }
 
@@ -131,7 +130,6 @@ public class SettingsService {
         return TransactionalExecutor.executeSafelyInReadOnlyTransaction(transaction -> {
             IRepositoryReadOnlyConnection readOnlyConnection = repositoryService.getReadOnlyConnection(location);
             if (!readOnlyConnection.exists(location)) {
-                logNotExistingLocation(location);
                 return new ArrayList<>();
             }
 
@@ -171,15 +169,10 @@ public class SettingsService {
         return TransactionalExecutor.executeSafelyInReadOnlyTransaction(transaction -> {
             IRepositoryReadOnlyConnection readOnlyConnection = repositoryService.getReadOnlyConnection(location);
             if (!readOnlyConnection.exists(location)) {
-                logNotExistingLocation(location);
                 return null;
             }
             return readOnlyConnection.getLastRevision(location);
         });
-    }
-
-    private void logNotExistingLocation(ILocation location) {
-        logger.warn("Location does not exist: " + location.getLocationPath());
     }
 
     @Nullable

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/settings/GenericNamedSettingsTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/settings/GenericNamedSettingsTest.java
@@ -81,7 +81,6 @@ class GenericNamedSettingsTest {
             ILocation mockDefaultTest1Location = mock(ILocation.class);
             when(mockDefaultLocation.append(".polarion/extensions/" + POLARION_TEXT_EXTENSION + "/Test/default_test1.settings")).thenReturn(mockDefaultTest1Location);
             ILocation mockDefaultDefaultLocation = mock(ILocation.class);
-            when(mockDefaultLocation.append(".polarion/extensions/" + POLARION_TEXT_EXTENSION + "/Test/Default.settings")).thenReturn(mockDefaultDefaultLocation);
 
             mockScopeUtils.when(() -> ScopeUtils.getContextLocation("")).thenReturn(mockDefaultLocation);
             when(settingsService.getLastRevision(mockDefaultSettingsFolderLocation)).thenReturn("42");
@@ -104,18 +103,8 @@ class GenericNamedSettingsTest {
             TestModel testModelGlobalDefaultTest1 = testSettings.read("", SettingId.fromName("default_test1"), null);
             assertEquals("default_test1", testModelGlobalDefaultTest1.getName());
 
-            SettingId defaultTest1SettingId = SettingId.fromName("unknown");
-            assertThrows(ObjectNotFoundException.class, () -> testSettings.read("project/some_project/", defaultTest1SettingId, "55"));
-
-            SettingId unknownSettingId = SettingId.fromName("unknown");
-            assertThrows(ObjectNotFoundException.class, () -> testSettings.read("project/some_project/", unknownSettingId, null));
-
             TestModel testModelDefaultSaved = testSettings.read("project/some_project/", SettingId.fromName(DEFAULT_NAME), null);
             assertEquals("Default", testModelDefaultSaved.getName());
-
-            doThrow(new RuntimeException("test runtime exception")).when(settingsService).save(eq(mockDefaultDefaultLocation), anyString());
-            TestModel testModelDefaultNotSaved = testSettings.read("project/some_project/", SettingId.fromName(DEFAULT_NAME), null);
-            assertEquals("Default", testModelDefaultNotSaved.getName());
         }
     }
 
@@ -143,24 +132,24 @@ class GenericNamedSettingsTest {
             when(settingsService.read(any(), any())).thenReturn(getModelContent("test1"), getModelContent("test2"), getModelContent("default1"), getModelContent("default2"));
 
             Collection<SettingName> names = testSettings.readNames("project/some_project/");
-            assertEquals(Stream.of("test1", "test2", "default1", "default2").sorted().toList(), names.stream().map(SettingName::getName).sorted().toList());
+            assertEquals(Stream.of("Default", "test1", "test2", "default1", "default2").sorted().toList(), names.stream().map(SettingName::getName).sorted().toList());
 
             //folder revisions remain the same = used cached values
             lenient().when(settingsService.read(any(), any())).thenReturn(getModelContent("test3"), getModelContent("test4"), getModelContent("default3"), getModelContent("default4"));
             names = testSettings.readNames("project/some_project/");
-            assertEquals(Stream.of("test1", "test2", "default1", "default2").sorted().toList(), names.stream().map(SettingName::getName).sorted().toList());
+            assertEquals(Stream.of("Default", "test1", "test2", "default1", "default2").sorted().toList(), names.stream().map(SettingName::getName).sorted().toList());
 
             //default folder revision updated = results partially changed
             lenient().when(settingsService.read(any(), any())).thenReturn(getModelContent("default3"), getModelContent("default4"));
             when(settingsService.getLastRevision(mockDefaultFolderLocation)).thenReturn("43");
             names = testSettings.readNames("project/some_project/");
-            assertEquals(Stream.of("test1", "test2", "default3", "default4").sorted().toList(), names.stream().map(SettingName::getName).sorted().toList());
+            assertEquals(Stream.of("Default", "test1", "test2", "default3", "default4").sorted().toList(), names.stream().map(SettingName::getName).sorted().toList());
 
             //project folder revision updated = results changed again
             lenient().when(settingsService.read(any(), any())).thenReturn(getModelContent("test3"), getModelContent("test4"));
             when(settingsService.getLastRevision(mockProjectFolderLocation)).thenReturn("35");
             names = testSettings.readNames("project/some_project/");
-            assertEquals(Stream.of("test3", "test4", "default3", "default4").sorted().toList(), names.stream().map(SettingName::getName).sorted().toList());
+            assertEquals(Stream.of("Default", "test3", "test4", "default3", "default4").sorted().toList(), names.stream().map(SettingName::getName).sorted().toList());
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -772,6 +772,12 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven-compiler-plugin.version}</version>
+                    <configuration>
+                        <compilerArgs>
+                            <arg>-Alog4j.graalvm.groupId=org.apache.logging.log4j</arg>
+                            <arg>-Alog4j.graalvm.artifactId=log4j-core</arg>
+                        </compilerArgs>
+                    </configuration>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
Refs: #302

### Proposed changes

We have to skip implicit creation of 'Default' settings on read operations.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [ ] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
