### PR TITLE
fix: ensure stable button ordering in DLE-toolbar injector

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ of writing the injection logic in every extension. The engine knows the toolbar 
 user clicks *Save* — so the button does not disappear (a one-time injection otherwise would).
 
 The engine is served to each extension at `/polarion/<extension>/ui/generic/js/dle-toolbar-starter.js`
-and exposes `window.GenericDleToolbarStarter.create({ markerId, alternateHtml, defaultHtml })`.
+and exposes `window.GenericDleToolbarStarter.create({ markerId, alternateHtml, defaultHtml, order })`.
 
 Add a thin `starter.js` to your extension's webapp that supplies only the extension-specific parts
 (button markup, a unique `markerId`, any css/js the button needs) and bootstraps the engine:
@@ -445,10 +445,18 @@ Add a thin `starter.js` to your extension's webapp that supplies only the extens
     const ALTERNATE_TOOLBAR_HTML = `<table class="dleToolBarTable">...your button...</table>`;  // variant for inside the toolbar row
 
     // Expose the global immediately and queue calls until the engine has loaded.
-    let starter = null;
+    let starter = null, order;
     const pending = [];
     window.MyExtensionStarter = {
-        injectToolbar: (params) => starter ? starter.injectToolbar(params) : pending.push(params)
+        injectToolbar: (params) => {
+            // Capture this button's position among all toolbar buttons: this stub runs synchronously
+            // as dleEditorHead executes, so the shared counter reflects config order (see "Ordering").
+            if (order === undefined) {
+                const seq = top.__genericDleToolbarSeq || (top.__genericDleToolbarSeq = { n: 0 });
+                order = seq.n++;
+            }
+            starter ? starter.injectToolbar(params) : pending.push(params);
+        }
     };
 
     const engine = document.createElement('script');
@@ -460,7 +468,8 @@ Add a thin `starter.js` to your extension's webapp that supplies only the extens
         starter = generic.create({
             markerId: 'my-extension-toolbar-injected',   // unique id set on the injected element
             alternateHtml: ALTERNATE_TOOLBAR_HTML,
-            defaultHtml: TOOLBAR_HTML
+            defaultHtml: TOOLBAR_HTML,
+            order                                        // stable left-to-right order (see "Ordering")
         });
         pending.forEach(p => starter.injectToolbar(p));
         pending.length = 0;
@@ -479,3 +488,23 @@ scriptInjection.dleEditorHead=<script src="/polarion/my-extension/js/starter.js"
 `injectToolbar({ alternate: true })` inserts the button into the editor toolbar row; calling it without
 `alternate` renders the standalone `defaultHtml` variant above the rich-text area. The engine is
 idempotent (guarded by `markerId`) and sets up one self-healing observer per extension.
+
+#### Ordering multiple buttons
+
+When several extensions each add a button (separate `dleEditorHead` entries), the engine keeps them in a
+stable left-to-right order across re-renders. The order is **not configured by hand** — it is the
+position of the `injectToolbar` call in `dleEditorHead`:
+
+- The inline `<script>…injectToolbar(...)</script>` tags in `dleEditorHead` execute in document order, so
+  each thin starter's `injectToolbar` stub runs synchronously in that order.
+- On its first call the stub reads (and increments) a shared `top.__genericDleToolbarSeq` counter and
+  passes that value as `order` to `create({ order })`.
+- On every (re-)injection the engine inserts the button before the first already-present button whose
+  `order` is higher, otherwise before the toolbar spacer cell. The marker→order map lives on
+  `top.__genericDleToolbarOrder`, so placement is independent of which extension's self-healing observer
+  happens to re-fire first after a toolbar re-render.
+
+To change the order, reorder the `injectToolbar` lines in `dleEditorHead`. Note that determinism requires
+**distinct** `order` values: buttons that share the same `order` (including any caller that omits it — it
+defaults to `0`) tie-break by observer-fire order, i.e. non-deterministically, exactly as before this
+mechanism existed.

--- a/app/src/main/resources/js/dle-toolbar-starter.js
+++ b/app/src/main/resources/js/dle-toolbar-starter.js
@@ -67,8 +67,10 @@
         create: function (config) {
             // Stable left-to-right order across re-renders. Each button keeps the order it was
             // registered with (config.order — the config-execution order); re-injection inserts
-            // before the first already-present button with a higher order, so the visual order is
-            // independent of which extension's observer happens to re-fire first.
+            // before the first already-present button with a *higher* order. Buttons with distinct
+            // orders keep their position regardless of which extension's observer re-fires first;
+            // buttons sharing an order (e.g. callers that omit it → default 0) tie-break by
+            // observer-fire order, so distinct orders are required for full determinism.
             const myOrder = (typeof config.order === 'number') ? config.order : 0;
             const orderByMarker = top.__genericDleToolbarOrder || (top.__genericDleToolbarOrder = {});
             orderByMarker[config.markerId] = myOrder;

--- a/app/src/main/resources/js/dle-toolbar-starter.js
+++ b/app/src/main/resources/js/dle-toolbar-starter.js
@@ -65,6 +65,14 @@
          * @returns {{ injectToolbar: function, destroy: function }}
          */
         create: function (config) {
+            // Stable left-to-right order across re-renders. Each button keeps the order it was
+            // registered with (config.order — the config-execution order); re-injection inserts
+            // before the first already-present button with a higher order, so the visual order is
+            // independent of which extension's observer happens to re-fire first.
+            const myOrder = (typeof config.order === 'number') ? config.order : 0;
+            const orderByMarker = top.__genericDleToolbarOrder || (top.__genericDleToolbarOrder = {});
+            orderByMarker[config.markerId] = myOrder;
+
             // Idempotent: only inject if the toolbar exists and our button isn't already there.
             function inject(params) {
                 if (top.document.getElementById(config.markerId)) {
@@ -78,11 +86,21 @@
                     const toolbarContainer = top.document.createElement('td');
                     toolbarContainer.id = config.markerId;
                     toolbarContainer.innerHTML = config.alternateHtml;
-                    const reference = toolbarParent.querySelector('td[width="100%"]');
-                    if (!reference) {
+                    const spacer = toolbarParent.querySelector('td[width="100%"]');
+                    if (!spacer) {
                         // Polarion DOM changed (e.g. after an upgrade) — fall back to appending at the
                         // end of the row, but warn so the mislayout is diagnosable.
                         console.warn(`GenericDleToolbarStarter: reference cell td[width="100%"] not found for '${config.markerId}'; appending button at the end of the toolbar row.`);
+                    }
+                    // Keep a stable order: insert before the first already-present button whose order
+                    // is higher than ours, otherwise before the spacer cell.
+                    let reference = spacer;
+                    for (const cell of toolbarParent.children) {
+                        const cellOrder = orderByMarker[cell.id];
+                        if (cellOrder !== undefined && cellOrder > myOrder) {
+                            reference = cell;
+                            break;
+                        }
                     }
                     toolbarParent.insertBefore(toolbarContainer, reference);
                 } else {


### PR DESCRIPTION
### Proposed changes

- Introduce order-based logic for consistent left-to-right button insertion
- Use `config.order` to determine insertion point relative to other buttons
- Maintain idempotent behavior while handling dynamic toolbar re-renders

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
