### PR TITLE
fix: reflect native select state on searchabledropdown disabled options a11y

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,7 +455,8 @@ The popup is portalled into `document.body` so it is never clipped by an ancesto
 (narrow side panels, scrollable modals). It integrates with `ExtensionContext` (`setSelector` /
 `setValueById` / `displayIf`) and auto-refreshes when its `<select>` options are repopulated; it also
 mirrors the wrapped `<select>`'s `disabled` state (setting `select.disabled` dims the control and
-makes it non-interactive) and its `<option disabled>` options (dimmed, non-selectable). It exposes
+makes it non-interactive), its `<option disabled>` options (dimmed, non-selectable), and its `title`
+tooltip. It exposes
 full ARIA combobox/listbox semantics (`role`, `aria-expanded`, `aria-activedescendant`, per-option
 `aria-selected`/`aria-disabled`, and an `aria-label` derived from the associated `<label>`) so screen
 readers announce and navigate it like a native `<select>`. Call

--- a/README.md
+++ b/README.md
@@ -455,7 +455,10 @@ The popup is portalled into `document.body` so it is never clipped by an ancesto
 (narrow side panels, scrollable modals). It integrates with `ExtensionContext` (`setSelector` /
 `setValueById` / `displayIf`) and auto-refreshes when its `<select>` options are repopulated; it also
 mirrors the wrapped `<select>`'s `disabled` state (setting `select.disabled` dims the control and
-makes it non-interactive). Call
+makes it non-interactive) and its `<option disabled>` options (dimmed, non-selectable). It exposes
+full ARIA combobox/listbox semantics (`role`, `aria-expanded`, `aria-activedescendant`, per-option
+`aria-selected`/`aria-disabled`, and an `aria-label` derived from the associated `<label>`) so screen
+readers announce and navigate it like a native `<select>`. Call
 `destroy()` to tear an instance down (removes the portal and container, disconnects observers, and
 unbinds global listeners); re-wrapping the same `<select>` also disposes the previous instance
 automatically, so a pane that re-initialises its dropdowns won't stack duplicates.

--- a/README.md
+++ b/README.md
@@ -453,7 +453,9 @@ in the list and on the closed single-select trigger.
 
 The popup is portalled into `document.body` so it is never clipped by an ancestor's `overflow`
 (narrow side panels, scrollable modals). It integrates with `ExtensionContext` (`setSelector` /
-`setValueById` / `displayIf`) and auto-refreshes when its `<select>` options are repopulated. Call
+`setValueById` / `displayIf`) and auto-refreshes when its `<select>` options are repopulated; it also
+mirrors the wrapped `<select>`'s `disabled` state (setting `select.disabled` dims the control and
+makes it non-interactive). Call
 `destroy()` to tear an instance down (removes the portal and container, disconnects observers, and
 unbinds global listeners); re-wrapping the same `<select>` also disposes the previous instance
 automatically, so a pane that re-initialises its dropdowns won't stack duplicates.

--- a/app/src/main/resources/css/searchable-dropdown.css
+++ b/app/src/main/resources/css/searchable-dropdown.css
@@ -32,6 +32,12 @@
     outline: none;
 }
 
+/* Disabled state — mirrors the wrapped <select>'s `disabled`: dimmed and non-interactive. */
+.searchable-dropdown.disabled {
+    opacity: 0.55;
+    pointer-events: none;
+}
+
 /* Selected option's icon overlaid on the single-select trigger (the <input> can't hold markup);
    .has-icon makes room for it on the left. */
 .searchable-dropdown > input.sd-trigger.has-icon {
@@ -210,6 +216,13 @@
    Only one option is highlighted at a time (follows mouse/keyboard), managed via the .active class. */
 .sd-portal .option.active {
     background-color: #ebf7f8;
+}
+
+/* Disabled option (<option disabled>): dimmed and non-interactive; keyboard nav skips it. */
+.sd-portal .option.disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    pointer-events: none;
 }
 
 /* Optional per-option icon (from <option data-icon="…"> or addOption(value, text, icon)). */

--- a/app/src/main/resources/js/modules/SearchableDropdown.js
+++ b/app/src/main/resources/js/modules/SearchableDropdown.js
@@ -1,6 +1,7 @@
 export default class SearchableDropdown {
     static COOKIE_PREFIX = 'searchable_dropdown_';
     static COOKIE_EXPIRY_DAYS = 30;
+    static _idCounter = 0;
 
     constructor({
                     element = null,
@@ -79,10 +80,14 @@ export default class SearchableDropdown {
         this.preserveOptionClasses = preserveOptionClasses || this.buildMode;
         this.isOpen = false;
         this.activeIndex = -1;
+        // Unique id prefix for ARIA wiring (listbox + option ids, aria-controls/activedescendant).
+        this._uid = 'sd-' + (++SearchableDropdown._idCounter);
 
         this._createContainer();
         this._render();
         this._bindEvents();
+        // Reflect the <select>'s initial disabled state (needs the trigger created in _render).
+        this._syncDisabled();
     }
 
     _getCookieKey() {
@@ -201,9 +206,6 @@ export default class SearchableDropdown {
                 }
             });
             this._optionsObserver.observe(this.originalElement, { childList: true });
-
-            // Reflect the <select>'s initial disabled state onto the container.
-            this._syncDisabled();
         }
     }
 
@@ -215,6 +217,7 @@ export default class SearchableDropdown {
         }
         const disabled = this.originalElement.disabled;
         this.container.classList.toggle('disabled', disabled);
+        this.trigger.setAttribute('aria-disabled', disabled ? 'true' : 'false');
         if (disabled && this.isOpen) {
             this._close();
         }
@@ -241,6 +244,18 @@ export default class SearchableDropdown {
             }
         }
 
+        // Accessibility: expose the custom control as a combobox with a listbox popup so screen
+        // readers announce it like a native <select> (role, expanded state, label, active option).
+        this._listboxId = this._uid + '-listbox';
+        this.trigger.setAttribute('role', 'combobox');
+        this.trigger.setAttribute('aria-haspopup', 'listbox');
+        this.trigger.setAttribute('aria-expanded', 'false');
+        this.trigger.setAttribute('aria-controls', this._listboxId);
+        const labelText = this._resolveLabelText();
+        if (labelText) {
+            this.trigger.setAttribute('aria-label', labelText);
+        }
+
         // Popup menu (opens on click)
         this.optionsEl = document.createElement('div');
         this.optionsEl.className = 'options';
@@ -254,6 +269,10 @@ export default class SearchableDropdown {
             this.searchInput = document.createElement('input');
             this.searchInput.type = 'text';
             this.searchInput.className = 'search-box';
+            this.searchInput.setAttribute('role', 'searchbox');
+            this.searchInput.setAttribute('aria-label', 'Search');
+            this.searchInput.setAttribute('aria-controls', this._listboxId);
+            this.searchInput.setAttribute('autocomplete', 'off');
             // size=1 keeps the input's intrinsic width tiny so it doesn't blow up the
             // popup's max-content width; flex:1 then stretches it to the list width.
             this.searchInput.size = 1;
@@ -275,9 +294,14 @@ export default class SearchableDropdown {
             this.optionsEl.appendChild(searchRow);
         }
 
-        // Scrollable items list
+        // Scrollable items list — the listbox referenced by the trigger's aria-controls.
         this.itemsEl = document.createElement('div');
         this.itemsEl.className = 'items';
+        this.itemsEl.id = this._listboxId;
+        this.itemsEl.setAttribute('role', 'listbox');
+        if (this.multiselect) {
+            this.itemsEl.setAttribute('aria-multiselectable', 'true');
+        }
         this.optionsEl.appendChild(this.itemsEl);
 
         this.container.appendChild(this.trigger);
@@ -409,6 +433,8 @@ export default class SearchableDropdown {
         list.forEach((item, index) => {
             const option = document.createElement('div');
             option.className = 'option';
+            option.id = this._uid + '-opt-' + index;
+            option.setAttribute('role', 'option');
 
             if (this.multiselect) {
                 option.classList.add('multiselect-option');
@@ -443,7 +469,13 @@ export default class SearchableDropdown {
                 // Dimmed + non-interactive (CSS pointer-events:none); keyboard nav skips it and
                 // selectItem() ignores it.
                 option.classList.add('disabled');
+                option.setAttribute('aria-disabled', 'true');
             }
+
+            const isSelected = (this.multiselect || this.buildMode)
+                ? !!item.selected
+                : item.value === this.value;
+            option.setAttribute('aria-selected', isSelected ? 'true' : 'false');
 
             if (index === this.activeIndex) {
                 option.classList.add('active');
@@ -466,6 +498,7 @@ export default class SearchableDropdown {
 
             this.itemsEl.appendChild(option);
         });
+        this._updateActiveDescendant();
     }
 
     _paintActive() {
@@ -473,6 +506,7 @@ export default class SearchableDropdown {
         for (let i = 0; i < options.length; i++) {
             options[i].classList.toggle('active', i === this.activeIndex);
         }
+        this._updateActiveDescendant();
     }
 
     _createOptionIcon(src) {
@@ -481,6 +515,44 @@ export default class SearchableDropdown {
         icon.src = src;
         icon.alt = '';
         return icon;
+    }
+
+    // Accessible name for the combobox — from the passed label, the <select>'s aria-label, or the
+    // associated <label for="…">.
+    _resolveLabelText() {
+        if (this.label && this.label.textContent) {
+            return this.label.textContent.trim();
+        }
+        if (this.isSelect) {
+            const ariaLabel = this.originalElement.getAttribute('aria-label');
+            if (ariaLabel) {
+                return ariaLabel;
+            }
+            const id = this.originalElement.id;
+            if (id) {
+                try {
+                    const labelEl = document.querySelector('label[for="' + id + '"]');
+                    if (labelEl && labelEl.textContent) {
+                        return labelEl.textContent.trim();
+                    }
+                } catch (e) {
+                    // id not usable as a selector — ignore
+                }
+            }
+        }
+        return '';
+    }
+
+    // Point aria-activedescendant (on whichever element has focus) at the highlighted option so
+    // screen readers announce it during arrow-key navigation.
+    _updateActiveDescendant() {
+        const target = this.searchable ? this.searchInput : this.trigger;
+        const active = this.activeIndex >= 0 ? this.itemsEl.children[this.activeIndex] : null;
+        if (active && active.id) {
+            target.setAttribute('aria-activedescendant', active.id);
+        } else {
+            target.removeAttribute('aria-activedescendant');
+        }
     }
 
     // Next selectable (non-disabled) index in the given direction, wrapping around. Returns the
@@ -544,6 +616,7 @@ export default class SearchableDropdown {
         }
         this.isOpen = true;
         this.container.classList.add('open');
+        this.trigger.setAttribute('aria-expanded', 'true');
         // Highlight the currently selected item on open (single-select only, and only if something
         // is actually selected). The highlight then follows the mouse/keyboard. Multi-select shows
         // its state via checkboxes, so nothing is pre-highlighted.
@@ -581,6 +654,11 @@ export default class SearchableDropdown {
         }
         this.isOpen = false;
         this.container.classList.remove('open');
+        this.trigger.setAttribute('aria-expanded', 'false');
+        this.trigger.removeAttribute('aria-activedescendant');
+        if (this.searchable) {
+            this.searchInput.removeAttribute('aria-activedescendant');
+        }
         this._hide();
         if (this._repositionHandler) {
             window.removeEventListener('scroll', this._repositionHandler, true);

--- a/app/src/main/resources/js/modules/SearchableDropdown.js
+++ b/app/src/main/resources/js/modules/SearchableDropdown.js
@@ -86,8 +86,9 @@ export default class SearchableDropdown {
         this._createContainer();
         this._render();
         this._bindEvents();
-        // Reflect the <select>'s initial disabled state (needs the trigger created in _render).
+        // Reflect the <select>'s initial disabled state + title (need the trigger from _render).
         this._syncDisabled();
+        this._syncTitle();
     }
 
     _getCookieKey() {
@@ -191,10 +192,11 @@ export default class SearchableDropdown {
                 this.container.style.display = this.originalElement.style.display || '';
                 this.container.style.visibility = this.originalElement.style.visibility || '';
                 this._syncDisabled();
+                this._syncTitle();
             });
             this._visibilityObserver.observe(this.originalElement, {
                 attributes: true,
-                attributeFilter: ['style', 'disabled']
+                attributeFilter: ['style', 'disabled', 'title']
             });
 
             // Keep in sync when the <select>'s options are (re)populated dynamically
@@ -220,6 +222,19 @@ export default class SearchableDropdown {
         this.trigger.setAttribute('aria-disabled', disabled ? 'true' : 'false');
         if (disabled && this.isOpen) {
             this._close();
+        }
+    }
+
+    // Mirror the wrapped <select>'s title (tooltip) onto the visible trigger.
+    _syncTitle() {
+        if (!this.isSelect) {
+            return;
+        }
+        const title = this.originalElement.getAttribute('title');
+        if (title) {
+            this.trigger.setAttribute('title', title);
+        } else {
+            this.trigger.removeAttribute('title');
         }
     }
 

--- a/app/src/main/resources/js/modules/SearchableDropdown.js
+++ b/app/src/main/resources/js/modules/SearchableDropdown.js
@@ -122,6 +122,7 @@ export default class SearchableDropdown {
                 label: option.text,
                 className: option.className,
                 selected: option.selected,
+                disabled: option.disabled,
                 // Optional per-option icon: <option data-icon="/polarion/…/icon.svg">Label</option>
                 icon: option.getAttribute('data-icon') || ''
             }));
@@ -184,10 +185,11 @@ export default class SearchableDropdown {
             this._visibilityObserver = new MutationObserver(() => {
                 this.container.style.display = this.originalElement.style.display || '';
                 this.container.style.visibility = this.originalElement.style.visibility || '';
+                this._syncDisabled();
             });
             this._visibilityObserver.observe(this.originalElement, {
                 attributes: true,
-                attributeFilter: ['style']
+                attributeFilter: ['style', 'disabled']
             });
 
             // Keep in sync when the <select>'s options are (re)populated dynamically
@@ -199,6 +201,22 @@ export default class SearchableDropdown {
                 }
             });
             this._optionsObserver.observe(this.originalElement, { childList: true });
+
+            // Reflect the <select>'s initial disabled state onto the container.
+            this._syncDisabled();
+        }
+    }
+
+    // Mirror the wrapped <select>'s disabled state onto the container (dimmed + non-interactive via
+    // the .disabled CSS class). Driven by the visibility MutationObserver when the attribute toggles.
+    _syncDisabled() {
+        if (!this.isSelect) {
+            return;
+        }
+        const disabled = this.originalElement.disabled;
+        this.container.classList.toggle('disabled', disabled);
+        if (disabled && this.isOpen) {
+            this._close();
         }
     }
 
@@ -421,6 +439,12 @@ export default class SearchableDropdown {
                 option.classList.add(...item.className.split(/\s+/).filter(Boolean));
             }
 
+            if (item.disabled) {
+                // Dimmed + non-interactive (CSS pointer-events:none); keyboard nav skips it and
+                // selectItem() ignores it.
+                option.classList.add('disabled');
+            }
+
             if (index === this.activeIndex) {
                 option.classList.add('active');
             }
@@ -459,11 +483,24 @@ export default class SearchableDropdown {
         return icon;
     }
 
+    // Next selectable (non-disabled) index in the given direction, wrapping around. Returns the
+    // current index if every option is disabled.
+    _nextEnabledIndex(start, direction) {
+        const count = this._visibleItems.length;
+        for (let step = 1; step <= count; step++) {
+            const idx = (((start + direction * step) % count) + count) % count;
+            if (!this._visibleItems[idx].disabled) {
+                return idx;
+            }
+        }
+        return this.activeIndex;
+    }
+
     _handleArrowDown() {
         if (!this._visibleItems || this._visibleItems.length === 0) {
             return;
         }
-        this.activeIndex = (this.activeIndex + 1) % this._visibleItems.length;
+        this.activeIndex = this._nextEnabledIndex(this.activeIndex, 1);
         this._refreshActive();
     }
 
@@ -471,9 +508,7 @@ export default class SearchableDropdown {
         if (!this._visibleItems || this._visibleItems.length === 0) {
             return;
         }
-        this.activeIndex = this.activeIndex <= 0
-            ? this._visibleItems.length - 1
-            : this.activeIndex - 1;
+        this.activeIndex = this._nextEnabledIndex(this.activeIndex, -1);
         this._refreshActive();
     }
 
@@ -500,6 +535,11 @@ export default class SearchableDropdown {
 
     _open() {
         if (this.isOpen) {
+            return;
+        }
+        // A disabled control doesn't open (CSS also sets pointer-events:none; this guards the
+        // programmatic/keyboard paths).
+        if (this.isSelect && this.originalElement.disabled) {
             return;
         }
         this.isOpen = true;
@@ -738,6 +778,9 @@ export default class SearchableDropdown {
     }
 
     selectItem(item, preventClosing = false) {
+        if (item && item.disabled) {
+            return;
+        }
         if (this.multiselect) {
             if (item) {
                 item.selected = !item.selected;

--- a/app/src/main/resources/js/modules/SearchableDropdown.js
+++ b/app/src/main/resources/js/modules/SearchableDropdown.js
@@ -574,8 +574,11 @@ export default class SearchableDropdown {
     // current index if every option is disabled.
     _nextEnabledIndex(start, direction) {
         const count = this._visibleItems.length;
+        // From "no selection" (start < 0) the first step must land on the first item (Arrow Down)
+        // or the last item (Arrow Up), mirroring a native <select>; normalise the start so it does.
+        const from = start >= 0 ? start : (direction > 0 ? -1 : 0);
         for (let step = 1; step <= count; step++) {
-            const idx = (((start + direction * step) % count) + count) % count;
+            const idx = (((from + direction * step) % count) + count) % count;
             if (!this._visibleItems[idx].disabled) {
                 return idx;
             }

--- a/app/src/test/js/modules/SearchableDropdownTest.js
+++ b/app/src/test/js/modules/SearchableDropdownTest.js
@@ -168,6 +168,36 @@ describe('SearchableDropdown', function () {
         second.destroy();
     });
 
+    it('exposes ARIA combobox/listbox semantics', function () {
+        const label = document.createElement('label');
+        label.setAttribute('for', 'single');
+        label.textContent = 'Paper size';
+        document.body.appendChild(label);
+
+        const dropdown = new SearchableDropdown({ element: document.getElementById('single'), rememberSelection: false });
+        expect(dropdown.trigger.getAttribute('role')).to.equal('combobox');
+        expect(dropdown.trigger.getAttribute('aria-haspopup')).to.equal('listbox');
+        expect(dropdown.trigger.getAttribute('aria-expanded')).to.equal('false');
+        expect(dropdown.trigger.getAttribute('aria-label')).to.equal('Paper size');
+        expect(dropdown.trigger.getAttribute('aria-controls')).to.equal(dropdown.itemsEl.id);
+        expect(dropdown.itemsEl.getAttribute('role')).to.equal('listbox');
+
+        dropdown._renderOptions(dropdown.items);
+        const first = dropdown.itemsEl.children[0];
+        expect(first.getAttribute('role')).to.equal('option');
+        expect(first.getAttribute('aria-selected')).to.equal('true'); // 'a' is the selected first option
+        const disabledOpt = dropdown.itemsEl.children[2];
+        expect(disabledOpt.getAttribute('aria-disabled')).to.equal('true');
+
+        dropdown._open();
+        expect(dropdown.trigger.getAttribute('aria-expanded')).to.equal('true');
+        dropdown._close();
+        expect(dropdown.trigger.getAttribute('aria-expanded')).to.equal('false');
+
+        dropdown.destroy();
+        label.remove();
+    });
+
     it('ignores a disabled option and skips it in keyboard navigation', function () {
         const dropdown = new SearchableDropdown({ element: document.getElementById('single'), rememberSelection: false });
         const disabledItem = dropdown.items.find(i => i.value === 'c');

--- a/app/src/test/js/modules/SearchableDropdownTest.js
+++ b/app/src/test/js/modules/SearchableDropdownTest.js
@@ -168,6 +168,15 @@ describe('SearchableDropdown', function () {
         second.destroy();
     });
 
+    it('mirrors the <select> title tooltip onto the trigger', function () {
+        const select = document.getElementById('single');
+        select.setAttribute('title', 'Choose a size');
+        const dropdown = new SearchableDropdown({ element: select, rememberSelection: false });
+        expect(dropdown.trigger.getAttribute('title')).to.equal('Choose a size');
+        dropdown.destroy();
+        select.removeAttribute('title');
+    });
+
     it('exposes ARIA combobox/listbox semantics', function () {
         const label = document.createElement('label');
         label.setAttribute('for', 'single');

--- a/app/src/test/js/modules/SearchableDropdownTest.js
+++ b/app/src/test/js/modules/SearchableDropdownTest.js
@@ -13,6 +13,7 @@ describe('SearchableDropdown', function () {
             <select id="single">
                 <option value="a">A</option>
                 <option value="b">B</option>
+                <option value="c" disabled>C</option>
             </select>
             <select id="multi" multiple>
                 <option value="a">A</option>
@@ -165,6 +166,33 @@ describe('SearchableDropdown', function () {
         const second = new SearchableDropdown({ element: select, rememberSelection: false });
         expect(second.getSelectedValue()).to.equal('a');
         second.destroy();
+    });
+
+    it('ignores a disabled option and skips it in keyboard navigation', function () {
+        const dropdown = new SearchableDropdown({ element: document.getElementById('single'), rememberSelection: false });
+        const disabledItem = dropdown.items.find(i => i.value === 'c');
+        expect(disabledItem.disabled).to.be.true;
+
+        // Selecting a disabled option is a no-op (stays on the first option).
+        dropdown.selectItem(disabledItem);
+        expect(dropdown.getSelectedValue()).to.equal('a');
+
+        // Keyboard navigation skips the disabled option (a=0, b=1, c=2 disabled → wraps to a).
+        dropdown._visibleItems = dropdown.items;
+        expect(dropdown._nextEnabledIndex(1, 1)).to.equal(0);
+        dropdown.destroy();
+    });
+
+    it('reflects the wrapped <select> disabled state onto the container', function () {
+        const select = document.getElementById('single');
+        select.disabled = true;
+        const dropdown = new SearchableDropdown({ element: select, rememberSelection: false });
+        expect(dropdown.container.classList.contains('disabled')).to.be.true;
+
+        select.disabled = false;
+        dropdown._syncDisabled();
+        expect(dropdown.container.classList.contains('disabled')).to.be.false;
+        dropdown.destroy();
     });
 
     it('re-wrapping the same <select> does not stack duplicate containers/portals', function () {

--- a/app/src/test/js/modules/SearchableDropdownTest.js
+++ b/app/src/test/js/modules/SearchableDropdownTest.js
@@ -219,6 +219,9 @@ describe('SearchableDropdown', function () {
         // Keyboard navigation skips the disabled option (a=0, b=1, c=2 disabled → wraps to a).
         dropdown._visibleItems = dropdown.items;
         expect(dropdown._nextEnabledIndex(1, 1)).to.equal(0);
+        // From no selection (index -1): Down → first (a=0), Up → last enabled (c=2 is disabled → b=1).
+        expect(dropdown._nextEnabledIndex(-1, 1)).to.equal(0);
+        expect(dropdown._nextEnabledIndex(-1, -1)).to.equal(1);
         dropdown.destroy();
     });
 


### PR DESCRIPTION
### Proposed changes

This pull request introduces significant accessibility and usability improvements to the `SearchableDropdown` component, ensuring it better mirrors native `<select>` behavior, especially for disabled states and ARIA semantics. The main changes include full ARIA combobox/listbox support, proper handling of disabled controls and options, and enhanced keyboard navigation. Comprehensive tests are added to verify these behaviors.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
