### PR TITLE
docs: update README to clarify REST architecture and security models for internal and API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,58 @@ public class PdfExporterRestApplication extends GenericRestApplication {
 }
 ```
 
+### REST architecture: `/internal` vs `/api`
+
+Extensions built on top of this generic extension expose REST endpoints under two distinct URL spaces with **different security models**. Understanding the split is important - they are not interchangeable, and `@Secured` is intentionally applied to one but not the other.
+
+| URL space | Intended caller | Authentication | Authorization | CSRF protection |
+|---|---|---|---|---|
+| `/rest/internal/*` | The extension's own UI, running inside an authenticated Polarion session | Servlet container (`<security-constraint>` in `web.xml` with `<role-name>user</role-name>`, FORM-based login against `PolarionRealm`) | Real Polarion user from the session — operations run under that user's permissions | Polarion session cookie + `X-Polarion-REST-Token` (XSRF), which the Polarion UI attaches |
+| `/rest/api/*` | External clients (scripts, integrations, other services) | `@Secured` filter (`AuthenticationFilter`), validating either `Authorization: Bearer <PAT>` or `X-Polarion-REST-Token` | Wrapped in `polarionService.callPrivileged(...)` — the PAT principal has no Polarion subject, so calls run with elevated privileges | Custom header (PAT / XSRF) is itself a CSRF defense per OWASP — browsers cannot attach custom headers to cookie-only cross-origin requests without a CORS preflight |
+
+The controller pattern that implements this split is illustrated by `NamedSettingsInternalController` and `NamedSettingsApiController`:
+
+* `NamedSettingsInternalController` — `@Path("/internal")`, **no** `@Secured`. Container-level auth already gates the endpoint.
+* `NamedSettingsApiController extends NamedSettingsInternalController` — `@Path("/api")`, `@Secured`, each method overridden to wrap the inherited logic in `polarionService.callPrivileged(...)`.
+
+Each consuming extension's `web.xml` must declare both constraints — the role-protected one for `/*` and an open one for `/rest/api/*` so the container does not interfere with `@Secured`:
+
+```xml
+<!-- Container-level auth: everything except /rest/api/* requires a Polarion session -->
+<security-constraint>
+    <web-resource-collection>
+        <web-resource-name>All</web-resource-name>
+        <url-pattern>/*</url-pattern>
+    </web-resource-collection>
+    <auth-constraint>
+        <role-name>user</role-name>
+    </auth-constraint>
+</security-constraint>
+
+<!-- /rest/api/* is opened at the container level — auth happens in @Secured (AuthenticationFilter) -->
+<security-constraint>
+    <web-resource-collection>
+        <web-resource-name>All</web-resource-name>
+        <url-pattern>/rest/api/*</url-pattern>
+    </web-resource-collection>
+    <auth-constraint/>
+</security-constraint>
+
+<login-config>
+    <auth-method>FORM</auth-method>
+    <realm-name>PolarionRealm</realm-name>
+    <form-login-config>
+        <form-login-page>/login/login</form-login-page>
+        <form-error-page>/login/error</form-error-page>
+    </form-login-config>
+</login-config>
+```
+
+Consequences of this design:
+
+* **Do not add `@Secured` to `/internal/*` controllers.** It is redundant with the container's `<security-constraint>`, and it would break the extension's UI flow, which authenticates via the Polarion session, not via PAT.
+* **Do not call `/internal/*` from external clients.** It is not a public API. External integrations must use `/rest/api/*`.
+
 ### UI servlet class
 
 If new extension will contain UI parts/pages/artifacts, UI servlet class should be created extending `GenericUiServlet`

--- a/README.md
+++ b/README.md
@@ -334,17 +334,17 @@ public class PdfExporterRestApplication extends GenericRestApplication {
 
 Extensions built on top of this generic extension expose REST endpoints under two distinct URL spaces with **different security models**. Understanding the split is important - they are not interchangeable, and `@Secured` is intentionally applied to one but not the other.
 
-| URL space | Intended caller | Authentication | Authorization | CSRF protection |
-|---|---|---|---|---|
-| `/rest/internal/*` | The extension's own UI, running inside an authenticated Polarion session | Servlet container (`<security-constraint>` in `web.xml` with `<role-name>user</role-name>`, FORM-based login against `PolarionRealm`) | Real Polarion user from the session — operations run under that user's permissions | Polarion session cookie + `X-Polarion-REST-Token` (XSRF), which the Polarion UI attaches |
-| `/rest/api/*` | External clients (scripts, integrations, other services) | `@Secured` filter (`AuthenticationFilter`), validating either `Authorization: Bearer <PAT>` or `X-Polarion-REST-Token` | Wrapped in `polarionService.callPrivileged(...)` — the PAT principal has no Polarion subject, so calls run with elevated privileges | Custom header (PAT / XSRF) is itself a CSRF defense per OWASP — browsers cannot attach custom headers to cookie-only cross-origin requests without a CORS preflight |
+| URL space | Intended caller | Authentication | Authorization                                                                                                                       | CSRF protection                                                                                                                                                                                                                                                                                                                                          |
+|---|---|---|-------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `/rest/internal/*` | The extension's own UI, running inside an authenticated Polarion session | Servlet container (`<security-constraint>` in `web.xml` with `<role-name>user</role-name>`, FORM-based login against `PolarionRealm`); Polarion's `DoAsFilter` then propagates the session's `Subject` to the request thread | Real Polarion user from the session - operations run under that user's permissions | No server-side token check - `X-Polarion-REST-Token` is **not** validated on `/internal/*`. Defence relies on (a) the container session being required, (b) browser SameSite=Lax cookie default, which prevents cookie-bearing cross-site `<form>` POST/PUT/DELETE, and (c) the REST convention that state-changing methods are POST/PUT/DELETE, not GET |
+| `/rest/api/*` | External clients. Mirrors Polarion's own public REST API authentication model (see `AccessTokenAuthenticator`) | `@Secured` filter (`AuthenticationFilter`), validating either `Authorization: Bearer <PAT>` or `X-Polarion-REST-Token` | Wrapped in `polarionService.callPrivileged(...)` - the PAT principal has no Polarion subject, so calls run with elevated privileges | Custom-header requirement is itself a CSRF defence per OWASP - browsers cannot attach custom headers to cookie-only cross-origin requests without a CORS preflight                                                                                                                                                                                       |
 
 The controller pattern that implements this split is illustrated by `NamedSettingsInternalController` and `NamedSettingsApiController`:
 
-* `NamedSettingsInternalController` — `@Path("/internal")`, **no** `@Secured`. Container-level auth already gates the endpoint.
-* `NamedSettingsApiController extends NamedSettingsInternalController` — `@Path("/api")`, `@Secured`, each method overridden to wrap the inherited logic in `polarionService.callPrivileged(...)`.
+* `NamedSettingsInternalController` - `@Path("/internal")`, **no** `@Secured`. Container-level auth already gates the endpoint.
+* `NamedSettingsApiController extends NamedSettingsInternalController` - `@Path("/api")`, `@Secured`, each method overridden to wrap the inherited logic in `polarionService.callPrivileged(...)`.
 
-Each consuming extension's `web.xml` must declare both constraints — the role-protected one for `/*` and an open one for `/rest/api/*` so the container does not interfere with `@Secured`:
+Each consuming extension's `web.xml` must declare both constraints - the role-protected one for `/*` and an open one for `/rest/api/*` so the container does not interfere with `@Secured`:
 
 ```xml
 <!-- Container-level auth: everything except /rest/api/* requires a Polarion session -->
@@ -358,7 +358,7 @@ Each consuming extension's `web.xml` must declare both constraints — the role-
     </auth-constraint>
 </security-constraint>
 
-<!-- /rest/api/* is opened at the container level — auth happens in @Secured (AuthenticationFilter) -->
+<!-- /rest/api/* is opened at the container level - auth happens in @Secured (AuthenticationFilter) -->
 <security-constraint>
     <web-resource-collection>
         <web-resource-name>All</web-resource-name>
@@ -366,6 +366,13 @@ Each consuming extension's `web.xml` must declare both constraints — the role-
     </web-resource-collection>
     <auth-constraint/>
 </security-constraint>
+
+<!--
+    Note on the empty <auth-constraint/>: per the Servlet spec this would deny all access, but
+    Polarion's `PolarionRealm` (com.polarion.platform/.../PolarionRealm.java) overrides
+    `hasResourcePermission()` to always return `true`, disabling container-level role enforcement.
+    In this stack the empty constraint effectively means "open at the container level".
+-->
 
 <login-config>
     <auth-method>FORM</auth-method>


### PR DESCRIPTION
### Proposed changes

This pull request adds comprehensive documentation to the `README.md` explaining the architectural split between `/internal` and `/api` REST endpoints, their security models, and the correct usage patterns for each. This clarification will help extension developers implement authentication and authorization correctly and avoid common pitfalls.

REST architecture and security documentation:

* Added a detailed section describing the differences between `/rest/internal/*` and `/rest/api/*` endpoints, including intended callers, authentication and authorization mechanisms, and CSRF protection strategies.
* Provided a table summarizing the security characteristics of each URL space, making it easier for developers to understand the implications.
* Explained the controller inheritance pattern (`NamedSettingsInternalController` and `NamedSettingsApiController`) that enforces these security boundaries in code.
* Included example `web.xml` configuration to illustrate proper servlet container security constraints for both endpoint types.
* Added explicit guidance and warnings to prevent misconfiguration, such as not adding `@Secured` to `/internal/*` controllers and not calling internal endpoints from external clients.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
