### PR TITLE
feat: single shared dropdown component

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,70 @@ public class PdfExporterAdminUiServlet extends GenericUiServlet {
 }
 ```
 
+### UI components (JavaScript / CSS)
+
+The generic module ships shared, Polarion-matched front-end components so every extension's UI looks
+and behaves the same. They are served by the extension's `GenericUiServlet` at
+`/polarion/<extension>/ui/generic/{js,css}/…` and imported from there:
+
+```js
+import SearchableDropdown from '../ui/generic/js/modules/SearchableDropdown.js';
+import ExtensionContext from '../ui/generic/js/modules/ExtensionContext.js';
+```
+
+#### `SearchableDropdown` — the standard dropdown
+
+`js/modules/SearchableDropdown.js` is the single dropdown component for all extensions. It renders a
+Polarion-styled combobox with a searchable, never-clipped popup and supports single- and
+multi-select. Prefer it over a raw `<select>` or any bespoke widget.
+
+- **Element mode** — wrap an existing native `<select>` (the `<select>` stays the source of truth):
+
+  ```js
+  new SearchableDropdown({ element: document.getElementById('paper-size'), rememberSelection: false });
+  ```
+
+- **Build mode** — render into a `<div>` and populate programmatically. It exposes the same API as
+  the (now deprecated) `CustomSelect` (`addOption`, `empty`, `selectValue`, `selectMultipleValues`,
+  `getSelectedValue`, `getSelectedText`, `containsOption`), so it is a drop-in replacement:
+
+  ```js
+  const dd = new SearchableDropdown({ selectContainer: document.getElementById('css-select'), label });
+  dd.addOption('A4', 'A4');            // single-select defaults to the first option added
+  dd.selectValue('A4');
+  ```
+
+Key options: `multiselect` (removable chips + in-list checkboxes; the popup stays open while
+toggling), `searchable` (default `true`), `placeholder`, `rememberSelection` (cookie; usually pass
+`false`), `preserveOptionClasses` (mirror each `<option>`'s CSS class onto the rendered option — e.g.
+the `parent` class renders a global-scope configuration with an italic `global` marker). The popup is
+portalled into `document.body` so it is never clipped by an ancestor's `overflow` (narrow side
+panels, scrollable modals). It integrates with `ExtensionContext` (`setSelector` / `setValueById` /
+`displayIf`) and auto-refreshes when its `<select>` options are repopulated.
+
+#### Shared control styling
+
+`css/common.css` (`@import` it, or link it from admin JSPs) pulls in the neutral, Polarion-matched
+styles for `checkboxes.css`, `radios.css`, `inputs.css` and `searchable-dropdown.css`, plus the
+`.toolbar-button` styling. The checkbox / radio / input rules are intentionally **scoped** to the
+UI wrappers `.modal__container` (popups), `.standard-admin-page` (admin pages) and `.form-wrapper`
+(document-properties side panels) so they never restyle Polarion's own controls — put the matching
+wrapper class on your surface.
+
+#### `ConfigurationsPane`
+
+`js/modules/ConfigurationsPane.js` renders the admin "choose a configuration" pane (backed by a
+native `<select id="configurations-select">` wrapped by `SearchableDropdown`), including the
+italic `global` marker for configurations inherited from a broader scope.
+
+#### Deprecated components
+
+The following are kept only for backward compatibility and should not be used in new code:
+
+- `js/modules/CustomSelect.js` — superseded by `SearchableDropdown` (build mode).
+- `js/custom-select.js` (non-module `SbbCustomSelect`) — superseded by `SearchableDropdown`.
+- `js/configurations.js` (non-module `Configurations`) — superseded by the `ConfigurationsPane` module.
+
 ### Custom extension configuration
 
 In order to register additional configuration properties a subclass of `ExtensionConfiguration` must be marked with the `@Discoverable`:

--- a/app/src/main/resources/META-INF/resources/common/jsp/configurations.jsp
+++ b/app/src/main/resources/META-INF/resources/common/jsp/configurations.jsp
@@ -5,7 +5,7 @@
 <div class="input-group common-configuration-panel">
     <div id="configurations-pane">
         <label id="configurations-label"><span class="configuration-label-capitalized">Configuration</span>:</label>
-        <div id="configurations-select"></div>
+        <select id="configurations-select"></select>
         <div class="action-buttons">
             <button id="configurations-button-edit" class="toolbar-button" onclick="Configurations.editConfiguration()">
                 <img class="button-image" src="/polarion/ria/images/actions/edit.gif?bundle=<%= bundleTimestamp %>">Rename

--- a/app/src/main/resources/css/common.css
+++ b/app/src/main/resources/css/common.css
@@ -1,4 +1,7 @@
 @import url("checkboxes.css");
+@import url("radios.css");
+@import url("inputs.css");
+@import url("searchable-dropdown.css");
 
 @font-face {
     font-family: "Selawik";
@@ -217,6 +220,14 @@ code-input {
 }
 
 .toolbar-button {
+    /* inline-flex + align-items:center vertically centres the label; without it text-only
+       buttons and <label class="toolbar-button"> render their text high in the 28px box.
+       Icon buttons keep "icon left + text": the <img class="button-image"> is simply the
+       first flex item (its float is inert here), with padding-right for the gap. */
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
     font-size: 12px;
     font-weight: bold;
     padding: 3px 6px;

--- a/app/src/main/resources/css/inputs.css
+++ b/app/src/main/resources/css/inputs.css
@@ -22,11 +22,15 @@
 .form-wrapper input[type="text"]:not(.sd-trigger):not(.search-box),
 .form-wrapper input[type="number"],
 .form-wrapper input[type="password"],
-.form-wrapper input[type="search"] {
+.form-wrapper input[type="search"],
+.modal__container input:not([type]):not(.sd-trigger):not(.search-box),
+.standard-admin-page input:not([type]):not(.sd-trigger):not(.search-box),
+.form-wrapper input:not([type]):not(.sd-trigger):not(.search-box) {
     box-sizing: border-box;
     height: 23px;
     border: 1px solid #c9c9c9;
-    border-radius: 2px;
+    /* Square corners to match Polarion's own text inputs (its inputs are not rounded). */
+    border-radius: 0;
     padding: 2px 6px;
     background-color: #fff;
     font-family: "Segoe UI", "Selawik", "Open Sans", Arial, sans-serif;
@@ -46,7 +50,10 @@
 .form-wrapper input[type="text"]:not(.sd-trigger):not(.search-box):focus,
 .form-wrapper input[type="number"]:focus,
 .form-wrapper input[type="password"]:focus,
-.form-wrapper input[type="search"]:focus {
+.form-wrapper input[type="search"]:focus,
+.modal__container input:not([type]):not(.sd-trigger):not(.search-box):focus,
+.standard-admin-page input:not([type]):not(.sd-trigger):not(.search-box):focus,
+.form-wrapper input:not([type]):not(.sd-trigger):not(.search-box):focus {
     border-color: #1491EB;
     outline: none;
 }

--- a/app/src/main/resources/css/inputs.css
+++ b/app/src/main/resources/css/inputs.css
@@ -1,0 +1,52 @@
+/*
+ * Unified text-input styling — the Polarion look (border #c9c9c9, 23px height,
+ * 13px Segoe, blue focus #1491EB), matching our combobox trigger and Polarion's
+ * own inputs. Single source for every extension.
+ *
+ * SCOPED to our UI wrappers (.modal__container popups, .standard-admin-page admin
+ * pages, .form-wrapper document-properties side panels) so it never restyles
+ * Polarion's own inputs. The combobox's own inputs (.sd-trigger / .search-box)
+ * are excluded — they have their dedicated styling in searchable-dropdown.css.
+ *
+ * Loaded by: common.css (@import) for admin pages; injected/linked by each
+ * extension's popup/side-panel for the document-view contexts.
+ */
+.modal__container input[type="text"]:not(.sd-trigger):not(.search-box),
+.modal__container input[type="number"],
+.modal__container input[type="password"],
+.modal__container input[type="search"],
+.standard-admin-page input[type="text"]:not(.sd-trigger):not(.search-box),
+.standard-admin-page input[type="number"],
+.standard-admin-page input[type="password"],
+.standard-admin-page input[type="search"],
+.form-wrapper input[type="text"]:not(.sd-trigger):not(.search-box),
+.form-wrapper input[type="number"],
+.form-wrapper input[type="password"],
+.form-wrapper input[type="search"] {
+    box-sizing: border-box;
+    height: 23px;
+    border: 1px solid #c9c9c9;
+    border-radius: 2px;
+    padding: 2px 6px;
+    background-color: #fff;
+    font-family: "Segoe UI", "Selawik", "Open Sans", Arial, sans-serif;
+    font-size: 13px;
+    font-weight: 600;
+    color: #1a1a1a;
+}
+
+.modal__container input[type="text"]:not(.sd-trigger):not(.search-box):focus,
+.modal__container input[type="number"]:focus,
+.modal__container input[type="password"]:focus,
+.modal__container input[type="search"]:focus,
+.standard-admin-page input[type="text"]:not(.sd-trigger):not(.search-box):focus,
+.standard-admin-page input[type="number"]:focus,
+.standard-admin-page input[type="password"]:focus,
+.standard-admin-page input[type="search"]:focus,
+.form-wrapper input[type="text"]:not(.sd-trigger):not(.search-box):focus,
+.form-wrapper input[type="number"]:focus,
+.form-wrapper input[type="password"]:focus,
+.form-wrapper input[type="search"]:focus {
+    border-color: #1491EB;
+    outline: none;
+}

--- a/app/src/main/resources/css/radios.css
+++ b/app/src/main/resources/css/radios.css
@@ -1,0 +1,45 @@
+/*
+ * Neutral 2606 radio buttons — the counterpart to checkboxes.css.
+ *
+ * Polarion does NOT ship a radio image set (unlike checkboxes, which use
+ * /polarion/ria/images/checkbox/*.png) — it renders native radios. To keep our
+ * radios neutral and consistent with our checkboxes we draw the control with CSS
+ * (appearance:none + a bordered circle and a grey centre dot when checked).
+ *
+ * Single source for every extension. SCOPED to our own UI wrappers
+ * (.modal__container popups, .standard-admin-page admin pages, .form-wrapper
+ * document-properties side panels) so it is safe to inject into the Polarion
+ * document page without ever restyling Polarion's own radios.
+ *
+ * Loaded by: common.css (@import) for admin pages; injected by each extension's
+ * popup/side-panel for the document-view contexts (alongside checkboxes.css).
+ */
+.modal__container input[type="radio"],
+.standard-admin-page input[type="radio"],
+.form-wrapper input[type="radio"] {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 15px;
+    height: 15px;
+    margin: 0 4px 0 0;
+    vertical-align: middle;
+    cursor: pointer;
+    box-sizing: border-box;
+    border: 1px solid #c9c9c9;
+    border-radius: 50%;
+    background-color: #fff;
+}
+
+.modal__container input[type="radio"]:checked,
+.standard-admin-page input[type="radio"]:checked,
+.form-wrapper input[type="radio"]:checked {
+    background-image: radial-gradient(circle, #595959 0 34%, transparent 38%);
+}
+
+/* Keep the radio vertically centered with its label text. */
+.modal__container label:has(input[type="radio"]),
+.standard-admin-page label:has(input[type="radio"]),
+.form-wrapper label:has(input[type="radio"]) {
+    display: inline-flex;
+    align-items: center;
+}

--- a/app/src/main/resources/css/searchable-dropdown.css
+++ b/app/src/main/resources/css/searchable-dropdown.css
@@ -1,78 +1,248 @@
 .searchable-dropdown {
     position: relative;
-    width: auto;
-    min-width: 250px;
+    display: inline-block;
+    /* Default width; overridden inline when the original element has an explicit width,
+       and overridable per-context by consumers via CSS (e.g. .comparison .searchable-dropdown). */
+    width: 130px;
     font-family: "Segoe UI", "Selawik", "Open Sans", Arial, sans-serif;
 }
 
-/* Input styled as select */
-.searchable-dropdown input {
+/* Trigger — the closed combobox (Polarion JSSelector-Combo) */
+.searchable-dropdown > input.sd-trigger {
     width: 100%;
+    height: 23px;
     box-sizing: border-box;
-    padding: 2px 2rem 4px .4rem;
-    border: 1px solid #ccc;
+    padding: 2px 2rem 2px .5rem;
+    border: 1px solid #c9c9c9;
     border-radius: 2px;
     background-color: #fff;
     cursor: pointer;
     overflow: hidden;
     text-overflow: ellipsis;
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    color: #1a1a1a;
 }
 
-.searchable-dropdown input.non-searchable {
+/* Open state — Polarion JSSelector-ComboOpen (blue border + shadow) */
+.searchable-dropdown.open > .sd-trigger {
+    border-color: #1491EB;
+    box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.3);
+    outline: none;
+}
+
+/* Multi-select trigger: renders selected values as chips and grows in height (wrapping) so all
+   selections stay visible instead of being truncated into a single comma-joined line. */
+.searchable-dropdown > .sd-trigger-multi {
+    width: 100%;
+    min-height: 23px;
+    box-sizing: border-box;
+    padding: 1px 2rem 1px 3px;
+    border: 1px solid #c9c9c9;
+    border-radius: 2px;
+    background-color: #fff;
     cursor: pointer;
-    caret-color: transparent;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    /* Uniform spacing between chips (row and column). */
+    gap: 4px;
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    color: #1a1a1a;
 }
 
-/* Arrow container */
+.searchable-dropdown > .sd-trigger-multi .sd-placeholder {
+    color: #7c7c7c;
+    padding-left: 3px;
+}
+
+.searchable-dropdown .sd-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    max-width: 100%;
+    box-sizing: border-box;
+    padding: 0 3px 0 5px;
+    background: #ebf7f8;
+    border: 1px solid #b6dfe3;
+    border-radius: 2px;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 17px;
+}
+
+.searchable-dropdown .sd-chip-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.searchable-dropdown .sd-chip-remove {
+    cursor: pointer;
+    color: #5c8a90;
+    font-weight: 700;
+    line-height: 1;
+}
+
+.searchable-dropdown .sd-chip-remove:hover {
+    color: #1a1a1a;
+}
+
+/* Arrow on the trigger — Polarion combo_box_old.png */
 .searchable-dropdown::after {
     content: '';
     position: absolute;
-    right: 12px;
-    top: 40%;
-    width: 6px;
-    height: 6px;
-    background: transparent url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAYAAAAGCAYAAADgzO9IAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAOUlEQVR4nGNgwAOKGRgY/qNhkBgDCwMDw0UkwasMDAysMF22DAwM/6ASjuhGLmVgYFiCzS5JKAYDACJtDIY1VpdwAAAAAElFTkSuQmCC") no-repeat;
+    right: 6px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 16px;
+    height: 16px;
+    background: transparent url("/polarion/ria/images/combo_box_old.png") center / contain no-repeat;
+    pointer-events: none;
 }
 
-.searchable-dropdown.open::after {
-    transform: rotate(180deg);
+/* The popup is portalled into <body> (see SearchableDropdown._render) so it can't be clipped by
+   an ancestor's overflow (narrow side panels, scrollable modals). The portal is fixed-positioned
+   in JS under the trigger, and given the trigger's width so the popup min-width (trigger + 35px)
+   resolves. All popup-internal styling therefore hangs off .sd-portal, not .searchable-dropdown. */
+.sd-portal {
+    position: fixed;
+    /* Very high so the body-level popup always renders above modals/overlays it may open from. */
+    z-index: 2147483000;
+    font-family: "Segoe UI", "Selawik", "Open Sans", Arial, sans-serif;
 }
 
-/* Dropdown list */
-.searchable-dropdown .options {
+/* Popup menu (Polarion JComboBox-ItemsContainer) */
+.sd-portal .options {
     position: absolute;
-    top: calc(100% + 2px);
+    top: 100%;
     left: 0;
-    right: 0;
+    /* Popup width is driven by the longest option, but never narrower than the trigger + 35px */
+    min-width: calc(100% + 35px);
+    width: max-content;
     background: #fff;
-    border: 1px solid #aaa;
-    border-radius: 4px;
-    max-height: 180px;
-    overflow-y: auto;
-    display: none;
-    z-index: 1000;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    border: 1px solid #CCCCD4;
+    border-radius: 2px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
 }
 
-.searchable-dropdown .options.dropup {
-    bottom: calc(100% + 2px);
+.sd-portal .options.dropup {
+    bottom: 100%;
     top: auto;
 }
 
-/* Option item */
-.searchable-dropdown .option {
-    padding: 8px 10px;
+/* Search row on top of the popup: search box + erase icon.
+   width:0 + min-width:100% keeps the search input OUT of the popup's max-content width
+   calculation (otherwise the input's intrinsic width would inflate the popup to a fixed,
+   too-wide size); the row then stretches to whatever width the option list resolves to. */
+.sd-portal .search-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 8px;
+    box-sizing: border-box;
+    width: 0;
+    min-width: 100%;
+}
+
+.sd-portal .search-box {
+    flex: 1;
+    min-width: 0;
+    box-sizing: border-box;
+    padding: 4px 6px;
+    border: 1px solid #1491EB;
+    border-radius: 2px;
+    background-color: #fff;
+    font-family: inherit;
+    font-size: 13px;
+    color: #1a1a1a;
+    outline: none;
+}
+
+/* Erase (clear search) icon — Polarion search_combo_erase.png */
+.sd-portal .erase {
+    flex: none;
+    width: 12px;
+    height: 12px;
     cursor: pointer;
 }
 
-.searchable-dropdown .option:hover {
-    background-color: #DAECF0;
+/* Scrollable items list */
+.sd-portal .items {
+    max-height: 180px;
+    overflow-y: auto;
 }
 
-.searchable-dropdown .option.active {
-    background-color: #DAECF0;
-}
-
-.searchable-dropdown .option.selected {
+/* Option item */
+.sd-portal .option {
+    padding: 6px 12px;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 13px;
     font-weight: 600;
+    color: #1a1a1a;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* Highlight — exact Polarion .polarion-JComboBox-ItemOver colour.
+   Only one option is highlighted at a time (follows mouse/keyboard), managed via the .active class. */
+.sd-portal .option.active {
+    background-color: #ebf7f8;
+}
+
+/* Multi-select option: a checkbox in front of the label (toggles without closing the popup). */
+.sd-portal .option.multiselect-option {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.sd-portal .option.multiselect-option input[type="checkbox"] {
+    flex: none;
+    margin: 0;
+    /* Let clicks fall through to the option row so a single handler toggles selection
+       (avoids a double-toggle between the native checkbox and our handler). */
+    pointer-events: none;
+    /* Polarion-styled checkbox (the portal lives in <body>, outside the wrappers checkboxes.css
+       scopes to, so replicate the image styling here — only for in-list multi-select checkboxes). */
+    -webkit-appearance: none;
+    appearance: none;
+    width: 15px;
+    height: 15px;
+    background: url(/polarion/ria/images/checkbox/unchecked.png) no-repeat center;
+    background-size: 15px 15px;
+}
+
+.sd-portal .option.multiselect-option input[type="checkbox"]:checked {
+    background-image: url(/polarion/ria/images/checkbox/checked.png);
+}
+
+.sd-portal .option.multiselect-option .option-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* preserveOptionClasses: options inherit the source <option>'s class.
+   .parent = a config inherited from a broader (e.g. global) scope. The name is
+   shown in normal text and a small italic "global" marker is appended on the
+   right — matching Polarion's original config selector (was configurations.css
+   .parent::after). The trigger is an <input>, which can't render ::after, so the
+   selected value there shows just the config name. */
+.sd-portal .option.parent {
+    display: flex;
+    align-items: baseline;
+    overflow: visible;
+}
+
+.sd-portal .option.parent::after {
+    content: "global";
+    margin-left: auto;
+    padding-left: 16px;
+    font-size: 10px;
+    font-style: italic;
 }

--- a/app/src/main/resources/css/searchable-dropdown.css
+++ b/app/src/main/resources/css/searchable-dropdown.css
@@ -14,7 +14,7 @@
     box-sizing: border-box;
     padding: 2px 2rem 2px .5rem;
     border: 1px solid #c9c9c9;
-    border-radius: 2px;
+    border-radius: 0;
     background-color: #fff;
     cursor: pointer;
     overflow: hidden;
@@ -32,6 +32,23 @@
     outline: none;
 }
 
+/* Selected option's icon overlaid on the single-select trigger (the <input> can't hold markup);
+   .has-icon makes room for it on the left. */
+.searchable-dropdown > input.sd-trigger.has-icon {
+    padding-left: 26px;
+}
+
+.searchable-dropdown .sd-trigger-icon {
+    position: absolute;
+    left: 7px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 16px;
+    height: 16px;
+    object-fit: contain;
+    pointer-events: none;
+}
+
 /* Multi-select trigger: renders selected values as chips and grows in height (wrapping) so all
    selections stay visible instead of being truncated into a single comma-joined line. */
 .searchable-dropdown > .sd-trigger-multi {
@@ -40,7 +57,7 @@
     box-sizing: border-box;
     padding: 1px 2rem 1px 3px;
     border: 1px solid #c9c9c9;
-    border-radius: 2px;
+    border-radius: 0;
     background-color: #fff;
     cursor: pointer;
     display: flex;
@@ -68,7 +85,7 @@
     padding: 0 3px 0 5px;
     background: #ebf7f8;
     border: 1px solid #b6dfe3;
-    border-radius: 2px;
+    border-radius: 0;
     font-size: 12px;
     font-weight: 600;
     line-height: 17px;
@@ -125,7 +142,7 @@
     width: max-content;
     background: #fff;
     border: 1px solid #CCCCD4;
-    border-radius: 2px;
+    border-radius: 0;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
 }
 
@@ -154,7 +171,7 @@
     box-sizing: border-box;
     padding: 4px 6px;
     border: 1px solid #1491EB;
-    border-radius: 2px;
+    border-radius: 0;
     background-color: #fff;
     font-family: inherit;
     font-size: 13px;
@@ -193,6 +210,20 @@
    Only one option is highlighted at a time (follows mouse/keyboard), managed via the .active class. */
 .sd-portal .option.active {
     background-color: #ebf7f8;
+}
+
+/* Optional per-option icon (from <option data-icon="…"> or addOption(value, text, icon)). */
+.sd-portal .option.has-icon {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.sd-portal .option .option-icon {
+    flex: none;
+    width: 16px;
+    height: 16px;
+    object-fit: contain;
 }
 
 /* Multi-select option: a checkbox in front of the label (toggles without closing the popup). */

--- a/app/src/main/resources/js/configurations.js
+++ b/app/src/main/resources/js/configurations.js
@@ -1,5 +1,10 @@
 const SELECTED_CONFIGURATION_COOKIE = 'selected-configuration-';
 
+/**
+ * @deprecated Non-module legacy configuration pane. Use the ES module `ConfigurationsPane`
+ * (`js/modules/ConfigurationsPane.js`) instead, which renders the selector via SearchableDropdown.
+ * Kept only for backward compatibility.
+ */
 const Configurations = {
     configurationsPane: document.getElementById("configurations-pane"),
     editConfigurationPane: document.getElementById("edit-configuration-pane"),

--- a/app/src/main/resources/js/custom-select.js
+++ b/app/src/main/resources/js/custom-select.js
@@ -1,3 +1,7 @@
+/**
+ * @deprecated Non-module legacy widget. Use the ES module {@link SearchableDropdown}
+ * (`js/modules/SearchableDropdown.js`) in build mode instead. Kept only for backward compatibility.
+ */
 function SbbCustomSelect({selectContainer, label, changeListener, multiselect = false}) {
     this.selectContainer = selectContainer ? selectContainer : document.createElement('div');
     this.selectContainer.classList.add('sbb-custom-select');

--- a/app/src/main/resources/js/modules/ConfigurationsPane.js
+++ b/app/src/main/resources/js/modules/ConfigurationsPane.js
@@ -1,4 +1,4 @@
-import CustomSelect from "./CustomSelect.js";
+import SearchableDropdown from "./SearchableDropdown.js";
 
 export default class ConfigurationsPane {
 
@@ -60,11 +60,19 @@ export default class ConfigurationsPane {
         this.preDeleteCallback = preDeleteCallback;
         this.newConfigurationCallback = newConfigurationCallback;
 
-        this.configurationsSelect = new CustomSelect({
-            selectContainer: document.getElementById("configurations-select"),
-            label: document.getElementById("configurations-label"),
-            changeListener: (selectedCheckbox) => this.configurationChanged(selectedCheckbox)
+        this.configSelectElement = document.getElementById("configurations-select");
+        const configLabel = document.getElementById("configurations-label");
+        if (configLabel) {
+            configLabel.htmlFor = "configurations-select";
+        }
+        this.configurationsSelect = new SearchableDropdown({
+            element: this.configSelectElement,
+            preserveOptionClasses: true,
+            rememberSelection: false
         });
+        // Native <select> change (user pick or programmatic dispatch) drives the config logic
+        this.configSelectElement.addEventListener('change', () =>
+            this.configurationChanged(this.configSelectElement.selectedOptions[0] || null));
     }
 
     loadConfigurationNames() {
@@ -75,7 +83,7 @@ export default class ConfigurationsPane {
             url: `/polarion/${this.ctx.extension}/rest/internal/settings/${this.ctx.setting}/names?scope=${this.ctx.scope}`,
             contentType: 'application/json',
             onOk: (responseText) => {
-                this.configurationsSelect.empty();
+                this.configSelectElement.innerHTML = "";
 
                 const previouslySelectedValue = this.ctx.getCookie(ConfigurationsPane.SELECTED_CONFIGURATION_COOKIE + this.ctx.setting);
                 let preselectDefault = true;
@@ -86,21 +94,25 @@ export default class ConfigurationsPane {
                     if (name.name === previouslySelectedValue) {
                         preselectDefault = false;
                     }
-                    const addedOption = this.configurationsSelect.addOption(name.name);
-                    if (name.scope !== this.ctx.scope) {
-                        addedOption.checkbox.classList.add('parent');
-                        addedOption.label.classList.add('parent');
+                    const option = document.createElement('option');
+                    option.value = name.name;
+                    option.textContent = name.name;
+                    if (name.scope !== this.ctx.scope) { // inherited from a broader (e.g. global) scope
+                        option.classList.add('parent');
                     }
+                    this.configSelectElement.appendChild(option);
                 }
 
                 const hasNames = names.length > 0
                 this.ctx.disableIf('configurations-button-edit', !hasNames);
                 this.ctx.disableIf('configurations-button-delete', !hasNames);
                 if (hasNames) {
-                    this.configurationsSelect.selectValue(previouslySelectedValue && !preselectDefault ? previouslySelectedValue : defaultValue);
+                    this.configSelectElement.value = previouslySelectedValue && !preselectDefault ? previouslySelectedValue : defaultValue;
+                    this.configSelectElement.dispatchEvent(new Event('change'));
                     this.setContentAreaEnabled(true);
                 } else {
-                    this.configurationsSelect.setSelectedOptionValue('');
+                    this.configSelectElement.value = "";
+                    this.configurationChanged(null);
                 }
             },
             onError: () => document.getElementById("configurations-load-error").style.display = "block"
@@ -137,7 +149,7 @@ export default class ConfigurationsPane {
         this.editConfigurationPane.style.display = "none";
         this.configurationsPane.style.display = "block";
         this.setContentAreaEnabled(true);
-        this.configurationsSelect.handleChange();
+        this.configSelectElement.dispatchEvent(new Event('change'));
     }
 
     saveConfiguration() {
@@ -194,10 +206,10 @@ export default class ConfigurationsPane {
     }
 
     nameClashes(newValue, oldValue) {
-        for (let checkbox of this.configurationsSelect.getAllCheckboxes()) {
-            if (!checkbox.classList.contains('parent')) { // Projects scope configurations can override ones from global scope
-                if (checkbox.value !== oldValue) { // Ignore persisted name of the option to be renamed itself
-                    if (checkbox.value === newValue) {
+        for (let option of Array.from(this.configSelectElement.options)) {
+            if (!option.classList.contains('parent')) { // Projects scope configurations can override ones from global scope
+                if (option.value !== oldValue) { // Ignore persisted name of the option to be renamed itself
+                    if (option.value === newValue) {
                         return true;
                     }
                 }
@@ -260,7 +272,7 @@ export default class ConfigurationsPane {
     }
 
     getSelectedConfiguration() {
-        return this.configurationsSelect.getSelectedValue();
+        return this.configSelectElement.value;
     }
 
     loadConfigurationContent(configurationName) {

--- a/app/src/main/resources/js/modules/CustomSelect.js
+++ b/app/src/main/resources/js/modules/CustomSelect.js
@@ -1,3 +1,10 @@
+/**
+ * @deprecated Use {@link SearchableDropdown} in build mode instead
+ * (`new SearchableDropdown({selectContainer, label, multiselect})`). SearchableDropdown exposes the
+ * same API (addOption/empty/selectValue/selectMultipleValues/getSelectedValue/getSelectedText/
+ * containsOption) plus a Polarion-styled, searchable, never-clipped popup and multi-select chips.
+ * Kept only for backward compatibility with not-yet-migrated extensions.
+ */
 export default class CustomSelect {
     constructor({selectContainer, label, changeListener, multiselect = false}) {
         this.selectContainer = selectContainer ? selectContainer : window.document.createElement('div');

--- a/app/src/main/resources/js/modules/ExtensionContext.js
+++ b/app/src/main/resources/js/modules/ExtensionContext.js
@@ -43,7 +43,11 @@ export default class ExtensionContext {
     }
 
     setValueById(elementId, value) {
-        this.getElementById(elementId).value = value
+        const element = this.getElementById(elementId);
+        element.value = value;
+        if (element._searchableDropdown) {
+            element._searchableDropdown.syncFromElement();
+        }
     }
 
     getValue(elementId) {
@@ -73,6 +77,9 @@ export default class ExtensionContext {
     setSelector(elementId, value) {
         const selector = this.getElementById(elementId);
         selector.value = this.containsOption(selector, value) ? value : ExtensionContext.DEFAULT;
+        if (selector._searchableDropdown) {
+            selector._searchableDropdown.syncFromElement();
+        }
     }
 
     selectOptionByValue(id, optionValue) {

--- a/app/src/main/resources/js/modules/SearchableDropdown.js
+++ b/app/src/main/resources/js/modules/SearchableDropdown.js
@@ -413,7 +413,9 @@ export default class SearchableDropdown {
     }
 
     _refreshActive() {
-        this._renderOptions(this._visibleItems);
+        // Keyboard navigation only moves the highlight — repaint the .active class on the existing
+        // option nodes instead of rebuilding the whole list on every Arrow key.
+        this._paintActive();
         this._scrollActiveIntoView();
     }
 

--- a/app/src/main/resources/js/modules/SearchableDropdown.js
+++ b/app/src/main/resources/js/modules/SearchableDropdown.js
@@ -111,7 +111,9 @@ export default class SearchableDropdown {
                 value: option.value,
                 label: option.text,
                 className: option.className,
-                selected: option.selected
+                selected: option.selected,
+                // Optional per-option icon: <option data-icon="/polarion/…/icon.svg">Label</option>
+                icon: option.getAttribute('data-icon') || ''
             }));
     }
 
@@ -238,6 +240,17 @@ export default class SearchableDropdown {
 
         this.container.appendChild(this.trigger);
 
+        // Single-select trigger is a read-only <input> (can't hold markup), so the selected option's
+        // icon is overlaid as an absolutely-positioned image at its left edge (with .has-icon adding
+        // room for it). Multi-select shows icons inside its chips instead.
+        if (!this.multiselect) {
+            this.triggerIcon = document.createElement('img');
+            this.triggerIcon.className = 'sd-trigger-icon';
+            this.triggerIcon.alt = '';
+            this.triggerIcon.style.display = 'none';
+            this.container.appendChild(this.triggerIcon);
+        }
+
         // The popup is rendered into a portal appended to <body> (position:fixed) rather than
         // nested in the container. This lets it escape any ancestor overflow clipping (narrow side
         // panels, scrollable modals) and its width is driven in JS from the trigger, so it always
@@ -259,6 +272,23 @@ export default class SearchableDropdown {
             }
         }
         this._applyTriggerClass();
+        this._refreshTriggerIcon();
+    }
+
+    // Show/hide the selected option's icon on the single-select trigger (overlaid on the <input>).
+    _refreshTriggerIcon() {
+        if (this.multiselect || !this.triggerIcon) {
+            return;
+        }
+        const item = this.items.find(i => i.value === this.value);
+        if (item && item.icon) {
+            this.triggerIcon.src = item.icon;
+            this.triggerIcon.style.display = '';
+            this.trigger.classList.add('has-icon');
+        } else {
+            this.triggerIcon.style.display = 'none';
+            this.trigger.classList.remove('has-icon');
+        }
     }
 
     _bindEvents() {
@@ -345,6 +375,16 @@ export default class SearchableDropdown {
                 checkbox.checked = !!item.selected;
                 checkbox.tabIndex = -1;
                 option.appendChild(checkbox);
+                if (item.icon) {
+                    option.appendChild(this._createOptionIcon(item.icon));
+                }
+                const labelSpan = document.createElement('span');
+                labelSpan.className = 'option-label';
+                labelSpan.textContent = item.label;
+                option.appendChild(labelSpan);
+            } else if (item.icon) {
+                option.classList.add('has-icon');
+                option.appendChild(this._createOptionIcon(item.icon));
                 const labelSpan = document.createElement('span');
                 labelSpan.className = 'option-label';
                 labelSpan.textContent = item.label;
@@ -385,6 +425,14 @@ export default class SearchableDropdown {
         for (let i = 0; i < options.length; i++) {
             options[i].classList.toggle('active', i === this.activeIndex);
         }
+    }
+
+    _createOptionIcon(src) {
+        const icon = document.createElement('img');
+        icon.className = 'option-icon';
+        icon.src = src;
+        icon.alt = '';
+        return icon;
     }
 
     _handleArrowDown() {
@@ -532,6 +580,7 @@ export default class SearchableDropdown {
         const selected = this.items.filter(i => i.selected);
         this.trigger.value = selected.length ? selected[0].label : '';
         this._applyTriggerClass();
+        this._refreshTriggerIcon();
     }
 
     // Multi-select trigger content: one removable chip per selected value (empty → placeholder).
@@ -636,6 +685,7 @@ export default class SearchableDropdown {
         const item = this.items.find(i => i.value === value);
         this.trigger.value = item ? item.label : '';
         this._applyTriggerClass();
+        this._refreshTriggerIcon();
     }
 
     _applyTriggerClass() {
@@ -678,6 +728,7 @@ export default class SearchableDropdown {
         } else {
             this.trigger.value = item ? item.label : '';
             this._applyTriggerClass();
+            this._refreshTriggerIcon();
         }
 
         if (!preventClosing) {
@@ -700,12 +751,13 @@ export default class SearchableDropdown {
     // Append a selectable option. Returns lightweight handles whose classList mutations are
     // mirrored onto the rendered option — this preserves the CustomSelect contract where callers do
     // `addOption(...).label.classList.add('parent')` to mark a global-scope config.
-    addOption(value, text) {
+    addOption(value, text, icon) {
         const item = {
             value,
             label: text !== undefined && text !== null ? text : value,
             className: '',
-            selected: false
+            selected: false,
+            icon: icon || ''
         };
         this.items.push(item);
         // Single-select defaults to the first option (no empty/placeholder state), matching a
@@ -743,8 +795,15 @@ export default class SearchableDropdown {
     empty() {
         this.items = [];
         this.activeIndex = -1;
-        this.trigger.value = '';
-        this._applyTriggerClass();
+        if (this.multiselect) {
+            // The multi-select trigger is a chip container div — re-render it so stale chips (and
+            // their mousedown closures over removed items) are cleared and the placeholder shows.
+            this._updateTriggerFromSelection();
+        } else {
+            this.trigger.value = '';
+            this._applyTriggerClass();
+            this._refreshTriggerIcon();
+        }
         if (this.isOpen) {
             this._renderOptions(this.items);
         }
@@ -841,5 +900,6 @@ export default class SearchableDropdown {
         } else {
             this.trigger.value = val;
         }
+        this._refreshTriggerIcon();
     }
 }

--- a/app/src/main/resources/js/modules/SearchableDropdown.js
+++ b/app/src/main/resources/js/modules/SearchableDropdown.js
@@ -1,40 +1,74 @@
 export default class SearchableDropdown {
     static COOKIE_PREFIX = 'searchable_dropdown_';
     static COOKIE_EXPIRY_DAYS = 30;
-    static BLUR_DELAY_MS = 100;
 
     constructor({
-                    element,
+                    element = null,
+                    selectContainer = null,
+                    label = null,
+                    changeListener = null,
+                    multiselect = false,
                     items = [],
-                    placeholder = 'Search...',
+                    placeholder = '',
                     searchable = true,
-                    rememberSelection = true
+                    rememberSelection = true,
+                    preserveOptionClasses = false
                 }) {
-        if (!element) {
-            throw new Error('SearchableDropdown: element is required');
+        if (!element && !selectContainer) {
+            throw new Error('SearchableDropdown: element or selectContainer is required');
         }
 
-        this.originalElement =
-            typeof element === 'string'
-                ? document.querySelector(element)
-                : element;
+        // Two construction modes:
+        //  - "select" mode: wrap an existing native <select> (element) — the <select> stays the
+        //    source of truth, is visually hidden, and the dropdown mirrors it.
+        //  - "build" mode: render into a provided container <div> (selectContainer) and let the
+        //    consumer populate it via addOption()/selectValue()/... This makes SearchableDropdown a
+        //    drop-in replacement for the legacy CustomSelect (same API surface), so a single
+        //    component covers both the native-<select> case and the programmatically-built case,
+        //    including multi-select.
+        this.buildMode = !element && !!selectContainer;
 
-        if (!this.originalElement) {
-            throw new Error('SearchableDropdown: element not found');
+        if (this.buildMode) {
+            this.originalElement = null;
+            this.container =
+                typeof selectContainer === 'string'
+                    ? document.querySelector(selectContainer)
+                    : selectContainer;
+            if (!this.container) {
+                throw new Error('SearchableDropdown: selectContainer not found');
+            }
+            this.isSelect = false;
+            // Items in build mode carry their own selection state.
+            this.items = items.map(i => ({selected: false, className: '', ...i}));
+        } else {
+            this.originalElement =
+                typeof element === 'string'
+                    ? document.querySelector(element)
+                    : element;
+            if (!this.originalElement) {
+                throw new Error('SearchableDropdown: element not found');
+            }
+            this.isSelect = this.originalElement.tagName === 'SELECT';
+            this.items = this.isSelect
+                ? this._extractItemsFromSelect(this.originalElement)
+                : items;
         }
 
-        this.isSelect = this.originalElement.tagName === 'SELECT';
-        this.rememberSelection = rememberSelection && !!this.originalElement.id;
-
-        this.items = this.isSelect
-            ? this._extractItemsFromSelect(this.originalElement)
-            : items;
+        this.multiselect = multiselect;
+        this.label = label;
+        this.changeListener = changeListener;
+        this.rememberSelection =
+            rememberSelection && !this.buildMode && !!this.originalElement.id;
 
         this.placeholder = placeholder;
         this.searchable = searchable;
+        // Mirror each source option's CSS class onto the rendered option (and, in select mode, the
+        // trigger when selected) — e.g. a global-scope config is marked with the `parent` class,
+        // which renders a small italic "global" marker. Always on in build mode so classes added
+        // via addOption(...).classList surface.
+        this.preserveOptionClasses = preserveOptionClasses || this.buildMode;
         this.isOpen = false;
         this.activeIndex = -1;
-        this._blurTimeoutId = null;
 
         this._createContainer();
         this._render();
@@ -75,11 +109,19 @@ export default class SearchableDropdown {
                 return style.display !== 'none'; // Skip not visible items
             }).map(option => ({
                 value: option.value,
-                label: option.text
+                label: option.text,
+                className: option.className,
+                selected: option.selected
             }));
     }
 
     _createContainer() {
+        if (this.buildMode) {
+            // Render straight into the consumer-provided container.
+            this.container.classList.add('searchable-dropdown');
+            return;
+        }
+
         this.container = document.createElement('div');
         this.container.className = 'searchable-dropdown';
 
@@ -88,175 +130,266 @@ export default class SearchableDropdown {
             this.originalElement.nextSibling
         );
 
+        // Let ExtensionContext.setSelector/setValue sync this dropdown on programmatic value changes
+        this.originalElement._searchableDropdown = this;
+
+        // Width is configurable from the consumer side: inherit an explicit width from the original
+        // element (e.g. <select style="width:142px">, or width:100%). When none is set, the width
+        // falls back to the CSS default (.searchable-dropdown), which consumers can override per context.
+        if (this.originalElement.style.width) {
+            this.container.style.width = this.originalElement.style.width;
+        }
+
         if (this.isSelect) {
-            this.originalElement.style.display = 'none';
+            // Mirror the element's current visibility onto the container...
+            this.container.style.display = this.originalElement.style.display || '';
+            this.container.style.visibility = this.originalElement.style.visibility || '';
+
+            // ...then visually hide the native <select> WITHOUT touching display/visibility,
+            // so consumer-driven display/visibility changes (displayIf, visibleIf, inline
+            // onchange handlers) stay observable and can be mirrored onto the container.
+            this.originalElement.style.position = 'absolute';
+            this.originalElement.style.width = '1px';
+            this.originalElement.style.height = '1px';
+            this.originalElement.style.overflow = 'hidden';
+            this.originalElement.style.opacity = '0';
+            this.originalElement.style.pointerEvents = 'none';
+
+            this._visibilityObserver = new MutationObserver(() => {
+                this.container.style.display = this.originalElement.style.display || '';
+                this.container.style.visibility = this.originalElement.style.visibility || '';
+            });
+            this._visibilityObserver.observe(this.originalElement, {
+                attributes: true,
+                attributeFilter: ['style']
+            });
+
+            // Keep in sync when the <select>'s options are (re)populated dynamically
+            this._optionsObserver = new MutationObserver(() => {
+                this.items = this._extractItemsFromSelect(this.originalElement);
+                this.syncFromElement();
+                if (this.isOpen) {
+                    this._renderOptions(this.items);
+                }
+            });
+            this._optionsObserver.observe(this.originalElement, { childList: true });
         }
     }
 
     _render() {
-        this.input = document.createElement('input');
-        this.input.type = 'text';
-        this.input.placeholder = this.placeholder;
-
-        if (!this.searchable) {
-            this.input.readOnly = true;
-            this.input.classList.add('non-searchable');
+        // Trigger — the closed combobox. Single-select uses a read-only input; multi-select uses a
+        // div that renders the selected values as removable chips and grows in height to show them.
+        if (this.multiselect) {
+            this.trigger = document.createElement('div');
+            this.trigger.className = 'sd-trigger sd-trigger-multi';
+            this.trigger.tabIndex = 0;
+        } else {
+            this.trigger = document.createElement('input');
+            this.trigger.type = 'text';
+            this.trigger.className = 'sd-trigger';
+            this.trigger.placeholder = this.placeholder;
+            this.trigger.readOnly = true;
+        }
+        if (this.buildMode && this.container.id) {
+            this.trigger.id = this.container.id + '_sd-trigger';
+            if (this.label && !this.multiselect) {
+                this.label.htmlFor = this.trigger.id;
+            }
         }
 
+        // Popup menu (opens on click)
         this.optionsEl = document.createElement('div');
         this.optionsEl.className = 'options';
 
-        this.container.appendChild(this.input);
-        this.container.appendChild(this.optionsEl);
+        if (this.searchable) {
+            // Search row on top of the popup: search box + erase icon
+            // (mirrors Polarion's JComboBox-SearchBox / JComboBox-EraseIcon)
+            const searchRow = document.createElement('div');
+            searchRow.className = 'search-row';
 
-        if (this.isSelect && this.originalElement.value) {
+            this.searchInput = document.createElement('input');
+            this.searchInput.type = 'text';
+            this.searchInput.className = 'search-box';
+            // size=1 keeps the input's intrinsic width tiny so it doesn't blow up the
+            // popup's max-content width; flex:1 then stretches it to the list width.
+            this.searchInput.size = 1;
+
+            this.eraseIcon = document.createElement('img');
+            this.eraseIcon.className = 'erase';
+            this.eraseIcon.src = '/polarion/ria/images/search_combo_erase.png';
+            this.eraseIcon.alt = '';
+            this.eraseIcon.addEventListener('mousedown', e => {
+                e.preventDefault();
+                this.searchInput.value = '';
+                this.activeIndex = -1;
+                this._renderOptions(this.items);
+                this.searchInput.focus();
+            });
+
+            searchRow.appendChild(this.searchInput);
+            searchRow.appendChild(this.eraseIcon);
+            this.optionsEl.appendChild(searchRow);
+        }
+
+        // Scrollable items list
+        this.itemsEl = document.createElement('div');
+        this.itemsEl.className = 'items';
+        this.optionsEl.appendChild(this.itemsEl);
+
+        this.container.appendChild(this.trigger);
+
+        // The popup is rendered into a portal appended to <body> (position:fixed) rather than
+        // nested in the container. This lets it escape any ancestor overflow clipping (narrow side
+        // panels, scrollable modals) and its width is driven in JS from the trigger, so it always
+        // shows in full. Hidden until opened.
+        this.portal = document.createElement('div');
+        this.portal.className = 'sd-portal';
+        this.portal.style.display = 'none';
+        this.portal.appendChild(this.optionsEl);
+        document.body.appendChild(this.portal);
+
+        if (this.multiselect) {
+            this._updateTriggerFromSelection();
+        } else if (!this.buildMode && this.isSelect && this.originalElement.value) {
             const selected = this.items.find(
                 item => item.value === this.originalElement.value
             );
             if (selected) {
-                this.input.value = selected.label;
+                this.trigger.value = selected.label;
             }
         }
+        this._applyTriggerClass();
     }
 
     _bindEvents() {
-        if (this.searchable) {
-            // Add filtering logic, but only for dropdowns which have this logic enabled
-            this.input.addEventListener('input', () => {
-                const query = this.input.value.toLowerCase();
-                const filtered = this.items.filter(item =>
-                    item.label.toLowerCase().includes(query)
-                );
-                this._renderOptions(filtered);
-                this._open();
-            });
-        }
-
-        // Sequential clicks on input field should trigger open/close logic
-        this.input.addEventListener('mousedown', e => {
+        // Clicking the trigger opens/closes the popup
+        this.trigger.addEventListener('mousedown', e => {
             e.preventDefault(); // critical: prevents focus-triggered reopen
-
             if (this.isOpen) {
                 this._close();
             } else {
                 this._open();
-                this.input.focus();
             }
         });
 
-        // We should handle blur events to validate user input. If entered value doesn't correspond any available option,
-        // dropdown selection will be reset
-        this.input.addEventListener('blur', () => {
-            // Should be timed out, otherwise disturbs item selection via mouse
-            this._blurTimeoutId = setTimeout(() => {
-                this._blurTimeoutId = null;
-                if (this.searchable) {
-                    const text = this.input.value.trim();
-                    if (!text) {
-                        this.selectItem(null);
-                        return;
-                    }
-                    const match = this.items.find(
-                        item => item.label === text
-                    );
-                    this.selectItem(match);
+        if (this.searchable) {
+            this.searchInput.addEventListener('input', () => {
+                const query = this.searchInput.value.toLowerCase();
+                const filtered = this.items.filter(item =>
+                    item.label.toLowerCase().includes(query)
+                );
+                this.activeIndex = -1;
+                this._renderOptions(filtered);
+            });
+
+            this.searchInput.addEventListener('keydown', e => {
+                if (e.key === 'ArrowDown') {
+                    e.preventDefault();
+                    this._handleArrowDown();
+                } else if (e.key === 'ArrowUp') {
+                    e.preventDefault();
+                    this._handleArrowUp();
+                } else if (e.key === 'Enter') {
+                    e.preventDefault();
+                    this._handleEnter();
+                } else if (e.key === 'Escape') {
+                    this._close();
                 }
-                this._close();
-            }, SearchableDropdown.BLUR_DELAY_MS);
-        });
+            });
+        }
 
-        // Better UX - add possibility to navigate the list and select items via keyboard
-        this.input.addEventListener('keydown', e => {
-            if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                this._handleArrowDown();
-            }
-
-            if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                this._handleArrowUp();
-            }
-
-            if (e.key === 'Enter') {
-                e.preventDefault();
-                this._handleEnter();
-            }
-
-            if (e.key === 'Escape') {
-                this._close();
-            }
-        });
-
-        // Focusing input element should automatically open dropdown's list
-        this.input.addEventListener('focus', () => {
-            this._open();
-        });
-
-        // Clicking outside of component should automatically close dropdown's list
+        // Clicking outside of the component closes the popup. The popup lives in a body-level
+        // portal, so it must be checked separately from the container.
         document.addEventListener('mousedown', e => {
-            if (!this.container.contains(e.target)) {
+            if (!this.container.contains(e.target) && !this.portal.contains(e.target)) {
                 this._close();
             }
         });
+
+        // Keep the trigger in sync when the underlying <select> value is changed externally
+        // (e.g. a consumer sets select.value and dispatches 'change'). syncFromElement never
+        // dispatches, so this cannot loop.
+        if (this.isSelect) {
+            this.originalElement.addEventListener('change', () => this.syncFromElement());
+        }
     }
 
     _renderOptions(list) {
-        this.optionsEl.innerHTML = '';
+        this.itemsEl.innerHTML = '';
         this._visibleItems = list;
 
         list.forEach((item, index) => {
             const option = document.createElement('div');
             option.className = 'option';
-            option.textContent = item.label;
 
-            if (item.value === this.value) {
-                option.classList.add('selected');
+            if (this.multiselect) {
+                option.classList.add('multiselect-option');
+                const checkbox = document.createElement('input');
+                checkbox.type = 'checkbox';
+                checkbox.checked = !!item.selected;
+                checkbox.tabIndex = -1;
+                option.appendChild(checkbox);
+                const labelSpan = document.createElement('span');
+                labelSpan.className = 'option-label';
+                labelSpan.textContent = item.label;
+                option.appendChild(labelSpan);
+            } else {
+                option.textContent = item.label;
+            }
+
+            if (this.preserveOptionClasses && item.className) {
+                option.classList.add(...item.className.split(/\s+/).filter(Boolean));
             }
 
             if (index === this.activeIndex) {
                 option.classList.add('active');
             }
 
-            option.addEventListener('mousedown', () => {
+            // Highlight follows the mouse — only one option is highlighted at a time
+            option.addEventListener('mouseover', () => {
+                this.activeIndex = index;
+                this._paintActive();
+            });
+
+            option.addEventListener('mousedown', e => {
+                e.preventDefault();
+                // Stop the event before it reaches the document-level outside-click handler:
+                // selectItem() may re-render the list (multi-select), detaching this option, after
+                // which portal.contains(e.target) would be false and wrongly close the popup.
+                e.stopPropagation();
                 this.selectItem(item);
             });
 
-            this.optionsEl.appendChild(option);
+            this.itemsEl.appendChild(option);
         });
     }
 
-    _handleArrowDown() {
-        if (!this.isOpen) {
-            this._open();
-            this.activeIndex = 0;
-        } else {
-            this.activeIndex = (this.activeIndex + 1) % this._visibleItems.length;
+    _paintActive() {
+        const options = this.itemsEl.children;
+        for (let i = 0; i < options.length; i++) {
+            options[i].classList.toggle('active', i === this.activeIndex);
         }
+    }
 
+    _handleArrowDown() {
+        if (!this._visibleItems || this._visibleItems.length === 0) {
+            return;
+        }
+        this.activeIndex = (this.activeIndex + 1) % this._visibleItems.length;
         this._refreshActive();
     }
 
     _handleArrowUp() {
-        if (!this.isOpen) {
-            this._open();
-            this.activeIndex = this._visibleItems.length - 1;
-        } else {
-            const visibleLength = this._visibleItems.length;
-            if (this.activeIndex === -1) {
-                this.activeIndex = visibleLength - 1;
-            } else {
-                this.activeIndex = (this.activeIndex - 1 + visibleLength) % visibleLength;
-            }
+        if (!this._visibleItems || this._visibleItems.length === 0) {
+            return;
         }
-
+        this.activeIndex = this.activeIndex <= 0
+            ? this._visibleItems.length - 1
+            : this.activeIndex - 1;
         this._refreshActive();
     }
 
     _handleEnter() {
-        if (!this.isOpen) {
-            return;
-        }
-
         const item = this._visibleItems[this.activeIndex];
         if (item) {
             this.selectItem(item);
@@ -269,7 +402,7 @@ export default class SearchableDropdown {
     }
 
     _scrollActiveIntoView() {
-        const active = this.optionsEl.querySelector('.option.active');
+        const active = this.itemsEl.querySelector('.option.active');
         if (active) {
             active.scrollIntoView({ block: 'nearest' });
         }
@@ -279,37 +412,128 @@ export default class SearchableDropdown {
         if (this.isOpen) {
             return;
         }
-
         this.isOpen = true;
-
+        this.container.classList.add('open');
+        // Highlight the currently selected item on open (single-select only, and only if something
+        // is actually selected). The highlight then follows the mouse/keyboard. Multi-select shows
+        // its state via checkboxes, so nothing is pre-highlighted.
+        this.activeIndex = (!this.multiselect && this.trigger.value)
+            ? this.items.findIndex(item => item.value === this.value)
+            : -1;
+        if (this.searchable) {
+            this.searchInput.value = '';
+        }
         this._renderOptions(this.items);
-        this.activeIndex = this._visibleItems.findIndex(item => item.value === this.value);
         this._show();
-        this._scrollActiveIntoView();
+        // Reposition the portal while open if the page scrolls or resizes (capture phase catches
+        // scrolling in nested containers such as the document side panel).
+        if (!this._repositionHandler) {
+            this._repositionHandler = () => {
+                if (this.isOpen) {
+                    this._position();
+                }
+            };
+        }
+        window.addEventListener('scroll', this._repositionHandler, true);
+        window.addEventListener('resize', this._repositionHandler);
+        if (this.searchable) {
+            this.searchInput.focus();
+        }
     }
 
     _close() {
         if (!this.isOpen) {
             return;
         }
-
         this.isOpen = false;
+        this.container.classList.remove('open');
         this._hide();
+        if (this._repositionHandler) {
+            window.removeEventListener('scroll', this._repositionHandler, true);
+            window.removeEventListener('resize', this._repositionHandler);
+        }
         this.activeIndex = -1;
     }
 
     _show() {
-        this.optionsEl.style.display = 'block';
+        this.portal.style.display = 'block';
+        this._position();
+    }
 
-        let boundingRect = this.optionsEl.getBoundingClientRect();
-        if (boundingRect.bottom > (window.innerHeight || document.documentElement.clientHeight)) {
+    // Position the body-level portal under (or above) the trigger, matching the trigger's width so
+    // the popup's min-width (trigger width + 35px) resolves correctly.
+    _position() {
+        const rect = this.trigger.getBoundingClientRect();
+        this.portal.style.position = 'fixed';
+        this.portal.style.left = rect.left + 'px';
+        this.portal.style.width = rect.width + 'px';
+
+        this.optionsEl.classList.remove('dropup');
+        this.portal.style.top = rect.bottom + 'px';
+
+        const popupHeight = this.optionsEl.offsetHeight;
+        const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+        if (rect.bottom + popupHeight > viewportHeight && rect.top - popupHeight > 0) {
             this.optionsEl.classList.add('dropup');
+            this.portal.style.top = rect.top + 'px';
         }
     }
 
     _hide() {
-        this.optionsEl.style.display = 'none';
+        this.portal.style.display = 'none';
         this.optionsEl.classList.remove('dropup');
+    }
+
+    _fireChangeListener() {
+        if (typeof this.changeListener === 'function') {
+            this.changeListener(this);
+        }
+    }
+
+    _updateTriggerFromSelection() {
+        if (this.multiselect) {
+            this._renderChips();
+            return;
+        }
+        const selected = this.items.filter(i => i.selected);
+        this.trigger.value = selected.length ? selected[0].label : '';
+        this._applyTriggerClass();
+    }
+
+    // Multi-select trigger content: one removable chip per selected value (empty → placeholder).
+    _renderChips() {
+        this.trigger.innerHTML = '';
+        const selected = this.items.filter(i => i.selected);
+        if (selected.length === 0) {
+            const placeholder = document.createElement('span');
+            placeholder.className = 'sd-placeholder';
+            placeholder.textContent = this.placeholder;
+            this.trigger.appendChild(placeholder);
+            return;
+        }
+        selected.forEach(item => {
+            const chip = document.createElement('span');
+            chip.className = 'sd-chip';
+
+            const label = document.createElement('span');
+            label.className = 'sd-chip-label';
+            label.textContent = item.label;
+            chip.appendChild(label);
+
+            const remove = document.createElement('span');
+            remove.className = 'sd-chip-remove';
+            remove.textContent = '×';
+            remove.title = 'Remove';
+            remove.addEventListener('mousedown', e => {
+                e.preventDefault();
+                // Don't let the trigger's open/close handler fire when removing a chip.
+                e.stopPropagation();
+                this.selectItem(item);
+            });
+            chip.appendChild(remove);
+
+            this.trigger.appendChild(chip);
+        });
     }
 
     /* ---------- Public API ---------- */
@@ -325,20 +549,77 @@ export default class SearchableDropdown {
     }
 
     refresh() {
-        this.items = this.isSelect
-            ? this._extractItemsFromSelect(this.originalElement)
-            : this.items;
+        if (!this.buildMode) {
+            this.items = this.isSelect
+                ? this._extractItemsFromSelect(this.originalElement)
+                : this.items;
+        }
         this.restoreSelection();
     }
 
+    // Sync the trigger display to the underlying <select>'s current value (no change event fired).
+    // Called by ExtensionContext.setSelector/setValue after a programmatic value change.
+    syncFromElement() {
+        if (this.buildMode) {
+            return;
+        }
+        if (this.multiselect) {
+            this.items = this._extractItemsFromSelect(this.originalElement);
+            this._updateTriggerFromSelection();
+            return;
+        }
+        if (this.isSelect && this.originalElement.selectedIndex === -1 && this.originalElement.options.length > 0) {
+            // Native single-select left blank (value cleared) — keep the first option selected.
+            this.originalElement.selectedIndex = 0;
+        }
+        const value = this.isSelect ? this.originalElement.value : this.trigger.value;
+        const item = this.items.find(i => i.value === value);
+        this.trigger.value = item ? item.label : '';
+        this._applyTriggerClass();
+    }
+
+    _applyTriggerClass() {
+        // The multi-select trigger is a chip container, not a value input — don't rewrite its class.
+        if (this.multiselect || !this.preserveOptionClasses) {
+            return;
+        }
+        const selected = this.buildMode
+            ? this.items.find(i => i.selected)
+            : this.items.find(i => i.value === this.value);
+        this.trigger.className = 'sd-trigger' + (selected && selected.className ? ' ' + selected.className : '');
+    }
+
     selectItem(item, preventClosing = false) {
-        // Cancel any pending blur timeout to prevent it from overwriting this selection
-        if (this._blurTimeoutId) {
-            clearTimeout(this._blurTimeoutId);
-            this._blurTimeoutId = null;
+        if (this.multiselect) {
+            if (item) {
+                item.selected = !item.selected;
+                // Mirror the toggle onto the native <select multiple> so it stays the source of
+                // truth for consumers that read select.selectedOptions.
+                if (this.isSelect) {
+                    const option = Array.from(this.originalElement.options)
+                        .find(o => o.value === item.value);
+                    if (option) {
+                        option.selected = item.selected;
+                    }
+                    this.originalElement.dispatchEvent(new Event('change', { bubbles: true }));
+                }
+            }
+            this._updateTriggerFromSelection();
+            // Keep the popup open and reflect the toggled checkbox.
+            this._renderOptions(this._visibleItems || this.items);
+            this._saveSelection(null);
+            this._fireChangeListener();
+            return;
         }
 
-        this.input.value = item ? item.label : "";
+        if (this.buildMode) {
+            this.items.forEach(i => i.selected = !!item && i.value === item.value);
+            this._updateTriggerFromSelection();
+        } else {
+            this.trigger.value = item ? item.label : '';
+            this._applyTriggerClass();
+        }
+
         if (!preventClosing) {
             this._close();
         }
@@ -351,27 +632,148 @@ export default class SearchableDropdown {
         }
 
         this._saveSelection(item ? item.value : null);
+        this._fireChangeListener();
+    }
+
+    /* ---------- Build-mode API (drop-in for CustomSelect) ---------- */
+
+    // Append a selectable option. Returns lightweight handles whose classList mutations are
+    // mirrored onto the rendered option — this preserves the CustomSelect contract where callers do
+    // `addOption(...).label.classList.add('parent')` to mark a global-scope config.
+    addOption(value, text) {
+        const item = {
+            value,
+            label: text !== undefined && text !== null ? text : value,
+            className: '',
+            selected: false
+        };
+        this.items.push(item);
+        // Single-select defaults to the first option (no empty/placeholder state), matching a
+        // native <select>. A later selectValue() overrides it.
+        if (!this.multiselect && this.items.length === 1) {
+            item.selected = true;
+            this._updateTriggerFromSelection();
+        }
+        if (this.isOpen) {
+            this._renderOptions(this.items);
+        }
+        const proxy = this._optionClassHandle(item);
+        return { checkbox: proxy, label: proxy };
+    }
+
+    _optionClassHandle(item) {
+        const mutate = (transform) => {
+            const classes = new Set((item.className || '').split(/\s+/).filter(Boolean));
+            transform(classes);
+            item.className = [...classes].join(' ');
+            if (this.isOpen) {
+                this._renderOptions(this._visibleItems || this.items);
+            }
+            this._applyTriggerClass();
+        };
+        return {
+            classList: {
+                add: (cls) => mutate(classes => classes.add(cls)),
+                remove: (cls) => mutate(classes => classes.delete(cls)),
+                toggle: (cls) => mutate(classes => classes.has(cls) ? classes.delete(cls) : classes.add(cls))
+            }
+        };
+    }
+
+    empty() {
+        this.items = [];
+        this.activeIndex = -1;
+        this.trigger.value = '';
+        this._applyTriggerClass();
+        if (this.isOpen) {
+            this._renderOptions(this.items);
+        }
+    }
+
+    containsOption(optionValue) {
+        return this.items.some(i => i.value === optionValue);
+    }
+
+    getSelectedValue() {
+        if (this.multiselect) {
+            return this.items.filter(i => i.selected).map(i => i.value);
+        }
+        if (this.buildMode) {
+            const selected = this.items.find(i => i.selected);
+            return selected ? selected.value : '';
+        }
+        return this.isSelect ? this.originalElement.value : this.trigger.value;
+    }
+
+    getSelectedText() {
+        if (this.multiselect) {
+            return this.items.filter(i => i.selected).map(i => i.label);
+        }
+        const selected = this.items.find(i => i.selected);
+        return selected ? selected.label : '';
+    }
+
+    selectValue(value) {
+        if (this.buildMode) {
+            this.items.forEach(i => i.selected = i.value === value);
+            // Single-select never stays empty — if the value matched nothing, fall back to the
+            // first option (like a native <select>).
+            if (!this.multiselect && this.items.length > 0 && !this.items.some(i => i.selected)) {
+                this.items[0].selected = true;
+            }
+            this._updateTriggerFromSelection();
+            if (this.isOpen) {
+                this._renderOptions(this._visibleItems || this.items);
+            }
+            this._fireChangeListener();
+        } else if (this.isSelect) {
+            this.originalElement.value = value;
+            // Native single-select: if the value didn't match any option, keep the first selected
+            // rather than leaving the control blank.
+            if (!this.multiselect && this.originalElement.selectedIndex === -1 && this.originalElement.options.length > 0) {
+                this.originalElement.selectedIndex = 0;
+            }
+            this.syncFromElement();
+        }
+    }
+
+    selectMultipleValues(values) {
+        this.items.forEach(i => i.selected = !!values && values.includes(i.value));
+        this._updateTriggerFromSelection();
+        if (this.isOpen) {
+            this._renderOptions(this._visibleItems || this.items);
+        }
+        this._fireChangeListener();
     }
 
     get id() {
-        return this.originalElement.id;
+        return this.buildMode
+            ? (this.container ? this.container.id : undefined)
+            : this.originalElement.id;
     }
 
     get value() {
+        if (this.buildMode || this.multiselect) {
+            return this.getSelectedValue();
+        }
         return this.isSelect
             ? this.originalElement.value
-            : this.input.value;
+            : this.trigger.value;
     }
 
     set value(val) {
+        if (this.buildMode) {
+            this.selectValue(val);
+            return;
+        }
         if (this.isSelect) {
             const item = this.items.find(i => i.value === val);
             if (item) {
                 this.originalElement.value = val;
-                this.input.value = item.label;
+                this.trigger.value = item.label;
             }
         } else {
-            this.input.value = val;
+            this.trigger.value = val;
         }
     }
 }

--- a/app/src/main/resources/js/modules/SearchableDropdown.js
+++ b/app/src/main/resources/js/modules/SearchableDropdown.js
@@ -272,6 +272,18 @@ export default class SearchableDropdown {
             }
         });
 
+        // Keyboard navigation. When searchable the focus is on the search box; otherwise it stays on
+        // the trigger — so the trigger also handles keys, both to open the closed popup and to drive
+        // an open one (arrows/enter/escape) when there is no search box.
+        this.trigger.addEventListener('keydown', e => {
+            if (this.isOpen) {
+                this._handleKeydown(e);
+            } else if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                this._open();
+            }
+        });
+
         if (this.searchable) {
             this.searchInput.addEventListener('input', () => {
                 const query = this.searchInput.value.toLowerCase();
@@ -282,35 +294,39 @@ export default class SearchableDropdown {
                 this._renderOptions(filtered);
             });
 
-            this.searchInput.addEventListener('keydown', e => {
-                if (e.key === 'ArrowDown') {
-                    e.preventDefault();
-                    this._handleArrowDown();
-                } else if (e.key === 'ArrowUp') {
-                    e.preventDefault();
-                    this._handleArrowUp();
-                } else if (e.key === 'Enter') {
-                    e.preventDefault();
-                    this._handleEnter();
-                } else if (e.key === 'Escape') {
-                    this._close();
-                }
-            });
+            this.searchInput.addEventListener('keydown', e => this._handleKeydown(e));
         }
 
         // Clicking outside of the component closes the popup. The popup lives in a body-level
-        // portal, so it must be checked separately from the container.
-        document.addEventListener('mousedown', e => {
+        // portal, so it must be checked separately from the container. Stored on the instance so
+        // destroy() can unbind it.
+        this._outsideClickHandler = e => {
             if (!this.container.contains(e.target) && !this.portal.contains(e.target)) {
                 this._close();
             }
-        });
+        };
+        document.addEventListener('mousedown', this._outsideClickHandler);
 
         // Keep the trigger in sync when the underlying <select> value is changed externally
         // (e.g. a consumer sets select.value and dispatches 'change'). syncFromElement never
         // dispatches, so this cannot loop.
         if (this.isSelect) {
             this.originalElement.addEventListener('change', () => this.syncFromElement());
+        }
+    }
+
+    _handleKeydown(e) {
+        if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            this._handleArrowDown();
+        } else if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            this._handleArrowUp();
+        } else if (e.key === 'Enter') {
+            e.preventDefault();
+            this._handleEnter();
+        } else if (e.key === 'Escape') {
+            this._close();
         }
     }
 
@@ -436,8 +452,12 @@ export default class SearchableDropdown {
         }
         window.addEventListener('scroll', this._repositionHandler, true);
         window.addEventListener('resize', this._repositionHandler);
+        // Move focus so keyboard navigation works: to the search box if present, otherwise to the
+        // trigger itself (the trigger's mousedown preventDefault suppressed the click-focus).
         if (this.searchable) {
             this.searchInput.focus();
+        } else {
+            this.trigger.focus();
         }
     }
 
@@ -463,16 +483,28 @@ export default class SearchableDropdown {
     // Position the body-level portal under (or above) the trigger, matching the trigger's width so
     // the popup's min-width (trigger width + 35px) resolves correctly.
     _position() {
+        const gap = 4;
         const rect = this.trigger.getBoundingClientRect();
         this.portal.style.position = 'fixed';
-        this.portal.style.left = rect.left + 'px';
+        // Keep the portal the trigger's width so the popup's min-width (trigger + 35px) resolves.
         this.portal.style.width = rect.width + 'px';
-
         this.optionsEl.classList.remove('dropup');
+        // Default: popup aligned to the trigger's left edge, opening downward.
+        this.portal.style.left = rect.left + 'px';
         this.portal.style.top = rect.bottom + 'px';
 
+        const popupWidth = this.optionsEl.offsetWidth;
         const popupHeight = this.optionsEl.offsetHeight;
+        const viewportWidth = window.innerWidth || document.documentElement.clientWidth;
         const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+
+        // Horizontal: the popup can be wider than the trigger; if it would overflow the right edge,
+        // shift it left so its right edge fits the viewport (like Polarion's native combo).
+        if (rect.left + popupWidth > viewportWidth - gap) {
+            this.portal.style.left = Math.max(gap, viewportWidth - popupWidth - gap) + 'px';
+        }
+
+        // Vertical: flip above the trigger when it wouldn't fit below.
         if (rect.bottom + popupHeight > viewportHeight && rect.top - popupHeight > 0) {
             this.optionsEl.classList.add('dropup');
             this.portal.style.top = rect.top + 'px';
@@ -555,6 +587,32 @@ export default class SearchableDropdown {
                 : this.items;
         }
         this.restoreSelection();
+    }
+
+    // Tear down the instance: remove the body-level portal, disconnect observers, and unbind the
+    // global listeners. Call this when a consumer rebuilds/replaces a pane that owns dropdowns so
+    // portals and document/window listeners don't accumulate.
+    destroy() {
+        this._close();
+        if (this.portal) {
+            this.portal.remove();
+        }
+        if (this._visibilityObserver) {
+            this._visibilityObserver.disconnect();
+        }
+        if (this._optionsObserver) {
+            this._optionsObserver.disconnect();
+        }
+        if (this._outsideClickHandler) {
+            document.removeEventListener('mousedown', this._outsideClickHandler);
+        }
+        if (this._repositionHandler) {
+            window.removeEventListener('scroll', this._repositionHandler, true);
+            window.removeEventListener('resize', this._repositionHandler);
+        }
+        if (this.originalElement && this.originalElement._searchableDropdown === this) {
+            delete this.originalElement._searchableDropdown;
+        }
     }
 
     // Sync the trigger display to the underlying <select>'s current value (no change event fired).
@@ -709,8 +767,14 @@ export default class SearchableDropdown {
         if (this.multiselect) {
             return this.items.filter(i => i.selected).map(i => i.label);
         }
-        const selected = this.items.find(i => i.selected);
-        return selected ? selected.label : '';
+        if (this.buildMode) {
+            const selected = this.items.find(i => i.selected);
+            return selected ? selected.label : '';
+        }
+        // Element mode (single) doesn't maintain items[].selected — derive the label from the live
+        // value so getSelectedText() and getSelectedValue() never disagree.
+        const item = this.items.find(i => i.value === this.value);
+        return item ? item.label : '';
     }
 
     selectValue(value) {

--- a/app/src/test/js/modules/ConfigurationsPaneTest.js
+++ b/app/src/test/js/modules/ConfigurationsPaneTest.js
@@ -1,5 +1,4 @@
 import ConfigurationsPane from '../../../main/resources/js/modules/ConfigurationsPane.js';
-import CustomSelect from '../../../main/resources/js/modules/CustomSelect.js';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { JSDOM } from 'jsdom';
@@ -16,7 +15,7 @@ describe('ConfigurationsPane', function () {
                 <div id="edit-configuration-pane"></div>
                 <input id="new-configuration-input"/>
                 <input id="edit-configuration-input"/>
-                <div id="configurations-select"></div>
+                <select id="configurations-select"></select>
                 <div id="configurations-label"></div>
                 <div id="configurations-load-error" style="display:none"></div>
                 <div id="configuration-save-error" style="display:none"></div>
@@ -30,6 +29,10 @@ describe('ConfigurationsPane', function () {
 
         global.window = window;
         global.document = document;
+        // jsdom's dispatchEvent requires an Event from the same realm as the element,
+        // so expose the window's Event constructor as the global one the modules use.
+        global.Event = window.Event;
+        global.MutationObserver = window.MutationObserver;
 
         ctxMock = {
             onClick: sinon.spy(),
@@ -41,13 +44,6 @@ describe('ConfigurationsPane', function () {
             scope: 'testScope',
             readAndFillRevisions: sinon.spy()
         };
-
-        sinon.stub(CustomSelect.prototype, 'addOption').returns({ checkbox: {}, label: {} });
-        sinon.stub(CustomSelect.prototype, 'empty');
-        sinon.stub(CustomSelect.prototype, 'selectValue');
-        sinon.stub(CustomSelect.prototype, 'getSelectedValue').returns('testConfig');
-        sinon.stub(CustomSelect.prototype, 'getAllCheckboxes').returns([]);
-        sinon.stub(CustomSelect.prototype, 'handleChange');
 
         preDelete = {
             then: (callback) => {
@@ -63,6 +59,8 @@ describe('ConfigurationsPane', function () {
     afterEach(function () {
         delete global.window;
         delete global.document;
+        delete global.Event;
+        delete global.MutationObserver;
         sinon.restore();
     });
 

--- a/app/src/test/js/modules/ConfigurationsPaneTest.js
+++ b/app/src/test/js/modules/ConfigurationsPaneTest.js
@@ -57,6 +57,8 @@ describe('ConfigurationsPane', function () {
     });
 
     afterEach(function () {
+        // Tear down the dropdown so its body-level portal and global listeners don't leak across tests.
+        configPane.configurationsSelect.destroy();
         delete global.window;
         delete global.document;
         delete global.Event;
@@ -94,5 +96,12 @@ describe('ConfigurationsPane', function () {
         configPane.getSelectedConfiguration = sinon.stub().returns('testConfig');
         configPane.deleteConfiguration();
         expect(ctxMock.callAsync.calledOnce).to.be.true;
+    });
+
+    it('should remove the dropdown portal on destroy', function () {
+        const before = document.querySelectorAll('.sd-portal').length;
+        expect(before).to.be.greaterThan(0);
+        configPane.configurationsSelect.destroy();
+        expect(document.querySelectorAll('.sd-portal').length).to.equal(before - 1);
     });
 });

--- a/app/src/test/js/modules/SearchableDropdownTest.js
+++ b/app/src/test/js/modules/SearchableDropdownTest.js
@@ -1,0 +1,133 @@
+import SearchableDropdown from '../../../main/resources/js/modules/SearchableDropdown.js';
+import { expect } from 'chai';
+import { JSDOM } from 'jsdom';
+
+describe('SearchableDropdown', function () {
+    let dom, window, document;
+
+    beforeEach(function () {
+        dom = new JSDOM(`<!DOCTYPE html>
+        <html lang="en">
+        <body>
+            <div id="build-container"></div>
+            <select id="multi" multiple>
+                <option value="a">A</option>
+                <option value="b">B</option>
+                <option value="c">C</option>
+            </select>
+        </body>
+        </html>`);
+
+        window = dom.window;
+        document = window.document;
+
+        global.window = window;
+        global.document = document;
+        global.Event = window.Event;
+        global.MutationObserver = window.MutationObserver;
+    });
+
+    afterEach(function () {
+        delete global.window;
+        delete global.document;
+        delete global.Event;
+        delete global.MutationObserver;
+    });
+
+    describe('build mode (CustomSelect-compatible API)', function () {
+        let dropdown;
+
+        beforeEach(function () {
+            dropdown = new SearchableDropdown({
+                selectContainer: document.getElementById('build-container'),
+                rememberSelection: false
+            });
+        });
+
+        afterEach(function () {
+            dropdown.destroy();
+        });
+
+        it('defaults the selection to the first added option', function () {
+            dropdown.addOption('a', 'Apple');
+            dropdown.addOption('b', 'Banana');
+            expect(dropdown.getSelectedValue()).to.equal('a');
+            expect(dropdown.getSelectedText()).to.equal('Apple');
+        });
+
+        it('selectValue selects a matching option', function () {
+            dropdown.addOption('a', 'Apple');
+            dropdown.addOption('b', 'Banana');
+            dropdown.selectValue('b');
+            expect(dropdown.getSelectedValue()).to.equal('b');
+            expect(dropdown.getSelectedText()).to.equal('Banana');
+        });
+
+        it('falls back to the first option when the value matches nothing', function () {
+            dropdown.addOption('a', 'Apple');
+            dropdown.addOption('b', 'Banana');
+            dropdown.selectValue('does-not-exist');
+            expect(dropdown.getSelectedValue()).to.equal('a');
+        });
+
+        it('containsOption and empty() behave as expected', function () {
+            dropdown.addOption('a', 'Apple');
+            expect(dropdown.containsOption('a')).to.be.true;
+            expect(dropdown.containsOption('x')).to.be.false;
+            dropdown.empty();
+            expect(dropdown.containsOption('a')).to.be.false;
+            expect(dropdown.getSelectedValue()).to.equal('');
+        });
+    });
+
+    describe('multi-select (native <select multiple>)', function () {
+        let dropdown, select;
+
+        beforeEach(function () {
+            select = document.getElementById('multi');
+            dropdown = new SearchableDropdown({
+                element: select,
+                multiselect: true,
+                rememberSelection: false
+            });
+        });
+
+        afterEach(function () {
+            dropdown.destroy();
+        });
+
+        it('starts with nothing selected', function () {
+            expect(dropdown.getSelectedValue()).to.deep.equal([]);
+        });
+
+        it('toggling an option mirrors onto the native <select multiple>', function () {
+            dropdown.selectItem(dropdown.items.find(i => i.value === 'b'));
+            expect(dropdown.getSelectedValue()).to.deep.equal(['b']);
+            expect(select.querySelector("option[value='b']").selected).to.be.true;
+        });
+
+        it('keeps multiple selected values', function () {
+            dropdown.selectItem(dropdown.items.find(i => i.value === 'a'));
+            dropdown.selectItem(dropdown.items.find(i => i.value === 'c'));
+            expect(dropdown.getSelectedValue()).to.deep.equal(['a', 'c']);
+        });
+
+        it('toggling the same option twice deselects it', function () {
+            const item = dropdown.items.find(i => i.value === 'a');
+            dropdown.selectItem(item);
+            dropdown.selectItem(item);
+            expect(dropdown.getSelectedValue()).to.deep.equal([]);
+            expect(select.querySelector("option[value='a']").selected).to.be.false;
+        });
+    });
+
+    it('destroy() removes the body-level portal', function () {
+        const dropdown = new SearchableDropdown({
+            selectContainer: document.getElementById('build-container'),
+            rememberSelection: false
+        });
+        expect(document.querySelectorAll('.sd-portal').length).to.equal(1);
+        dropdown.destroy();
+        expect(document.querySelectorAll('.sd-portal').length).to.equal(0);
+    });
+});

--- a/app/src/test/js/modules/SearchableDropdownTest.js
+++ b/app/src/test/js/modules/SearchableDropdownTest.js
@@ -121,6 +121,23 @@ describe('SearchableDropdown', function () {
         });
     });
 
+    it('empty() clears rendered chips in multi-select build mode', function () {
+        const dropdown = new SearchableDropdown({
+            selectContainer: document.getElementById('build-container'),
+            multiselect: true,
+            rememberSelection: false
+        });
+        dropdown.addOption('a', 'A');
+        dropdown.addOption('b', 'B');
+        dropdown.selectMultipleValues(['a', 'b']);
+        expect(dropdown.trigger.querySelectorAll('.sd-chip').length).to.equal(2);
+
+        dropdown.empty();
+        expect(dropdown.trigger.querySelectorAll('.sd-chip').length).to.equal(0);
+        expect(dropdown.getSelectedValue()).to.deep.equal([]);
+        dropdown.destroy();
+    });
+
     it('destroy() removes the body-level portal', function () {
         const dropdown = new SearchableDropdown({
             selectContainer: document.getElementById('build-container'),


### PR DESCRIPTION
### Proposed changes

it replaces both native `select` elements and the legacy checkbox-based CustomSelect across all extensions, plus a set of neutral, Polarion-matched form-control styles (checkboxes, radios, text inputs, toolbar buttons).

### Checklist


Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
