### PR TITLE
fix: add allowEmpty option to SearchableDropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,12 +440,23 @@ multi-select. Prefer it over a raw `<select>` or any bespoke widget.
   ```
 
 Key options: `multiselect` (removable chips + in-list checkboxes; the popup stays open while
-toggling), `searchable` (default `true`), `placeholder`, `rememberSelection` (cookie; usually pass
-`false`), `preserveOptionClasses` (mirror each `<option>`'s CSS class onto the rendered option — e.g.
-the `parent` class renders a global-scope configuration with an italic `global` marker). The popup is
-portalled into `document.body` so it is never clipped by an ancestor's `overflow` (narrow side
-panels, scrollable modals). It integrates with `ExtensionContext` (`setSelector` / `setValueById` /
-`displayIf`) and auto-refreshes when its `<select>` options are repopulated.
+toggling), `searchable` (default `true`), `placeholder`, `allowEmpty` (default `false` — a
+single-select then does **not** auto-select the first option; it stays unselected and shows the
+`placeholder` until the user picks, e.g. `{ allowEmpty: true, placeholder: 'Select…' }`),
+`rememberSelection` (cookie; usually pass `false`), `preserveOptionClasses` (mirror each `<option>`'s
+CSS class onto the rendered option — e.g. the `parent` class renders a global-scope configuration
+with an italic `global` marker).
+
+Per-option **icons**: give a source `<option>` a `data-icon="…"` (element mode) or pass a third
+argument to `addOption(value, text, icon)` (build mode); the icon is shown to the left of the label
+in the list and on the closed single-select trigger.
+
+The popup is portalled into `document.body` so it is never clipped by an ancestor's `overflow`
+(narrow side panels, scrollable modals). It integrates with `ExtensionContext` (`setSelector` /
+`setValueById` / `displayIf`) and auto-refreshes when its `<select>` options are repopulated. Call
+`destroy()` to tear an instance down (removes the portal and container, disconnects observers, and
+unbinds global listeners); re-wrapping the same `<select>` also disposes the previous instance
+automatically, so a pane that re-initialises its dropdowns won't stack duplicates.
 
 #### Shared control styling
 

--- a/app/src/main/resources/js/modules/SearchableDropdown.js
+++ b/app/src/main/resources/js/modules/SearchableDropdown.js
@@ -12,7 +12,8 @@ export default class SearchableDropdown {
                     placeholder = '',
                     searchable = true,
                     rememberSelection = true,
-                    preserveOptionClasses = false
+                    preserveOptionClasses = false,
+                    allowEmpty = false
                 }) {
         if (!element && !selectContainer) {
             throw new Error('SearchableDropdown: element or selectContainer is required');
@@ -49,12 +50,21 @@ export default class SearchableDropdown {
                 throw new Error('SearchableDropdown: element not found');
             }
             this.isSelect = this.originalElement.tagName === 'SELECT';
+            // If this element was already wrapped (e.g. a pane re-runs its dropdown init on save),
+            // tear the previous instance down first so we don't stack duplicate containers/portals.
+            if (this.originalElement._searchableDropdown) {
+                this.originalElement._searchableDropdown.destroy();
+            }
             this.items = this.isSelect
                 ? this._extractItemsFromSelect(this.originalElement)
                 : items;
         }
 
         this.multiselect = multiselect;
+        // When true, the single-select dropdown may stay unselected: it does not auto-select the
+        // first option and shows the placeholder (e.g. "Select…") until the user picks. Otherwise it
+        // behaves like a native <select> and always keeps an option selected.
+        this.allowEmpty = allowEmpty;
         this.label = label;
         this.changeListener = changeListener;
         this.rememberSelection =
@@ -143,6 +153,14 @@ export default class SearchableDropdown {
         }
 
         if (this.isSelect) {
+            // allowEmpty: a native <select> always auto-selects its first option — clear that so the
+            // control starts unselected (placeholder shown) unless an option is explicitly marked
+            // selected in the markup. The user must then choose.
+            if (this.allowEmpty
+                && !Array.from(this.originalElement.options).some(o => o.defaultSelected)) {
+                this.originalElement.selectedIndex = -1;
+            }
+
             // Mirror the element's current visibility onto the container...
             this.container.style.display = this.originalElement.style.display || '';
             this.container.style.visibility = this.originalElement.style.visibility || '';
@@ -150,6 +168,8 @@ export default class SearchableDropdown {
             // ...then visually hide the native <select> WITHOUT touching display/visibility,
             // so consumer-driven display/visibility changes (displayIf, visibleIf, inline
             // onchange handlers) stay observable and can be mirrored onto the container.
+            // Remember the original inline style so destroy() can restore the <select>.
+            this._originalElementCssText = this.originalElement.style.cssText;
             this.originalElement.style.position = 'absolute';
             this.originalElement.style.width = '1px';
             this.originalElement.style.height = '1px';
@@ -664,6 +684,16 @@ export default class SearchableDropdown {
         if (this.originalElement && this.originalElement._searchableDropdown === this) {
             delete this.originalElement._searchableDropdown;
         }
+        // In element mode we created the container as a sibling of the <select> and hid the
+        // <select>; remove the container and restore the <select> so nothing is left behind.
+        if (!this.buildMode) {
+            if (this.container && this.container.parentNode) {
+                this.container.remove();
+            }
+            if (this.originalElement && this._originalElementCssText !== undefined) {
+                this.originalElement.style.cssText = this._originalElementCssText;
+            }
+        }
     }
 
     // Sync the trigger display to the underlying <select>'s current value (no change event fired).
@@ -677,8 +707,9 @@ export default class SearchableDropdown {
             this._updateTriggerFromSelection();
             return;
         }
-        if (this.isSelect && this.originalElement.selectedIndex === -1 && this.originalElement.options.length > 0) {
-            // Native single-select left blank (value cleared) — keep the first option selected.
+        if (this.isSelect && !this.allowEmpty && this.originalElement.selectedIndex === -1 && this.originalElement.options.length > 0) {
+            // Native single-select left blank (value cleared) — keep the first option selected
+            // (unless allowEmpty lets it stay unselected to show the placeholder).
             this.originalElement.selectedIndex = 0;
         }
         const value = this.isSelect ? this.originalElement.value : this.trigger.value;
@@ -761,8 +792,8 @@ export default class SearchableDropdown {
         };
         this.items.push(item);
         // Single-select defaults to the first option (no empty/placeholder state), matching a
-        // native <select>. A later selectValue() overrides it.
-        if (!this.multiselect && this.items.length === 1) {
+        // native <select>. A later selectValue() overrides it. Skipped when allowEmpty is set.
+        if (!this.multiselect && !this.allowEmpty && this.items.length === 1) {
             item.selected = true;
             this._updateTriggerFromSelection();
         }
@@ -842,8 +873,8 @@ export default class SearchableDropdown {
         if (this.buildMode) {
             this.items.forEach(i => i.selected = i.value === value);
             // Single-select never stays empty — if the value matched nothing, fall back to the
-            // first option (like a native <select>).
-            if (!this.multiselect && this.items.length > 0 && !this.items.some(i => i.selected)) {
+            // first option (like a native <select>). Skipped when allowEmpty is set.
+            if (!this.multiselect && !this.allowEmpty && this.items.length > 0 && !this.items.some(i => i.selected)) {
                 this.items[0].selected = true;
             }
             this._updateTriggerFromSelection();
@@ -854,8 +885,8 @@ export default class SearchableDropdown {
         } else if (this.isSelect) {
             this.originalElement.value = value;
             // Native single-select: if the value didn't match any option, keep the first selected
-            // rather than leaving the control blank.
-            if (!this.multiselect && this.originalElement.selectedIndex === -1 && this.originalElement.options.length > 0) {
+            // rather than leaving the control blank. Skipped when allowEmpty is set.
+            if (!this.multiselect && !this.allowEmpty && this.originalElement.selectedIndex === -1 && this.originalElement.options.length > 0) {
                 this.originalElement.selectedIndex = 0;
             }
             this.syncFromElement();

--- a/app/src/main/resources/js/modules/SearchableDropdown.js
+++ b/app/src/main/resources/js/modules/SearchableDropdown.js
@@ -153,6 +153,10 @@ export default class SearchableDropdown {
         }
 
         if (this.isSelect) {
+            // Remember the original selection so destroy() can restore it (allowEmpty below may
+            // clear it to -1, which would otherwise leak to a later re-wrap of the same <select>).
+            this._originalSelectedIndex = this.originalElement.selectedIndex;
+
             // allowEmpty: a native <select> always auto-selects its first option — clear that so the
             // control starts unselected (placeholder shown) unless an option is explicitly marked
             // selected in the markup. The user must then choose.
@@ -692,6 +696,9 @@ export default class SearchableDropdown {
             }
             if (this.originalElement && this._originalElementCssText !== undefined) {
                 this.originalElement.style.cssText = this._originalElementCssText;
+            }
+            if (this.originalElement && this.isSelect && this._originalSelectedIndex !== undefined) {
+                this.originalElement.selectedIndex = this._originalSelectedIndex;
             }
         }
     }

--- a/app/src/test/js/modules/SearchableDropdownTest.js
+++ b/app/src/test/js/modules/SearchableDropdownTest.js
@@ -10,6 +10,10 @@ describe('SearchableDropdown', function () {
         <html lang="en">
         <body>
             <div id="build-container"></div>
+            <select id="single">
+                <option value="a">A</option>
+                <option value="b">B</option>
+            </select>
             <select id="multi" multiple>
                 <option value="a">A</option>
                 <option value="b">B</option>
@@ -136,6 +140,30 @@ describe('SearchableDropdown', function () {
         expect(dropdown.trigger.querySelectorAll('.sd-chip').length).to.equal(0);
         expect(dropdown.getSelectedValue()).to.deep.equal([]);
         dropdown.destroy();
+    });
+
+    it('single-select keeps the first option by default', function () {
+        const dropdown = new SearchableDropdown({ element: document.getElementById('single'), rememberSelection: false });
+        expect(dropdown.getSelectedValue()).to.equal('a');
+        dropdown.destroy();
+    });
+
+    it('allowEmpty leaves a native single-select unselected (shows placeholder)', function () {
+        const select = document.getElementById('single');
+        const dropdown = new SearchableDropdown({ element: select, allowEmpty: true, placeholder: 'Select...', rememberSelection: false });
+        expect(select.selectedIndex).to.equal(-1);
+        expect(dropdown.getSelectedValue()).to.equal('');
+        dropdown.destroy();
+    });
+
+    it('re-wrapping the same <select> does not stack duplicate containers/portals', function () {
+        const select = document.getElementById('multi');
+        new SearchableDropdown({ element: select, rememberSelection: false });
+        new SearchableDropdown({ element: select, rememberSelection: false });
+        new SearchableDropdown({ element: select, rememberSelection: false });
+        expect(document.querySelectorAll('.searchable-dropdown').length).to.equal(1);
+        expect(document.querySelectorAll('.sd-portal').length).to.equal(1);
+        select._searchableDropdown.destroy();
     });
 
     it('destroy() removes the body-level portal', function () {

--- a/app/src/test/js/modules/SearchableDropdownTest.js
+++ b/app/src/test/js/modules/SearchableDropdownTest.js
@@ -156,6 +156,17 @@ describe('SearchableDropdown', function () {
         dropdown.destroy();
     });
 
+    it('destroy() restores selectedIndex so allowEmpty does not leak to a re-wrap', function () {
+        const select = document.getElementById('single');
+        // First instance clears the selection (allowEmpty); re-wrapping without allowEmpty must see
+        // the first option again, not the -1 left behind.
+        new SearchableDropdown({ element: select, allowEmpty: true, placeholder: 'Select...', rememberSelection: false });
+        expect(select.selectedIndex).to.equal(-1);
+        const second = new SearchableDropdown({ element: select, rememberSelection: false });
+        expect(second.getSelectedValue()).to.equal('a');
+        second.destroy();
+    });
+
     it('re-wrapping the same <select> does not stack duplicate containers/portals', function () {
         const select = document.getElementById('multi');
         new SearchableDropdown({ element: select, rememberSelection: false });


### PR DESCRIPTION
### Proposed changes

Let single-select dropdowns stay unselected and show a placeholder until the user picks, instead of auto-selecting the first option. Also tear down a prior instance when re-wrapping the same 'select' and restore the element on destroy so no duplicate containers or portals are left behind.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
