### PR TITLE
feat: add universal self-healing DLE-toolbar button injector

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,3 +423,59 @@ public class PdfExporterExtensionConfiguration extends ExtensionConfiguration {
     ...
 }
 ```
+
+### Document (DLE) editor toolbar button
+
+To add a button to Polarion's document editor toolbar (via the `scriptInjection.dleEditorHead`
+configuration property), reuse the shared engine `dle-toolbar-starter.js` shipped by generic instead
+of writing the injection logic in every extension. The engine knows the toolbar DOM selectors and
+**re-injects the button automatically** whenever Polarion (GWT) re-renders the toolbar — e.g. after the
+user clicks *Save* — so the button does not disappear (a one-time injection otherwise would).
+
+The engine is served to each extension at `/polarion/<extension>/ui/generic/js/dle-toolbar-starter.js`
+and exposes `window.GenericDleToolbarStarter.create({ markerId, alternateHtml, defaultHtml })`.
+
+Add a thin `starter.js` to your extension's webapp that supplies only the extension-specific parts
+(button markup, a unique `markerId`, any css/js the button needs) and bootstraps the engine:
+
+```js
+(function () {
+    const ts = `?timestamp=${Date.now()}`;
+    const TOOLBAR_HTML = `<table class="dleToolBarTable">...your button...</table>`;           // standalone variant
+    const ALTERNATE_TOOLBAR_HTML = `<table class="dleToolBarTable">...your button...</table>`;  // variant for inside the toolbar row
+
+    // Expose the global immediately and queue calls until the engine has loaded.
+    let starter = null;
+    const pending = [];
+    window.MyExtensionStarter = {
+        injectToolbar: (params) => starter ? starter.injectToolbar(params) : pending.push(params)
+    };
+
+    const engine = document.createElement('script');
+    engine.src = `/polarion/my-extension/ui/generic/js/dle-toolbar-starter.js${ts}`;
+    engine.onload = () => {
+        const generic = window.GenericDleToolbarStarter;
+        generic.injectStyles("my-extension-styles", `/polarion/my-extension/css/my-extension.css${ts}`);
+        // ...inject any other css/js the button needs...
+        starter = generic.create({
+            markerId: 'my-extension-toolbar-injected',   // unique id set on the injected element
+            alternateHtml: ALTERNATE_TOOLBAR_HTML,
+            defaultHtml: TOOLBAR_HTML
+        });
+        pending.forEach(p => starter.injectToolbar(p));
+        pending.length = 0;
+    };
+    document.head.appendChild(engine);
+})();
+```
+
+Then point the document editor at it via the Polarion configuration property (the bootstrap loads the
+engine and queues the call, so this config is the same as without the shared engine):
+
+```properties
+scriptInjection.dleEditorHead=<script src="/polarion/my-extension/js/starter.js"></script><script>MyExtensionStarter.injectToolbar({alternate: true});</script>
+```
+
+`injectToolbar({ alternate: true })` inserts the button into the editor toolbar row; calling it without
+`alternate` renders the standalone `defaultHtml` variant above the rich-text area. The engine is
+idempotent (guarded by `markerId`) and sets up one self-healing observer per extension.

--- a/app/src/main/resources/js/dle-toolbar-starter.js
+++ b/app/src/main/resources/js/dle-toolbar-starter.js
@@ -1,0 +1,115 @@
+/*
+ * Universal self-healing DLE-toolbar button injector — single source for all extensions
+ * that inject a button into Polarion's document (DLE) editor toolbar via
+ * `scriptInjection.dleEditorHead`.
+ *
+ * Polarion (GWT) re-renders the toolbar sub-tree on actions like Save, which wipes out a
+ * one-time injected element. This engine injects idempotently and re-injects via a
+ * MutationObserver whenever the toolbar is re-rendered and the button disappears.
+ *
+ * The DLE toolbar selectors below are Polarion's own DOM and identical for every extension.
+ * Extension-specific parts (button HTML, marker id) come in via create(config).
+ *
+ * Usage (thin extension starter.js loads this, then):
+ *   const starter = window.GenericDleToolbarStarter.create({ markerId, alternateHtml, defaultHtml });
+ *   starter.injectToolbar({ alternate: true });
+ */
+(function () {
+    function injectStyles(id, href) {
+        if (!top.document.getElementById(id)) {
+            const link = top.document.createElement("link");
+            link.id = id;
+            link.rel = "stylesheet";
+            link.type = "text/css";
+            link.href = href;
+            top.document.head.appendChild(link);
+        }
+    }
+
+    function injectScript(id, src, type = "text/javascript") {
+        if (!top.document.getElementById(id)) {
+            const script = top.document.createElement("script");
+            script.id = id;
+            script.setAttribute("src", src);
+            script.setAttribute("type", type);
+            top.document.head.appendChild(script);
+        }
+    }
+
+    // Polarion DLE toolbar DOM — same for all extensions.
+    const ALTERNATE_TOOLBAR_SELECTOR = 'div.polarion-content-container div.polarion-Container div.polarion-dle-Container > div.polarion-dle-Wrapper > div.polarion-dle-RpcPanel > div.polarion-dle-MainDockPanel div.polarion-rte-ToolbarPanelWrapper table.polarion-dle-ToolbarPanel tr';
+    const RICH_TEXT_AREA_SELECTOR = 'div.polarion-content-container div.polarion-Container div.polarion-dle-Container>div.polarion-dle-Wrapper>div.polarion-dle-RpcPanel>div.polarion-dle-MainDockPanel div.polarion-dle-SplitPanel:last-child .polarion-dle-RichTextArea';
+    // Stable ancestor that survives the toolbar re-render — observed for re-injection.
+    const STABLE_ANCESTOR_SELECTOR = 'div.polarion-content-container div.polarion-Container div.polarion-dle-Container';
+
+    window.GenericDleToolbarStarter = {
+        injectStyles: injectStyles,
+        injectScript: injectScript,
+
+        /**
+         * @param config {{ markerId: string, alternateHtml: string, defaultHtml: string }}
+         * @returns {{ injectToolbar: function }}
+         */
+        create: function (config) {
+            // Idempotent: only inject if the toolbar exists and our button isn't already there.
+            function inject(params) {
+                if (top.document.getElementById(config.markerId)) {
+                    return; // already present
+                }
+                if (params && params.alternate) {
+                    const toolbarParent = top.document.querySelector(ALTERNATE_TOOLBAR_SELECTOR);
+                    if (!toolbarParent) {
+                        return; // toolbar not rendered (yet)
+                    }
+                    const toolbarContainer = top.document.createElement('td');
+                    toolbarContainer.id = config.markerId;
+                    toolbarContainer.innerHTML = config.alternateHtml;
+                    toolbarParent.insertBefore(toolbarContainer, toolbarParent.querySelector('td[width="100%"]'));
+                } else {
+                    const documentFrame = top.document.querySelector(RICH_TEXT_AREA_SELECTOR);
+                    if (!documentFrame) {
+                        return;
+                    }
+                    const toolbarContainer = top.document.createElement('div');
+                    toolbarContainer.id = config.markerId;
+                    toolbarContainer.classList.add("dleToolBarContainer");
+                    toolbarContainer.style.marginRight = "14px";
+                    toolbarContainer.innerHTML = config.defaultHtml;
+                    documentFrame.parentNode.parentNode.prepend(toolbarContainer);
+                }
+            }
+
+            let observerSetUp = false;
+
+            return {
+                injectToolbar: function (params) {
+                    inject(params);
+
+                    // Re-inject when Polarion re-renders the toolbar (e.g. after Save) and our button disappears.
+                    if (observerSetUp) {
+                        return;
+                    }
+                    const anchor = top.document.querySelector(STABLE_ANCESTOR_SELECTOR) || top.document.body;
+                    if (!anchor) {
+                        return;
+                    }
+                    observerSetUp = true;
+                    let scheduled = false;
+                    const observer = new MutationObserver(function () {
+                        // Cheap fast-path: button still present (or a re-inject already queued) → do nothing.
+                        if (top.document.getElementById(config.markerId) || scheduled) {
+                            return;
+                        }
+                        scheduled = true;
+                        // Coalesce the burst of mutations during a re-render into a single re-inject.
+                        requestAnimationFrame(function () {
+                            scheduled = false;
+                            inject(params);
+                        });
+                    });
+                    observer.observe(anchor, { childList: true, subtree: true });
+                }
+            };
+        }
+    };
+})();

--- a/app/src/main/resources/js/dle-toolbar-starter.js
+++ b/app/src/main/resources/js/dle-toolbar-starter.js
@@ -13,6 +13,7 @@
  * Usage (thin extension starter.js loads this, then):
  *   const starter = window.GenericDleToolbarStarter.create({ markerId, alternateHtml, defaultHtml });
  *   starter.injectToolbar({ alternate: true });
+ *   // optionally, when the caller tears down: starter.destroy();
  */
 (function () {
     function injectStyles(id, href) {
@@ -42,13 +43,26 @@
     // Stable ancestor that survives the toolbar re-render — observed for re-injection.
     const STABLE_ANCESTOR_SELECTOR = 'div.polarion-content-container div.polarion-Container div.polarion-dle-Container';
 
+    // Registry of live observers keyed by markerId, kept on the top window so it survives this
+    // script being re-loaded each time the DLE editor is (re-)opened in Polarion's GWT SPA.
+    // Re-using the key lets us disconnect the previous observer instead of accumulating them.
+    const observerRegistry = top.__genericDleToolbarObservers || (top.__genericDleToolbarObservers = {});
+
     window.GenericDleToolbarStarter = {
         injectStyles: injectStyles,
         injectScript: injectScript,
 
         /**
          * @param config {{ markerId: string, alternateHtml: string, defaultHtml: string }}
-         * @returns {{ injectToolbar: function }}
+         *   markerId      unique id set on the injected element; also the idempotency/dedup key.
+         *   alternateHtml markup injected into the toolbar row when injectToolbar({alternate: true}).
+         *   defaultHtml   markup injected above the rich-text area otherwise.
+         *
+         *   SECURITY: alternateHtml / defaultHtml are written via innerHTML into the top Polarion
+         *   frame, so they MUST be static, trusted markup. Never interpolate user-controlled data
+         *   (document fields, work-item attributes, ...) into them without sanitizing it first.
+         *
+         * @returns {{ injectToolbar: function, destroy: function }}
          */
         create: function (config) {
             // Idempotent: only inject if the toolbar exists and our button isn't already there.
@@ -64,7 +78,13 @@
                     const toolbarContainer = top.document.createElement('td');
                     toolbarContainer.id = config.markerId;
                     toolbarContainer.innerHTML = config.alternateHtml;
-                    toolbarParent.insertBefore(toolbarContainer, toolbarParent.querySelector('td[width="100%"]'));
+                    const reference = toolbarParent.querySelector('td[width="100%"]');
+                    if (!reference) {
+                        // Polarion DOM changed (e.g. after an upgrade) — fall back to appending at the
+                        // end of the row, but warn so the mislayout is diagnosable.
+                        console.warn(`GenericDleToolbarStarter: reference cell td[width="100%"] not found for '${config.markerId}'; appending button at the end of the toolbar row.`);
+                    }
+                    toolbarParent.insertBefore(toolbarContainer, reference);
                 } else {
                     const documentFrame = top.document.querySelector(RICH_TEXT_AREA_SELECTOR);
                     if (!documentFrame) {
@@ -80,12 +100,15 @@
             }
 
             let observerSetUp = false;
+            // The observer re-injects with the params of the latest injectToolbar() call.
+            let lastParams;
 
             return {
                 injectToolbar: function (params) {
+                    lastParams = params;
                     inject(params);
 
-                    // Re-inject when Polarion re-renders the toolbar (e.g. after Save) and our button disappears.
+                    // Set up the self-healing observer once per starter instance.
                     if (observerSetUp) {
                         return;
                     }
@@ -104,10 +127,25 @@
                         // Coalesce the burst of mutations during a re-render into a single re-inject.
                         requestAnimationFrame(function () {
                             scheduled = false;
-                            inject(params);
+                            inject(lastParams);
                         });
                     });
+                    // Disconnect any observer left over from a previous editor open for this markerId
+                    // so observers don't accumulate across the SPA's editor open/close cycles.
+                    if (observerRegistry[config.markerId]) {
+                        observerRegistry[config.markerId].disconnect();
+                    }
+                    observerRegistry[config.markerId] = observer;
                     observer.observe(anchor, { childList: true, subtree: true });
+                },
+
+                // Stop self-healing and release the observer (for callers that have a teardown hook).
+                destroy: function () {
+                    if (observerRegistry[config.markerId]) {
+                        observerRegistry[config.markerId].disconnect();
+                        delete observerRegistry[config.markerId];
+                    }
+                    observerSetUp = false;
                 }
             };
         }


### PR DESCRIPTION
### Proposed changes

Introduce a new engine for injecting a button into Polarion's DLE editor toolbar that re-injects the button idempotently using a MutationObserver to handle toolbar re-renders.

- Implement button injection logic with support for alternate and default HTML
- Ensure button persists through toolbar updates
- Provide a reusable API for extensions to configure the button

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
