### PR TITLE
ci: fix auto publishing to Maven Central

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -119,11 +119,7 @@ jobs:
             -Dmaven.test.skip=true \
             -P gpg-sign \
             -P central-publishing \
-            -Dcentral.timeout=3600 \
-            -Dcentral-publishing-maven-plugin.autoPublish=false
-          # In case of problems with the connection to Sonatype Central, you can uncomment and try the following lines
-          # -Dmaven.wagon.http.connectionTimeout=3600000 \
-          # -Dmaven.wagon.http.readTimeout=3600000 \
+            -Dcentral.timeout=3600
   deploy-github-packages:
     needs: build
     if: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
This pull request makes a small adjustment to the Maven build workflow configuration file. The change removes the `central-publishing-maven-plugin.autoPublish` parameter and its associated value, along with commented-out lines related to connection timeouts.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
