### PR TITLE
chore: make UncaughtExceptionMapper less verbose

### DIFF
--- a/app/src/main/java/ch/sbb/polarion/extension/generic/rest/exception/mapper/UncaughtExceptionMapper.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/rest/exception/mapper/UncaughtExceptionMapper.java
@@ -9,6 +9,7 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -33,12 +34,17 @@ public class UncaughtExceptionMapper implements ExceptionMapper<Throwable> {
 
     private static final Logger logger = Logger.getLogger(UncaughtExceptionMapper.class);
 
+    @Override
     public Response toResponse(Throwable throwable) {
         String errorId = UUID.randomUUID().toString();
-        logger.error("Error ID: " + errorId + " - Error message: " + throwable.getMessage(), throwable);
+        logger.error(formatLogMessage(errorId, throwable), throwable);
         return Response.status(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())
                 .entity(new ErrorEntity(GENERIC_MESSAGE + " (Error ID: " + errorId + ")"))
                 .type(MediaType.APPLICATION_JSON)
                 .build();
+    }
+
+    static String formatLogMessage(String errorId, Throwable throwable) {
+        return "Error ID: " + errorId + " - Error message: " + Objects.toString(throwable.getMessage(), "<no message>");
     }
 }

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/rest/exception/mapper/UncaughtExceptionMapper.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/rest/exception/mapper/UncaughtExceptionMapper.java
@@ -9,20 +9,35 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 
+import java.util.UUID;
+
 /**
  * Default mapper for all unmapped exceptions.
  * If you delete this mapper then {@link LogoutFilter}
  * will stop working.
+ *
+ * <p>Unmapped exceptions carry messages that are not under the application's control
+ * (class names, repository paths, parser details). To avoid leaking such internals into the
+ * response body, the full exception is logged server-side while the client receives a fixed,
+ * generic message.
+ *
+ * <p>To correlate a client-visible error with its server-side log entry, a random error id is
+ * generated per failure. The id is written to the log together with the exception and embedded
+ * into the generic response message, so a user can quote it to an administrator who then locates
+ * the matching log entry. This mirrors how Polarion itself reports server errors to the UI.
  */
 @Provider
 public class UncaughtExceptionMapper implements ExceptionMapper<Throwable> {
 
+    static final String GENERIC_MESSAGE = "Internal server error";
+
     private static final Logger logger = Logger.getLogger(UncaughtExceptionMapper.class);
 
     public Response toResponse(Throwable throwable) {
-        logger.error("Error in controller: " + throwable.getMessage(), throwable);
+        String errorId = UUID.randomUUID().toString();
+        logger.error("Error ID: " + errorId + " - Error message: " + throwable.getMessage(), throwable);
         return Response.status(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())
-                .entity(new ErrorEntity(throwable.getMessage()))
+                .entity(new ErrorEntity(GENERIC_MESSAGE + " (Error ID: " + errorId + ")"))
                 .type(MediaType.APPLICATION_JSON)
                 .build();
     }

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/rest/exception/mapper/UncaughtExceptionMapperTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/rest/exception/mapper/UncaughtExceptionMapperTest.java
@@ -5,19 +5,50 @@ import org.junit.jupiter.api.Test;
 
 import jakarta.ws.rs.core.Response;
 
+import java.util.regex.Pattern;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class UncaughtExceptionMapperTest {
 
+    private static final Pattern ERROR_ID_PATTERN = Pattern.compile(
+            "^" + Pattern.quote(UncaughtExceptionMapper.GENERIC_MESSAGE)
+                    + " \\(Error ID: [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\)$");
+
     @Test
     void testResponse() {
-        try (Response response = new UncaughtExceptionMapper().toResponse(new IllegalAccessException("test message"))) {
+        String leakyMessage = "com.polarion.internal.Foo failed at /repo/.polarion/records.xml";
+        try (Response response = new UncaughtExceptionMapper().toResponse(new IllegalAccessException(leakyMessage))) {
             assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
             ErrorEntity entity = (ErrorEntity) response.getEntity();
             assertNotNull(entity);
-            assertEquals("test message", entity.getMessage());
+            assertTrue(ERROR_ID_PATTERN.matcher(entity.getMessage()).matches(),
+                    "message must be the generic message followed by a correlation error id, but was: " + entity.getMessage());
+            assertFalse(entity.getMessage().contains("com.polarion"), "must not leak class names");
+            assertFalse(entity.getMessage().contains("/repo/"), "must not leak repository paths");
         } catch (Exception e) {
             fail("Exception thrown: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void testResponseWithoutMessage() {
+        try (Response response = new UncaughtExceptionMapper().toResponse(new NullPointerException())) {
+            assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+            ErrorEntity entity = (ErrorEntity) response.getEntity();
+            assertNotNull(entity);
+            assertTrue(ERROR_ID_PATTERN.matcher(entity.getMessage()).matches(),
+                    "message must be the generic message followed by a correlation error id, but was: " + entity.getMessage());
+        }
+    }
+
+    @Test
+    void testEachResponseGetsUniqueErrorId() {
+        try (Response first = new UncaughtExceptionMapper().toResponse(new IllegalStateException("boom"));
+             Response second = new UncaughtExceptionMapper().toResponse(new IllegalStateException("boom"))) {
+            String firstMessage = ((ErrorEntity) first.getEntity()).getMessage();
+            String secondMessage = ((ErrorEntity) second.getEntity()).getMessage();
+            assertNotEquals(firstMessage, secondMessage, "each error must carry its own correlation id");
         }
     }
 

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/rest/exception/mapper/UncaughtExceptionMapperTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/rest/exception/mapper/UncaughtExceptionMapperTest.java
@@ -43,6 +43,18 @@ class UncaughtExceptionMapperTest {
     }
 
     @Test
+    void testFormatLogMessageUsesExceptionMessage() {
+        String logMessage = UncaughtExceptionMapper.formatLogMessage("the-error-id", new IllegalStateException("boom"));
+        assertEquals("Error ID: the-error-id - Error message: boom", logMessage);
+    }
+
+    @Test
+    void testFormatLogMessageFallsBackWhenMessageIsNull() {
+        String logMessage = UncaughtExceptionMapper.formatLogMessage("the-error-id", new NullPointerException());
+        assertEquals("Error ID: the-error-id - Error message: <no message>", logMessage);
+    }
+
+    @Test
     void testEachResponseGetsUniqueErrorId() {
         try (Response first = new UncaughtExceptionMapper().toResponse(new IllegalStateException("boom"));
              Response second = new UncaughtExceptionMapper().toResponse(new IllegalStateException("boom"))) {


### PR DESCRIPTION
### Proposed changes

It would be nice to make UncaughtExceptionMapper less verbose.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
