### PR TITLE
chore: sync pre-commit config + zizmor from template

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,11 +10,14 @@ repos:
     rev: v6.0.0
     hooks:
       - id: check-added-large-files
+        args: [--maxkb=5120]
       - id: check-case-conflict
       - id: check-merge-conflict
       - id: trailing-whitespace
+        exclude_types: [markdown]  # Avoid conflicts with markdown formatting
       - id: check-xml
       - id: check-json
+      - id: check-toml
       - id: check-yaml
       - id: no-commit-to-branch
       - id: mixed-line-ending
@@ -46,7 +49,7 @@ repos:
       - id: check-git-config-user-email
         args: [--templates, ^\S+\.\S+@sbb\.ch$]
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.13.10
+    rev: v4.15.0
     hooks:
       - id: commitizen
   - repo: https://github.com/woodruffw/zizmor-pre-commit

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,13 @@
+---
+rules:
+  # These secrets are passed as required step inputs (with:) to third-party actions
+  # (claude-code-action, actions/setup-java) and cannot be moved to env: blocks.
+  # Fork-PR workflows are additionally protected by GitHub's approval requirement.
+  secrets-outside-env:
+    ignore: [claude-code-review.yml, maven-build.yml]
+  # Reusable workflows from our own org — tracking @main intentionally.
+  unpinned-uses:
+    config:
+      policies:
+        '*': hash-pin
+        SchweizerischeBundesbahnen/*: any


### PR DESCRIPTION
## Summary

Pulls drifted pre-commit hook configuration and adds the missing `zizmor.yml` from `open-source-polarion-java-repo-template`.

This is the **first** of several PRs splitting the template-sync work tracked in #403. Pre-commit goes first because it gates the rest.

## Drift detected

| File | Action | Source |
|------|--------|--------|
| `.pre-commit-config.yaml` | Update | Template PRs #133, #130, #99, #90 (hook bumps + new hooks) |
| `zizmor.yml` | Add | Template PR #114 |

Specific changes:
- `check-added-large-files`: add `--maxkb=5120`
- `trailing-whitespace`: add `exclude_types: [markdown]`
- New `check-toml` hook
- Bump commitizen hook `v4.13.10` → `v4.15.0`
- New `zizmor.yml` with `secrets-outside-env` exceptions for `maven-build.yml` and (future) `claude-code-review.yml`, and `unpinned-uses` policy allowing `@main` for SBB-org reusable workflows

## Skipped (not applicable)

- `pretty-format-json` / `mixed-line-ending` hooks scoped to `docs/openapi.json` — generic has no OpenAPI spec (it's an infrastructure library)

## Test plan

- [x] `pre-commit run -a` passes locally on changed files
- [ ] CI green on PR
- [ ] Reviewer confirms no project-specific hook customizations were lost

Refs #403