### PR TITLE
fix: move error logging inside exception handling to ensure it runs reliably

### DIFF
--- a/app/src/main/java/ch/sbb/polarion/extension/generic/util/BundleJarsPrioritizingRunnableExecutor.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/util/BundleJarsPrioritizingRunnableExecutor.java
@@ -40,10 +40,10 @@ final class BundleJarsPrioritizingRunnableExecutor {
 
             return invokeRunnable(cached.runnableClass(), cached.instance(), params);
         } catch (Exception e) {
-            Logger.getLogger(BundleJarsPrioritizingRunnable.class).error("Error while running cached impl", e);
             if (rethrowException) {
                 throw e;
             } else {
+                Logger.getLogger(BundleJarsPrioritizingRunnable.class).error("Error while running cached impl", e);
                 return Map.of(BundleJarsPrioritizingRunnable.ERROR_KEY, e);
             }
         } finally {
@@ -87,10 +87,10 @@ final class BundleJarsPrioritizingRunnableExecutor {
                 return invokeRunnable(runnableClass, runnable, params);
             }
         } catch (Exception e) {
-            Logger.getLogger(BundleJarsPrioritizingRunnable.class).error("Error while running impl", e);
             if (rethrowException) {
                 throw e;
             } else {
+                Logger.getLogger(BundleJarsPrioritizingRunnable.class).error("Error while running impl", e);
                 return Map.of(BundleJarsPrioritizingRunnable.ERROR_KEY, e);
             }
         } finally {


### PR DESCRIPTION
### Proposed changes

This pull request makes a small change to the error handling logic in `BundleJarsPrioritizingRunnableExecutor.java`. The logging of errors when running implementations is now only performed if the exception is not being rethrown, avoiding duplicate log entries.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
