### PR TITLE
fix: fix logic checking if path traversal exists in resource request

### DIFF
--- a/app/src/main/java/ch/sbb/polarion/extension/generic/GenericUiServlet.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/GenericUiServlet.java
@@ -112,26 +112,26 @@ public abstract class GenericUiServlet extends HttpServlet {
      * Note that {@code ..} inside a filename — such as {@code chunk..hash.js} or
      * {@code page/asset..v2.css} — is NOT treated as traversal.
      * <p>
-     * Percent-encoded separators ({@code %2F}, {@code %5C}) are intentionally NOT
-     * decoded here: the servlet container has already decoded the request URI by
-     * the time this method runs, so any real separator is present as a literal
-     * {@code /} or {@code \} and caught above. If a downstream layer ever bypasses
-     * that decoding, {@link javax.servlet.ServletContext#getResourceAsStream(String)}
-     * and {@link java.util.zip.ZipFile#getEntry(String)} treat the percent-encoded
-     * forms as literal filename characters, not separators, so no traversal is
-     * possible either way. Do NOT re-broaden this to a naive
-     * {@code relative.contains("..")} — that would falsely reject legitimate
-     * filenames containing {@code ..} (Turbopack chunks).
+     * Percent-encoded separators ({@code %2F}/{@code %5C}, any case) are first
+     * normalized to their literal {@code /} / {@code \} forms, then the checks
+     * above run against the normalized value. So {@code foo%2fbar.css} is
+     * accepted (it's just a subdirectory reference) while {@code ..%2ffoo.css}
+     * becomes {@code ../foo.css} and is rejected. This protects against a
+     * misconfigured container or downstream decoder that might unescape an
+     * encoded separator after this check.
      */
     @VisibleForTesting
     static boolean containsPathTraversal(@NotNull String relative) {
-        if (relative.indexOf('\\') >= 0) {
+        String normalized = relative
+                .replace("%2f", "/").replace("%2F", "/")
+                .replace("%5c", "\\").replace("%5C", "\\");
+        if (normalized.indexOf('\\') >= 0) {
             return true;
         }
-        if (relative.startsWith("/") || relative.contains("//")) {
+        if (normalized.startsWith("/") || normalized.contains("//")) {
             return true;
         }
-        for (String segment : relative.split("/", -1)) {
+        for (String segment : normalized.split("/", -1)) {
             if ("..".equals(segment)) {
                 return true;
             }

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/GenericUiServlet.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/GenericUiServlet.java
@@ -96,7 +96,7 @@ public abstract class GenericUiServlet extends HttpServlet {
      * <p>
      * Without this guard, a request like {@code /polarion/<app>/ui/../some.css}
      * would resolve through {@code ..} inside
-     * {@link jakarta.servlet.ServletContext#getResourceAsStream(String)} and could
+     * {@link javax.servlet.ServletContext#getResourceAsStream(String)} and could
      * expose files outside the intended UI resource directory
      * (see CodeQL alert {@code java/path-injection}).
      * <p>
@@ -111,6 +111,17 @@ public abstract class GenericUiServlet extends HttpServlet {
      * </ul>
      * Note that {@code ..} inside a filename — such as {@code chunk..hash.js} or
      * {@code page/asset..v2.css} — is NOT treated as traversal.
+     * <p>
+     * Percent-encoded separators ({@code %2F}, {@code %5C}) are intentionally NOT
+     * decoded here: the servlet container has already decoded the request URI by
+     * the time this method runs, so any real separator is present as a literal
+     * {@code /} or {@code \} and caught above. If a downstream layer ever bypasses
+     * that decoding, {@link javax.servlet.ServletContext#getResourceAsStream(String)}
+     * and {@link java.util.zip.ZipFile#getEntry(String)} treat the percent-encoded
+     * forms as literal filename characters, not separators, so no traversal is
+     * possible either way. Do NOT re-broaden this to a naive
+     * {@code relative.contains("..")} — that would falsely reject legitimate
+     * filenames containing {@code ..} (Turbopack chunks).
      */
     @VisibleForTesting
     static boolean containsPathTraversal(@NotNull String relative) {

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/GenericUiServlet.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/GenericUiServlet.java
@@ -83,17 +83,49 @@ public abstract class GenericUiServlet extends HttpServlet {
             throw new IllegalArgumentException("Unsupported file type");
         }
         String relative = fullUri.substring(acceptablePath.length());
-        // Reject path-traversal segments. The prefix and file-type checks above only
-        // bound which file types may be served; without this check, a request like
-        // `/polarion/<app>/ui/../some.css` would still resolve through `..` inside
-        // `getServletContext().getResourceAsStream(...)` and could expose files
-        // outside the intended UI resource directory.
-        // See CodeQL alert java/path-injection.
-        if (relative.contains("..") || relative.contains("\\") || relative.contains("//")
-                || relative.startsWith("/") || relative.startsWith("\\")) {
+        if (containsPathTraversal(relative)) {
             throw new IllegalArgumentException("Path traversal not allowed");
         }
         return relative;
+    }
+
+    /**
+     * Rejects path-traversal attempts in a relative resource path while still
+     * permitting filenames that merely contain {@code ..} (e.g. Turbopack chunk
+     * names like {@code chunk..hash.js}).
+     * <p>
+     * Without this guard, a request like {@code /polarion/<app>/ui/../some.css}
+     * would resolve through {@code ..} inside
+     * {@link jakarta.servlet.ServletContext#getResourceAsStream(String)} and could
+     * expose files outside the intended UI resource directory
+     * (see CodeQL alert {@code java/path-injection}).
+     * <p>
+     * Returns {@code true} if any of the following holds:
+     * <ul>
+     *   <li>the path contains a backslash (not a valid URL separator and a common
+     *       Windows-style traversal bypass);</li>
+     *   <li>the path starts with {@code /} or contains an empty segment
+     *       ({@code //}) — both can collapse the path or escape the configured root;</li>
+     *   <li>any path segment (substring between {@code /} separators, or at the
+     *       boundaries) is exactly {@code ".."}.</li>
+     * </ul>
+     * Note that {@code ..} inside a filename — such as {@code chunk..hash.js} or
+     * {@code page/asset..v2.css} — is NOT treated as traversal.
+     */
+    @VisibleForTesting
+    static boolean containsPathTraversal(@NotNull String relative) {
+        if (relative.indexOf('\\') >= 0) {
+            return true;
+        }
+        if (relative.startsWith("/") || relative.contains("//")) {
+            return true;
+        }
+        for (String segment : relative.split("/", -1)) {
+            if ("..".equals(segment)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @VisibleForTesting

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/GenericUiServletTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/GenericUiServletTest.java
@@ -175,7 +175,18 @@ class GenericUiServletTest {
             // generic-prefixed traversal
             "generic/../escape.html",
             // mixed
-            "../sub/..//foo.css"
+            "../sub/..//foo.css",
+            // Percent-encoded separators (%2F = '/', %5C = '\') in any case.
+            // No legitimate filename contains these — '/' and '\' aren't valid
+            // filename characters — so rejecting them is free defense in depth
+            // against misconfigured downstream decoders.
+            "..%2ffoo.css",
+            "..%2Ffoo.css",
+            "foo%2f..%2fbar.css",
+            "%2f..%2fevil.css",
+            "..%5cfoo.css",
+            "..%5Cfoo.css",
+            "foo%5cbar.css"
     })
     void containsPathTraversal_rejectsTraversal(String path) {
         assertTrue(GenericUiServlet.containsPathTraversal(path),
@@ -216,15 +227,14 @@ class GenericUiServletTest {
             // hashed/versioned filenames
             "main.abc123def..v2.js",
             "[locale]..page.js",
-            // Percent-encoded separators are NOT decoded at this layer — the
-            // servlet container decodes them before we run. If a downstream
-            // layer ever skips decoding, getResourceAsStream / ZipFile.getEntry
-            // treat these as literal filename characters, not separators, so
-            // no traversal is possible. Pinned here to prevent re-broadening
-            // the check to a naive contains("..").
-            "..%2ffoo.css",
-            "foo%2f..%2fbar.css",
-            "..%5cfoo.css"
+            // Percent-encoded separators are normalized to literal '/' before
+            // the segment check runs. So an encoded sequence is treated exactly
+            // as if a downstream decoder had unescaped it — which means a
+            // standalone encoded slash that is NOT next to ".." is fine, since
+            // its literal form (foo/bar.css) is just a subdirectory.
+            "foo%2fbar.css",
+            "foo%2Fbar.css",
+            "sub%2fchunk..hash.js"
     })
     void containsPathTraversal_allowsSafePaths(String path) {
         assertFalse(GenericUiServlet.containsPathTraversal(path),

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/GenericUiServletTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/GenericUiServletTest.java
@@ -4,6 +4,8 @@ import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.servlet.ServletOutputStream;
@@ -22,7 +24,9 @@ import java.util.zip.ZipOutputStream;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.*;
 
@@ -128,6 +132,94 @@ class GenericUiServletTest {
         exception = assertThrows(IllegalArgumentException.class,
                 () -> callServlet("/polarion/testServletName/ui/generic/../escape.html"));
         assertEquals("Path traversal not allowed", exception.getMessage());
+    }
+
+    @Test
+    @SneakyThrows
+    void testServiceAllowsTurbopackChunkNamesWithDoubleDot() {
+        // Turbopack/Next.js can emit chunk filenames that contain `..` inside the
+        // filename itself (e.g. `chunk..hash.js`). These are NOT path traversal
+        // and must be served normally.
+        TestServlet servlet = callServlet("/polarion/testServletName/ui/_next/static/chunks/page..a1b2c3.js");
+        verify(servlet, times(1)).serveResource(any(), eq("/_next/static/chunks/page..a1b2c3.js"));
+        verify(servlet, times(0)).serveGenericResource(any(), any());
+
+        servlet = callServlet("/polarion/testServletName/ui/asset..v2.css");
+        verify(servlet, times(1)).serveResource(any(), eq("/asset..v2.css"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            // bare ".." segment
+            "..",
+            "../foo.css",
+            "../../foo.css",
+            "foo/..",
+            "foo/../bar.css",
+            "foo/bar/../baz.css",
+            "foo/../../bar.css",
+            "a/b/c/../../d.css",
+            // leading slash (post-prefix empty segment)
+            "/foo.css",
+            "/sub/foo.css",
+            // empty segment in the middle
+            "foo//bar.css",
+            "a/b//c.css",
+            // backslash anywhere — Windows-style separator, used to bypass unix checks
+            "a\\b.css",
+            "..\\foo.css",
+            "foo\\..\\bar.css",
+            "foo/sub\\evil.css",
+            "\\evil.css",
+            "foo.css\\",
+            // generic-prefixed traversal
+            "generic/../escape.html",
+            // mixed
+            "../sub/..//foo.css"
+    })
+    void containsPathTraversal_rejectsTraversal(String path) {
+        assertTrue(GenericUiServlet.containsPathTraversal(path),
+                "expected to detect traversal in: " + path);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            // ordinary safe paths
+            "foo.css",
+            "app.js",
+            "sub/foo.css",
+            "deep/nested/path/foo.css",
+            "_next/static/chunks/main.js",
+            // ".." as part of the FILENAME (Turbopack-style) — must be allowed
+            "chunk..hash.js",
+            "page..a1b2c3.js",
+            "asset..v2.css",
+            "foo..bar.css",
+            "a/foo..bar.css",
+            "_next/static/chunks/page..a1b2c3.js",
+            "_next/static/chunks/[id]..[hash].js",
+            // ".." inside the middle of a segment, not as a full segment
+            "foo..bar/baz.css",
+            "foo/bar..baz.css",
+            "a/b..c/d.css",
+            "a/b../c.css",
+            "a/..b/c.css",
+            // names that start or end with ".." but are not the literal ".." segment
+            "..foo.css",
+            "foo...css",
+            "...css",
+            "....js",
+            // single-dot segments are allowed (not path traversal)
+            "./foo.css",
+            "a/./b.css",
+            ".foo.css",
+            // hashed/versioned filenames
+            "main.abc123def..v2.js",
+            "[locale]..page.js"
+    })
+    void containsPathTraversal_allowsSafePaths(String path) {
+        assertFalse(GenericUiServlet.containsPathTraversal(path),
+                "expected NOT to detect traversal in: " + path);
     }
 
     @Test

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/GenericUiServletTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/GenericUiServletTest.java
@@ -215,7 +215,16 @@ class GenericUiServletTest {
             ".foo.css",
             // hashed/versioned filenames
             "main.abc123def..v2.js",
-            "[locale]..page.js"
+            "[locale]..page.js",
+            // Percent-encoded separators are NOT decoded at this layer — the
+            // servlet container decodes them before we run. If a downstream
+            // layer ever skips decoding, getResourceAsStream / ZipFile.getEntry
+            // treat these as literal filename characters, not separators, so
+            // no traversal is possible. Pinned here to prevent re-broadening
+            // the check to a naive contains("..").
+            "..%2ffoo.css",
+            "foo%2f..%2fbar.css",
+            "..%5cfoo.css"
     })
     void containsPathTraversal_allowsSafePaths(String path) {
         assertFalse(GenericUiServlet.containsPathTraversal(path),


### PR DESCRIPTION
### Proposed changes

Current logic rejects paths to resources which contain "..", unfortunately turbopack which is default engine in NextJS can generate files with ".." in their names. So, we need to modify logic to be more wise, allowing filenames with ".." and rejecting real traversal attempt.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
