### PR TITLE
fix: resolve jar file paths with unencoded characters in GenericUiServlet

### DIFF
--- a/app/src/main/java/ch/sbb/polarion/extension/generic/GenericUiServlet.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/GenericUiServlet.java
@@ -98,8 +98,7 @@ public abstract class GenericUiServlet extends HttpServlet {
 
     @VisibleForTesting
     void serveGenericResource(@NotNull HttpServletResponse response, @NotNull String uri) throws IOException {
-        final URL location = GenericUiServlet.class.getProtectionDomain().getCodeSource().getLocation();
-        File resolvedJarFile = resolveJarFile(location);
+        File resolvedJarFile = resolveJarFile(getCodeLocation());
         try (ZipFile zipFile = new ZipFile(resolvedJarFile)) {
             final ZipEntry zipEntry = zipFile.getEntry(uri);
             try (InputStream inputStream = zipFile.getInputStream(zipEntry)) {
@@ -113,6 +112,11 @@ public abstract class GenericUiServlet extends HttpServlet {
                 }
             }
         }
+    }
+
+    @VisibleForTesting
+    @NotNull URL getCodeLocation() {
+        return GenericUiServlet.class.getProtectionDomain().getCodeSource().getLocation();
     }
 
     @VisibleForTesting

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/GenericUiServlet.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/GenericUiServlet.java
@@ -15,8 +15,10 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serial;
-import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.zip.ZipEntry;
@@ -95,10 +97,10 @@ public abstract class GenericUiServlet extends HttpServlet {
     }
 
     @VisibleForTesting
-    void serveGenericResource(@NotNull HttpServletResponse response, @NotNull String uri) throws IOException, URISyntaxException {
-        final URI currentJar = GenericUiServlet.class.getProtectionDomain().getCodeSource().getLocation().toURI();
-        final String path = new File(currentJar).getPath();
-        try (ZipFile zipFile = new ZipFile(path)) {
+    void serveGenericResource(@NotNull HttpServletResponse response, @NotNull String uri) throws IOException {
+        final URL location = GenericUiServlet.class.getProtectionDomain().getCodeSource().getLocation();
+        File resolvedJarFile = resolveJarFile(location);
+        try (ZipFile zipFile = new ZipFile(resolvedJarFile)) {
             final ZipEntry zipEntry = zipFile.getEntry(uri);
             try (InputStream inputStream = zipFile.getInputStream(zipEntry)) {
                 if (inputStream == null) {
@@ -110,6 +112,18 @@ public abstract class GenericUiServlet extends HttpServlet {
                     }
                 }
             }
+        }
+    }
+
+    @VisibleForTesting
+    static @NotNull File resolveJarFile(@NotNull URL location) {
+        try {
+            return new File(location.toURI());
+        } catch (URISyntaxException e) {
+            // CodeSource.getLocation() may return a URL with unencoded characters
+            // (e.g. literal spaces from a Windows username). URI.toURI() rejects
+            // those, so fall back to decoding the raw path.
+            return new File(URLDecoder.decode(location.getPath(), StandardCharsets.UTF_8));
         }
     }
 

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/GenericUiServletTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/GenericUiServletTest.java
@@ -13,6 +13,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.Serial;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -132,7 +133,7 @@ class GenericUiServletTest {
     @Test
     @SneakyThrows
     void testResolveJarFileWithRegularPath() {
-        URL location = new URL("file:/tmp/some-extension.jar");
+        URL location = URI.create("file:/tmp/some-extension.jar").toURL();
         File resolved = GenericUiServlet.resolveJarFile(location);
         assertEquals(new File("/tmp/some-extension.jar"), resolved);
     }
@@ -140,13 +141,16 @@ class GenericUiServletTest {
     @Test
     @SneakyThrows
     void testResolveJarFileWithPercentEncodedSpace() {
-        URL location = new URL("file:/tmp/dir%20with%20space/some-extension.jar");
+        URL location = URI.create("file:/tmp/dir%20with%20space/some-extension.jar").toURL();
         File resolved = GenericUiServlet.resolveJarFile(location);
         assertEquals(new File("/tmp/dir with space/some-extension.jar"), resolved);
     }
 
     @Test
     @SneakyThrows
+    @SuppressWarnings("deprecation") // URI.create rejects unencoded characters; the test
+    // intentionally constructs a URL like the one CodeSource.getLocation() returns on
+    // Windows when the username contains spaces — that is the bug being reproduced.
     void testResolveJarFileWithLiteralSpace() {
         URL location = new URL("file:/C:/Users/test folder with spaces/workspace/some-extension.jar");
         File resolved = GenericUiServlet.resolveJarFile(location);

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/GenericUiServletTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/GenericUiServletTest.java
@@ -3,16 +3,26 @@ package ch.sbb.polarion.extension.generic;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.Serial;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -143,6 +153,33 @@ class GenericUiServletTest {
         assertEquals("/C:/Users/test folder with spaces/workspace/some-extension.jar", resolved.getPath().replace('\\', '/'));
     }
 
+    @Test
+    @SneakyThrows
+    void testServeGenericResourceServesEntryFromJar(@TempDir Path tempDir) {
+        // Test the full serveGenericResource flow against a real ZIP — covers the
+        // resolveJarFile(getCodeLocation()) wiring inside the try-with-resources.
+        // Includes a literal space in the path to mirror the original failure mode.
+        Path dirWithSpace = Files.createDirectory(tempDir.resolve("dir with space"));
+        Path jarPath = dirWithSpace.resolve("fake-extension.jar");
+        byte[] payload = "console.log('hi');".getBytes();
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(jarPath))) {
+            zos.putNextEntry(new ZipEntry("genericUri/file.js"));
+            zos.write(payload);
+            zos.closeEntry();
+        }
+
+        TestServlet servlet = new TestServlet("testServletName", jarPath.toUri().toURL());
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        when(response.getOutputStream()).thenReturn(new CapturingServletOutputStream(captured));
+
+        servlet.serveGenericResource(response, "genericUri/file.js");
+
+        verify(response).setContentType("text/javascript");
+        assertArrayEquals(payload, captured.toByteArray());
+        verify(response, never()).sendError(anyInt());
+    }
+
     @SneakyThrows
     private TestServlet callServlet(String uri) {
         TestServlet spy = spy(new TestServlet("testServletName"));
@@ -160,8 +197,43 @@ class GenericUiServletTest {
         @Serial
         private static final long serialVersionUID = 7300367869059799910L;
 
+        private final URL codeLocationOverride;
+
         protected TestServlet(String webAppName) {
+            this(webAppName, null);
+        }
+
+        protected TestServlet(String webAppName, URL codeLocationOverride) {
             super(webAppName);
+            this.codeLocationOverride = codeLocationOverride;
+        }
+
+        @Override
+        URL getCodeLocation() {
+            return codeLocationOverride != null ? codeLocationOverride : super.getCodeLocation();
+        }
+    }
+
+    private static final class CapturingServletOutputStream extends ServletOutputStream {
+        private final ByteArrayOutputStream sink;
+
+        CapturingServletOutputStream(ByteArrayOutputStream sink) {
+            this.sink = sink;
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setWriteListener(WriteListener writeListener) {
+            // not needed for blocking writes in tests
+        }
+
+        @Override
+        public void write(int b) {
+            sink.write(b);
         }
     }
 }

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/GenericUiServletTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/GenericUiServletTest.java
@@ -7,7 +7,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.File;
 import java.io.Serial;
+import java.net.URL;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -115,6 +117,30 @@ class GenericUiServletTest {
         exception = assertThrows(IllegalArgumentException.class,
                 () -> callServlet("/polarion/testServletName/ui/generic/../escape.html"));
         assertEquals("Path traversal not allowed", exception.getMessage());
+    }
+
+    @Test
+    @SneakyThrows
+    void testResolveJarFileWithRegularPath() {
+        URL location = new URL("file:/tmp/some-extension.jar");
+        File resolved = GenericUiServlet.resolveJarFile(location);
+        assertEquals(new File("/tmp/some-extension.jar"), resolved);
+    }
+
+    @Test
+    @SneakyThrows
+    void testResolveJarFileWithPercentEncodedSpace() {
+        URL location = new URL("file:/tmp/dir%20with%20space/some-extension.jar");
+        File resolved = GenericUiServlet.resolveJarFile(location);
+        assertEquals(new File("/tmp/dir with space/some-extension.jar"), resolved);
+    }
+
+    @Test
+    @SneakyThrows
+    void testResolveJarFileWithLiteralSpace() {
+        URL location = new URL("file:/C:/Users/test folder with spaces/workspace/some-extension.jar");
+        File resolved = GenericUiServlet.resolveJarFile(location);
+        assertEquals("/C:/Users/test folder with spaces/workspace/some-extension.jar", resolved.getPath().replace('\\', '/'));
     }
 
     @SneakyThrows


### PR DESCRIPTION
### Proposed changes

This pull request improves the robustness of resource loading in `GenericUiServlet` by introducing a new method to correctly resolve JAR file paths from URLs, even when the paths contain spaces or percent-encoded characters. It also adds comprehensive tests to ensure correct behavior for various path formats.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
