### PR TITLE
chore: make resolveJarFile literal-space test OS-independent

### DIFF
--- a/app/src/test/java/ch/sbb/polarion/extension/generic/GenericUiServletTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/GenericUiServletTest.java
@@ -265,7 +265,10 @@ class GenericUiServletTest {
     void testResolveJarFileWithLiteralSpace() {
         URL location = new URL("file:/C:/Users/test folder with spaces/workspace/some-extension.jar");
         File resolved = GenericUiServlet.resolveJarFile(location);
-        assertEquals("/C:/Users/test folder with spaces/workspace/some-extension.jar", resolved.getPath().replace('\\', '/'));
+        // Compare File objects rather than the raw path string: File.getPath() canonicalizes
+        // "/C:/..." differently per OS (Windows strips the leading slash before the drive letter,
+        // Unix keeps it). Both sides go through the same normalization, so this holds on either.
+        assertEquals(new File("/C:/Users/test folder with spaces/workspace/some-extension.jar"), resolved);
     }
 
     @Test


### PR DESCRIPTION
### Proposed changes

We must fix unit test to run properly on both Win and Unix OS.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
