### PR TITLE
fix: SAXParseException: An invalid XML character (Unicode: 0x0) was f…

### DIFF
--- a/app/src/main/java/ch/sbb/polarion/extension/generic/jaxb/JAXBUtils.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/jaxb/JAXBUtils.java
@@ -21,6 +21,8 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.namespace.QName;
 import javax.xml.transform.stream.StreamSource;
 
+import com.polarion.core.util.xml.DOMHelper;
+
 import ch.sbb.polarion.extension.generic.exception.JAXBUnmarshalException;
 import lombok.experimental.UtilityClass;
 
@@ -102,7 +104,12 @@ public class JAXBUtils {
             }
 
             stringWriter.flush();
-            return stringWriter.toString();
+            // JAXB does not validate characters on marshaling, so the output may still contain
+            // characters which are illegal in XML 1.0 (control chars, unpaired surrogates, noncharacters).
+            // They would corrupt the persisted XML and break all subsequent reads, so strip them here.
+            // Reuse Polarion's own sanitizer to stay consistent with how the platform itself
+            // cleans content before persisting it (see DOMHelper#appendSafeTextNode).
+            return DOMHelper.stripXMLInvalidCharacters(stringWriter.toString());
         }
     }
 }

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/jaxb/JAXBUtilsTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/jaxb/JAXBUtilsTest.java
@@ -1,13 +1,18 @@
 package ch.sbb.polarion.extension.generic.jaxb;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import javax.xml.bind.JAXBException;
+import javax.xml.bind.UnmarshalException;
 import java.io.IOException;
 import java.io.Reader;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 class JAXBUtilsTest {
@@ -35,5 +40,62 @@ class JAXBUtilsTest {
         String serialized = JAXBUtils.serialize(testObject);
 
         assertEquals(TEST_OBJECT.replace(System.lineSeparator(), "\n"), serialized);
+    }
+
+    /**
+     * Samples cover each illegal range: control chars 0x0-0x8 / 0xB-0xC / 0xE-0x1F,
+     * the surrogate block 0xD800-0xDFFF and the noncharacters 0xFFFE-0xFFFF.
+     */
+    @ParameterizedTest
+    @ValueSource(ints = {0x0000, 0x0008, 0x000B, 0x001F, 0xD800, 0xFFFE, 0xFFFF})
+    void serializeStripsCharsIllegalInXml(int illegalCodePoint) throws JAXBException, IOException {
+        String illegalChar = String.valueOf((char) illegalCodePoint);
+        TestObject testObject = new TestObject("prefix" + illegalChar + "suffix", 100);
+
+        String serialized = JAXBUtils.serialize(testObject);
+        TestObject deserialized = JAXBUtils.deserialize(TestObject.class, serialized);
+
+        assertEquals("prefixsuffix", deserialized.getTestKey());
+    }
+
+    /**
+     * Legal samples cover the singletons (TAB, LF, SPACE), both BMP bands bordering the surrogate
+     * gap (0xD7FF / 0xE000 / 0xFFFD) and a supplementary code point (emoji at 0x1F600).
+     */
+    @ParameterizedTest
+    @ValueSource(ints = {0x0009, 0x000A, 0x0020, 0xD7FF, 0xE000, 0xFFFD, 0x1F600})
+    void serializeAcceptsCharsLegalInXml(int legalCodePoint) throws JAXBException, IOException {
+        String testKey = new String(Character.toChars(legalCodePoint));
+        TestObject testObject = new TestObject(testKey, 100);
+
+        String serialized = JAXBUtils.serialize(testObject);
+        TestObject deserialized = JAXBUtils.deserialize(TestObject.class, serialized);
+
+        assertEquals(testKey, deserialized.getTestKey());
+    }
+
+    @Test
+    void serializePreservesXmlMarkupChars() throws JAXBException, IOException {
+        TestObject testObject = new TestObject("a <b> & \"c\"", 100);
+
+        String serialized = JAXBUtils.serialize(testObject);
+        TestObject deserialized = JAXBUtils.deserialize(TestObject.class, serialized);
+
+        assertEquals("a <b> & \"c\"", deserialized.getTestKey());
+    }
+
+    /**
+     * Proves the reason for stripping illegal characters in {@link JAXBUtils#serialize}: XML which contains
+     * a character illegal in XML 1.0 cannot be unmarshalled back, so it must never be produced.
+     * Samples cover each illegal range: control chars 0x0-0x8 / 0xB-0xC / 0xE-0x1F,
+     * the surrogate block 0xD800-0xDFFF and the noncharacters 0xFFFE-0xFFFF.
+     */
+    @ParameterizedTest
+    @ValueSource(ints = {0x0000, 0x0004, 0x0008, 0x000B, 0x000C, 0x000E, 0x0013, 0x001F, 0xD800, 0xDC00, 0xDFFF, 0xFFFE, 0xFFFF})
+    void deserializeFailsOnCharsIllegalInXml(int illegalChar) {
+        String xml = TEST_OBJECT.replace(">key<", ">k" + (char) illegalChar + "y<");
+
+        UnmarshalException exception = assertThrows(UnmarshalException.class, () -> JAXBUtils.deserialize(TestObject.class, xml));
+        assertTrue(exception.getLinkedException().getMessage().contains("invalid XML character"));
     }
 }


### PR DESCRIPTION
…ound in the element content

Refs: #441

### Proposed changes

We must strip invalid characters in the `JAXBUtils.serialize`.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
