### PR TITLE
fix: update commons-logging version to 1.3.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
         <org.osgi.framework.version>1.10.0</org.osgi.framework.version>
         <swagger.version>2.2.50</swagger.version>
         <jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>
+        <commons-logging.version>1.3.6</commons-logging.version>
 
         <!-- Manifest entries -->
         <maven-jar-plugin.Manifest-Version>1.0</maven-jar-plugin.Manifest-Version>
@@ -277,10 +278,15 @@
                  a no-op for extensions that don't pull it. The runtime API is supplied by Polarion's OSGi
                  bundle org.apache.commons.logging_1.2.0, declared in `Require-Bundle.common` above — keep
                  these two in sync: removing org.apache.commons.logging from Require-Bundle would break
-                 logging resolution at runtime for every extension relying on this `provided` demotion. -->
+                 logging resolution at runtime for every extension relying on this `provided` demotion.
+                 The version here is required only to satisfy Sonatype Central's POM validation (every
+                 dependencyManagement entry must carry a version) and is build/test-classpath only — it
+                 need NOT match the runtime OSGi bundle 1.2.0, since the artifact is `provided` and never
+                 reaches WEB-INF/lib; renovate keeps it on the latest commons-logging release. -->
             <dependency>
                 <groupId>commons-logging</groupId>
                 <artifactId>commons-logging</artifactId>
+                <version>${commons-logging.version}</version>
                 <scope>provided</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
### Proposed changes

- Set commons-logging version to 1.3.6 in pom.xml
- Ensure compatibility with Sonatype Central's POM validation

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
