### PR TITLE
chore: move frontend-maven-plugin properties from module to parent pom

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -11,12 +11,6 @@
     <name>Versatile extension for developing additional extensions within Polarion ALM: common code and resources</name>
     <artifactId>ch.sbb.polarion.extension.generic.app</artifactId>
 
-    <properties>
-        <frontend-maven-plugin.version>1.15.4</frontend-maven-plugin.version>
-        <frontend-maven-plugin.nodeVersion>v20.19.5</frontend-maven-plugin.nodeVersion>
-        <frontend-maven-plugin.npmVersion>10.9.4</frontend-maven-plugin.npmVersion>
-    </properties>
-
     <profiles>
         <profile>
             <id>gpg-sign</id>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,10 @@
 
         <!-- exclude rest controllers from coverage report -->
         <sonar.coverage.exclusions>**/rest/controller/**</sonar.coverage.exclusions>
+
+        <frontend-maven-plugin.version>1.15.4</frontend-maven-plugin.version>
+        <frontend-maven-plugin.nodeVersion>v20.19.5</frontend-maven-plugin.nodeVersion>
+        <frontend-maven-plugin.npmVersion>10.9.4</frontend-maven-plugin.npmVersion>
     </properties>
 
     <profiles>


### PR DESCRIPTION
### Proposed changes

This pull request moves the configuration properties for the frontend Maven plugin (including its version, Node.js version, and npm version) from the `app/pom.xml` module file to the top-level `pom.xml` file.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
