### PR TITLE
fix: remove test skipping from Maven deploy command

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -116,7 +116,6 @@ jobs:
           # it cannot be implemented using deploy:deploy-file
           # central-publishing-maven-plugin needs to be used instead due to a specific deployment
           mvn --batch-mode -s "${SETTINGS_XML}" clean deploy \
-            -Dmaven.test.skip=true \
             -P gpg-sign \
             -P central-publishing \
             -Dcentral.timeout=3600


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/maven-build.yml` file. The change removes the `-Dmaven.test.skip=true` flag from the Maven deployment command, ensuring that tests are no longer skipped during the deployment process.

Fixing 
"Could not find artifact ch.sbb.polarion.extensions:ch.sbb.polarion.extension.generic.app:jar:tests:11.0.0"

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
