### PR TITLE
fix: add support for `.txt` file content type handling in `GenericUiServlet`

### DIFF
--- a/app/src/main/java/ch/sbb/polarion/extension/generic/GenericUiServlet.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/GenericUiServlet.java
@@ -33,7 +33,8 @@ public abstract class GenericUiServlet extends HttpServlet {
             Pair.of(".gif", "image/gif"),
             Pair.of(".woff", "application/font-woff"),
             Pair.of(".woff2", "application/font-woff2"),
-            Pair.of(".ico", "image/x-icon")
+            Pair.of(".ico", "image/x-icon"),
+            Pair.of(".txt", "text/plain")
     );
 
     private static final Logger logger = Logger.getLogger(GenericUiServlet.class);

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/GenericUiServletTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/GenericUiServletTest.java
@@ -54,6 +54,10 @@ class GenericUiServletTest {
         GenericUiServlet.setContentType("/img.ico", response);
         verify(response, times(1)).setContentType("image/x-icon");
 
+        response = mock(HttpServletResponse.class);
+        GenericUiServlet.setContentType("/data.txt", response);
+        verify(response, times(1)).setContentType("text/plain");
+
         HttpServletResponse servletResponse = mock(HttpServletResponse.class);
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> GenericUiServlet.setContentType("unknown_file.xml", servletResponse));
         assertEquals("Unsupported file type", exception.getMessage());


### PR DESCRIPTION
### Proposed changes

This pull request adds support for serving `.txt` files with the correct MIME type in the `GenericUiServlet` and updates the corresponding unit tests to verify this behavior.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
