### PR TITLE
updated readme for configuration conflict detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,11 +253,16 @@ This can happen when settings files are manually created or imported via SVN.
 
 ```json
 {
-  "message": "Multiple settings files contain the same name: Default"
+  "message": "Multiple settings files contain the same name: Default (68d0a695-9865-4612-a6ab-e6102bc8d1e1, 3ea1190b-adb9-4cda-8906-953030327958)"
 }
 ```
 
-If multiple duplicate names exist, they will be listed: `"Multiple settings files contain the same name: ConfigA, ConfigB"`.
+The message includes the setting name and the file IDs (UUIDs) of the conflicting files.
+If multiple duplicate names exist, they will all be listed:
+
+```
+Multiple settings files contain the same name: ConfigA (id1, id2), ConfigB (id3, id4, id5)
+```
 
 This validation is triggered on all settings operations: read, save, delete, list names, and list revisions.
 

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/settings/GenericNamedSettings.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/settings/GenericNamedSettings.java
@@ -209,13 +209,19 @@ public abstract class GenericNamedSettings<T extends SettingsModel> implements N
     private void checkForDuplicateNames(List<SettingName> settingNames) {
         Map<String, List<SettingName>> groupedByName = settingNames.stream()
                 .collect(Collectors.groupingBy(SettingName::getName));
-        List<String> duplicateNames = groupedByName.entrySet().stream()
+        List<String> duplicateEntries = groupedByName.entrySet().stream()
                 .filter(entry -> entry.getValue().size() > 1)
-                .map(Map.Entry::getKey)
-                .sorted()
+                .sorted(Map.Entry.comparingByKey())
+                .map(entry -> {
+                    String ids = entry.getValue().stream()
+                            .map(SettingName::getId)
+                            .sorted()
+                            .collect(Collectors.joining(", "));
+                    return entry.getKey() + " (" + ids + ")";
+                })
                 .toList();
-        if (!duplicateNames.isEmpty()) {
-            throw new DuplicateSettingNameException("Multiple settings files contain the same name: " + String.join(", ", duplicateNames));
+        if (!duplicateEntries.isEmpty()) {
+            throw new DuplicateSettingNameException("Multiple settings files contain the same name: " + String.join(", ", duplicateEntries));
         }
     }
 

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/settings/GenericNamedSettingsTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/settings/GenericNamedSettingsTest.java
@@ -304,8 +304,8 @@ class GenericNamedSettingsTest {
 
             DuplicateSettingNameException exception = assertThrows(DuplicateSettingNameException.class,
                     () -> testSettings.readNames("project/duplicate_project/"));
-            assertThat(exception.getMessage()).contains("Default");
             assertThat(exception.getMessage()).contains("Multiple settings files contain the same name");
+            assertThat(exception.getMessage()).contains("Default (file1-uuid, file2-uuid)");
         }
     }
 
@@ -346,8 +346,8 @@ class GenericNamedSettingsTest {
 
             DuplicateSettingNameException exception = assertThrows(DuplicateSettingNameException.class,
                     () -> testSettings.readNames("project/multi_duplicate/"));
-            assertThat(exception.getMessage()).contains("ConfigA");
-            assertThat(exception.getMessage()).contains("ConfigB");
+            assertThat(exception.getMessage()).contains("ConfigA (file1-uuid, file2-uuid)");
+            assertThat(exception.getMessage()).contains("ConfigB (file3-uuid, file4-uuid)");
         }
     }
 


### PR DESCRIPTION
### Proposed changes

This pull request improves the validation and error reporting for duplicate setting names in the settings API. The changes ensure that when duplicate setting names are detected, the error messages are more informative, listing both the conflicting names and their associated file IDs. The documentation and tests have been updated to reflect this enhanced behavior.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
