### PR TITLE
fix(ci): deploy test-jar to Maven Central

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -132,7 +132,7 @@ jobs:
         # Additionally, timeouts are set to 1 hour to avoid issues with the connection to Sonatype Central during deployment
         run: |
           mvn --batch-mode -s "${SETTINGS_XML}" clean deploy \
-            -Dmaven.test.skip=true \
+            -DskipTests=true \
             -P gpg-sign \
             -P central-publishing \
             -Dcentral.timeout=3600 \


### PR DESCRIPTION
Closes #422

## Summary

- Switch `deploy-maven-central` from `-Dmaven.test.skip=true` (skips test-class compilation, so `jar:test-jar` has nothing to package) to `-DskipTests=true` (skips only test *execution*; compilation and packaging still happen).
- Restores `*-tests.jar` deployment to Maven Central, which has been missing since 14.1.3.
- Unblocks downstream extensions that depend on `ch.sbb.polarion.extension.generic.app:tests` (currently breaking Renovate auto-merge in `docx-exporter` and likely others).

The regression entered via #406 (`chore: sync from template`). The template is single-module and produces no test-jar, so the flag is harmless there. Generic is multi-module and explicitly publishes a test-jar (`app/pom.xml:48`).

See #422 for full root-cause analysis and evidence.

## Test plan

- [ ] CI green on this PR (no behavior change in `build` job; deploy job not exercised on PRs).
- [ ] After merge, release-please will cut v14.1.4.
- [ ] Confirm 200 OK on:
  ```
  curl -I https://repo.maven.apache.org/maven2/ch/sbb/polarion/extensions/ch.sbb.polarion.extension.generic.app/14.1.4/ch.sbb.polarion.extension.generic.app-14.1.4-tests.jar
  ```
- [ ] Confirm Renovate branch in `docx-exporter` (`renovate/ch.sbb.polarion.extensions-ch.sbb.polarion.extension.generic-14.x`) goes green and auto-merges.

## Follow-up

To prevent future template-syncs from re-introducing this flag, either mark `maven-build.yml` as locally owned for `generic` (in the template-sync skill's ignore list) or soften the flag in the template to `-DskipTests=true` (semantically equivalent for single-module template consumers, safe-by-default for multi-module sync targets). Tracked separately.