### PR TITLE
fix(security): reject path traversal in GenericUiServlet

### DIFF
--- a/app/src/main/java/ch/sbb/polarion/extension/generic/GenericUiServlet.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/GenericUiServlet.java
@@ -80,7 +80,17 @@ public abstract class GenericUiServlet extends HttpServlet {
         if (ALLOWED_FILE_TYPES.stream().noneMatch(t -> fullUri.endsWith(t.left()))) {
             throw new IllegalArgumentException("Unsupported file type");
         }
-        return fullUri.substring(acceptablePath.length());
+        String relative = fullUri.substring(acceptablePath.length());
+        // Reject path-traversal segments. The prefix and file-type checks above only
+        // bound which file types may be served; without this check, a request like
+        // `/polarion/<app>/ui/../some.css` would still resolve through `..` inside
+        // `getServletContext().getResourceAsStream(...)` and could expose files
+        // outside the intended UI resource directory.
+        // See CodeQL alert java/path-injection.
+        if (relative.contains("..") || relative.contains("\\") || relative.contains("//")) {
+            throw new IllegalArgumentException("Path traversal not allowed");
+        }
+        return relative;
     }
 
     @VisibleForTesting

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/GenericUiServlet.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/GenericUiServlet.java
@@ -87,7 +87,8 @@ public abstract class GenericUiServlet extends HttpServlet {
         // `getServletContext().getResourceAsStream(...)` and could expose files
         // outside the intended UI resource directory.
         // See CodeQL alert java/path-injection.
-        if (relative.contains("..") || relative.contains("\\") || relative.contains("//")) {
+        if (relative.contains("..") || relative.contains("\\") || relative.contains("//")
+                || relative.startsWith("/") || relative.startsWith("\\")) {
             throw new IllegalArgumentException("Path traversal not allowed");
         }
         return relative;

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/GenericUiServletTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/GenericUiServletTest.java
@@ -100,7 +100,13 @@ class GenericUiServletTest {
                 () -> callServlet("/polarion/testServletName/ui/sub\\evil.css"));
         assertEquals("Path traversal not allowed", exception.getMessage());
 
-        // double slash
+        // double slash inside the path
+        exception = assertThrows(IllegalArgumentException.class,
+                () -> callServlet("/polarion/testServletName/ui/foo//bar.css"));
+        assertEquals("Path traversal not allowed", exception.getMessage());
+
+        // leading slash after the prefix (URI like `/polarion/<app>/ui//bypass.css`
+        // strips to `/bypass.css` — caught by `startsWith("/")`)
         exception = assertThrows(IllegalArgumentException.class,
                 () -> callServlet("/polarion/testServletName/ui//bypass.css"));
         assertEquals("Path traversal not allowed", exception.getMessage());

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/GenericUiServletTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/GenericUiServletTest.java
@@ -85,6 +85,32 @@ class GenericUiServletTest {
         verify(servlet, times(1)).serveResource(any(), any());
     }
 
+    @Test
+    @SneakyThrows
+    void testServiceRejectsPathTraversal() {
+        // `..` segment — would otherwise pass the prefix and suffix checks and
+        // reach getServletContext().getResourceAsStream(...) (CodeQL alert
+        // java/path-injection #5).
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> callServlet("/polarion/testServletName/ui/../some.css"));
+        assertEquals("Path traversal not allowed", exception.getMessage());
+
+        // backslash
+        exception = assertThrows(IllegalArgumentException.class,
+                () -> callServlet("/polarion/testServletName/ui/sub\\evil.css"));
+        assertEquals("Path traversal not allowed", exception.getMessage());
+
+        // double slash
+        exception = assertThrows(IllegalArgumentException.class,
+                () -> callServlet("/polarion/testServletName/ui//bypass.css"));
+        assertEquals("Path traversal not allowed", exception.getMessage());
+
+        // generic-prefixed traversal
+        exception = assertThrows(IllegalArgumentException.class,
+                () -> callServlet("/polarion/testServletName/ui/generic/../escape.html"));
+        assertEquals("Path traversal not allowed", exception.getMessage());
+    }
+
     @SneakyThrows
     private TestServlet callServlet(String uri) {
         TestServlet spy = spy(new TestServlet("testServletName"));


### PR DESCRIPTION
## Summary

Closes CodeQL alert [#5 (java/path-injection)](https://github.com/SchweizerischeBundesbahnen/ch.sbb.polarion.extension.generic/security/code-scanning/5).

## Background

PR #30 (June 2024) introduced `getInternalResourcePath` with a prefix check + file-type whitelist. Those bound *which file types* can be served, but not *where* on disk the resource is loaded from.

A request like

```
/polarion/<app>/ui/../some.css
```

passes both checks (`startsWith` `/polarion/<app>/ui/`, `endsWith` `.css`) and reaches `getServletContext().getResourceAsStream("/../some.css")` with the `..` segment intact. Whether the segment is honoured depends on the servlet container — the Servlet spec leaves it implementation-defined, so this is a real (if low-likelihood) defence-in-depth gap.

## Why now?

CodeQL's `java/path-injection` query is in the `security-extended` suite. We just adopted that suite (PR #405 added `codeql.yml` calling `reusable-codeql-java.yml`, default `query-suite: security-extended`). GitHub's previous "default setup" didn't run this query — **same code, new lens**.

## Fix

After the existing prefix and file-type checks, reject `..`, `\\`, and `//` segments:

```java
if (relative.contains("..") || relative.contains("\\") || relative.contains("//")) {
    throw new IllegalArgumentException("Path traversal not allowed");
}
```

Throws `IllegalArgumentException` — matches the surrounding failure style.

## Tests

Four new cases in `GenericUiServletTest#testServiceRejectsPathTraversal`, covering:

- Parent-traversal (`..` segment)
- Backslash injection (`\\`)
- Double slash (`//`)
- Traversal underneath the `/generic/` subpath

## Test plan

- [x] `pre-commit run` passes
- [ ] CI green on this PR (Maven test + CodeQL scan)
- [ ] After merge: alert #5 closes automatically on the next CodeQL scan