### PR TITLE
fix: inject shared control CSS for consistent styling across components

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,31 @@ UI wrappers `.modal__container` (popups), `.standard-admin-page` (admin pages) a
 (document-properties side panels) so they never restyle Polarion's own controls — put the matching
 wrapper class on your surface.
 
+#### Shared control CSS is self-provided by `SearchableDropdown` (versioned)
+
+The shared control CSS reaches a page as global `<link>`s. Historically that only happened via an
+exporter's `scriptInjection.*Head` → `starter.js` → `injectStyles(...)`. That path is **shared and
+optional**: the component classes are global, so one installed exporter styles every surface — but if
+no exporter's `starter.js` runs (unconfigured `scriptInjection`, or the injecting extension removed),
+a document-properties side panel renders its controls **unstyled** even though its JS already wrapped
+them. (A panel cannot fix this from its own HTML fragment: Polarion inserts it via `HtmlFragmentBuilder`,
+which honors an inline `<style>` but **not** external `<link>`/`<script>` — which is also why panels
+bootstrap their JS through a `<link onload>` hook.)
+
+So the component provides its own styling: the `SearchableDropdown` constructor calls
+`ensureSharedStyles()` (`js/modules/ensureSharedStyles.js`), which injects the shared CSS
+(`checkboxes` / `radios` / `inputs` / `searchable-dropdown`) as `<link>`s into `<head>`. Any surface
+that renders a dropdown — side panel, export popup, admin page — is therefore styled on its own, with
+**no per-extension wiring**: an extension just consumes the generic version that ships it.
+
+**Versioning.** Each injected `<link>` carries `data-generic-version` = the generic bundle build
+timestamp (baked into `generic-build-info.js` via `resources-filtered`). The `<link>` ids match the
+ones `injectStyles` uses, so the two never duplicate. On a clash `ensureSharedStyles` keeps the copy
+with the **higher** version and treats an unversioned copy (e.g. from an older `starter.js`) as the
+lowest — so across a page assembled from extensions on **different generic versions**, the newest
+generic's CSS always wins, deterministically and regardless of load order. `starter.js` needs no
+change: its unversioned injection is simply superseded once a versioned copy is present.
+
 #### `ConfigurationsPane`
 
 `js/modules/ConfigurationsPane.js` renders the admin "choose a configuration" pane (backed by a

--- a/app/src/main/resources/js/modules/SearchableDropdown.js
+++ b/app/src/main/resources/js/modules/SearchableDropdown.js
@@ -1,3 +1,5 @@
+import ensureSharedStyles from './ensureSharedStyles.js';
+
 export default class SearchableDropdown {
     static COOKIE_PREFIX = 'searchable_dropdown_';
     static COOKIE_EXPIRY_DAYS = 30;
@@ -19,6 +21,10 @@ export default class SearchableDropdown {
         if (!element && !selectContainer) {
             throw new Error('SearchableDropdown: element or selectContainer is required');
         }
+
+        // Guarantee our shared control CSS is on the page (versioned), so a pane/popup that uses this
+        // component is styled without depending on any extension's scriptInjection/starter.js.
+        ensureSharedStyles();
 
         // Two construction modes:
         //  - "select" mode: wrap an existing native <select> (element) — the <select> stays the

--- a/app/src/main/resources/js/modules/ensureSharedStyles.js
+++ b/app/src/main/resources/js/modules/ensureSharedStyles.js
@@ -1,0 +1,47 @@
+import { GENERIC_BUILD_TIMESTAMP } from './generic-build-info.js';
+
+/*
+ * Guarantees the shared Polarion-styled control CSS (checkboxes, radios, inputs, searchable-dropdown)
+ * is present on the page, as versioned <link>s in <head> — so any surface that renders our components
+ * (document-properties form-extension side panels, export popups, admin pages) looks right on its own,
+ * without depending on an exporter's `scriptInjection.*Head` → `starter.js` → `injectStyles(...)`.
+ *
+ * The <link> ids match the ones dle-toolbar-starter's `injectStyles` uses, so the two dedupe (only one
+ * copy ever lands). Each <link> carries `data-generic-version` = this bundle's build timestamp; on a
+ * clash we keep the copy with the HIGHER version and treat an unversioned copy (e.g. injected by an
+ * older `starter.js`) as the lowest. Result: across a page assembled from extensions on different
+ * generic versions, the NEWEST generic's CSS always wins — deterministically, regardless of load order.
+ */
+
+const STYLES = [
+    ['generic-checkbox-styles', 'checkboxes.css'],
+    ['generic-radios-styles', 'radios.css'],
+    ['generic-inputs-styles', 'inputs.css'],
+    ['generic-searchable-dropdown-styles', 'searchable-dropdown.css'],
+];
+
+export default function ensureSharedStyles() {
+    // Idempotent: on a repeat call our own links already carry our version, so the check below skips
+    // them (mine <= existing). No extra guard needed.
+    const cssBase = new URL('../../css/', import.meta.url).href;
+    const mine = Number(GENERIC_BUILD_TIMESTAMP) || 0;
+
+    STYLES.forEach(([id, file]) => {
+        const existing = document.getElementById(id);
+        if (existing) {
+            const attr = existing.getAttribute('data-generic-version');
+            // Keep what is already there only if it is versioned AND at least as new as us.
+            // A versioned copy beats an unversioned one; among versioned, the higher timestamp wins.
+            if (attr !== null && mine <= Number(attr)) {
+                return;
+            }
+            existing.remove();
+        }
+        const link = document.createElement('link');
+        link.id = id;
+        link.rel = 'stylesheet';
+        link.href = cssBase + file;
+        link.setAttribute('data-generic-version', String(mine));
+        document.head.appendChild(link);
+    });
+}

--- a/app/src/main/resources/js/modules/generic-build-info.js
+++ b/app/src/main/resources/js/modules/generic-build-info.js
@@ -1,0 +1,12 @@
+/*
+ * Build-time info for the generic UI bundle. This file is filtered at build time (see the
+ * maven-resources-plugin config in the parent pom, which filters ONLY this file with the default
+ * `${}` delimiters): Maven replaces `${maven.build.timestamp}`. It has no template literals, so
+ * filtering is safe. Digits only, so it is directly numeric-comparable across generic builds
+ * (a newer generic build yields a larger number). In unit tests the token stays unfiltered and
+ * reduces to '' → 0, which is fine.
+ */
+// Normalize to the first 12 digits (yyyyMMddHHmm), so both the ISO default (yyyyMMddHHmmss) and a
+// configured `yyyy-MM-dd HH:mm` reduce to the same minute-precision, comparable number regardless of
+// which timestamp format the build happens to use.
+export const GENERIC_BUILD_TIMESTAMP = '${maven.build.timestamp}'.replace(/\D/g, '').slice(0, 12);

--- a/app/src/test/js/modules/ensureSharedStylesTest.js
+++ b/app/src/test/js/modules/ensureSharedStylesTest.js
@@ -1,0 +1,76 @@
+import ensureSharedStyles from '../../../main/resources/js/modules/ensureSharedStyles.js';
+import { expect } from 'chai';
+import { JSDOM } from 'jsdom';
+
+describe('ensureSharedStyles', function () {
+    let dom;
+
+    const IDS = [
+        'generic-checkbox-styles',
+        'generic-radios-styles',
+        'generic-inputs-styles',
+        'generic-searchable-dropdown-styles',
+    ];
+    const SD_ID = 'generic-searchable-dropdown-styles';
+
+    beforeEach(function () {
+        dom = new JSDOM('<!DOCTYPE html><html lang="en"><head></head><body></body></html>');
+        global.window = dom.window;
+        global.document = dom.window.document;
+    });
+
+    afterEach(function () {
+        delete global.window;
+        delete global.document;
+    });
+
+    it('injects a versioned <link> for each shared stylesheet', function () {
+        ensureSharedStyles();
+        IDS.forEach(id => {
+            const link = document.getElementById(id);
+            expect(link, id).to.exist;
+            expect(link.tagName).to.equal('LINK');
+            expect(link.rel).to.equal('stylesheet');
+            expect(link.getAttribute('data-generic-version')).to.not.be.null;
+        });
+        expect(document.querySelectorAll('link[rel="stylesheet"]').length).to.equal(IDS.length);
+        expect(document.getElementById(SD_ID).href).to.contain('searchable-dropdown.css');
+    });
+
+    it('is idempotent — a repeat call does not duplicate links', function () {
+        ensureSharedStyles();
+        ensureSharedStyles();
+        expect(document.querySelectorAll('link[rel="stylesheet"]').length).to.equal(IDS.length);
+    });
+
+    it('replaces an unversioned copy (versioned beats unversioned)', function () {
+        // simulate an older starter.js injection: same id, no data-generic-version
+        const stale = document.createElement('link');
+        stale.id = SD_ID;
+        stale.rel = 'stylesheet';
+        stale.href = 'http://old/searchable-dropdown.css';
+        document.head.appendChild(stale);
+
+        ensureSharedStyles();
+
+        const links = document.querySelectorAll(`#${SD_ID}`);
+        expect(links.length).to.equal(1); // replaced, not stacked
+        expect(links[0].getAttribute('data-generic-version')).to.not.be.null; // now versioned
+        expect(links[0].href).to.not.contain('old');
+    });
+
+    it('keeps a newer versioned copy (never downgrades)', function () {
+        const newer = document.createElement('link');
+        newer.id = SD_ID;
+        newer.rel = 'stylesheet';
+        newer.href = 'http://newer/searchable-dropdown.css';
+        newer.setAttribute('data-generic-version', '99999999999999'); // far newer than the test build (0)
+        document.head.appendChild(newer);
+
+        ensureSharedStyles();
+
+        const link = document.getElementById(SD_ID);
+        expect(link.getAttribute('data-generic-version')).to.equal('99999999999999'); // untouched
+        expect(link.href).to.contain('newer');
+    });
+});

--- a/pom.xml
+++ b/pom.xml
@@ -1044,6 +1044,17 @@
             <resource>
                 <directory>src/main/resources</directory>
                 <filtering>false</filtering>
+                <!-- generic-build-info.js is filtered separately (below) to bake in the build timestamp -->
+                <excludes>
+                    <exclude>js/modules/generic-build-info.js</exclude>
+                </excludes>
+            </resource>
+            <resource> <!-- Bake ${maven.build.timestamp} into generic-build-info.js (it has no template literals, so default ${} filtering is safe) -->
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>js/modules/generic-build-info.js</include>
+                </includes>
             </resource>
             <resource> <!-- Below is a way to replace polarion version in generic.properties by version from a profile -->
                 <directory>src/main/resources-filtered</directory>


### PR DESCRIPTION
### Proposed changes

Ensure that shared Polarion-styled control CSS is injected as versioned `<link>` elements in the document head. This allows components like document-properties side panels and export popups to render styled correctly without relying on external script injections.

- Introduce ensureSharedStyles function to manage CSS injection
- Maintain versioning to ensure the latest styles are used
- Prevent duplication of styles on repeated calls

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
