### PR TITLE
fix: soft hover/focus shadow to inputs and comboboxes

### DIFF
--- a/app/src/main/resources/css/inputs.css
+++ b/app/src/main/resources/css/inputs.css
@@ -43,21 +43,21 @@
 
 /* The shared soft elevation shadow — mirrors the combobox trigger — shown on hover so every text
    input across all extensions gets the same subtle lift. */
-.modal__container input[type="text"]:not(.sd-trigger):not(.search-box):hover,
-.modal__container input[type="number"]:hover,
-.modal__container input[type="password"]:hover,
-.modal__container input[type="search"]:hover,
-.standard-admin-page input[type="text"]:not(.sd-trigger):not(.search-box):hover,
-.standard-admin-page input[type="number"]:hover,
-.standard-admin-page input[type="password"]:hover,
-.standard-admin-page input[type="search"]:hover,
-.form-wrapper input[type="text"]:not(.sd-trigger):not(.search-box):hover,
-.form-wrapper input[type="number"]:hover,
-.form-wrapper input[type="password"]:hover,
-.form-wrapper input[type="search"]:hover,
-.modal__container input:not([type]):not(.sd-trigger):not(.search-box):hover,
-.standard-admin-page input:not([type]):not(.sd-trigger):not(.search-box):hover,
-.form-wrapper input:not([type]):not(.sd-trigger):not(.search-box):hover {
+.modal__container input[type="text"]:not(.sd-trigger):not(.search-box):not(:disabled):hover,
+.modal__container input[type="number"]:not(:disabled):hover,
+.modal__container input[type="password"]:not(:disabled):hover,
+.modal__container input[type="search"]:not(:disabled):hover,
+.standard-admin-page input[type="text"]:not(.sd-trigger):not(.search-box):not(:disabled):hover,
+.standard-admin-page input[type="number"]:not(:disabled):hover,
+.standard-admin-page input[type="password"]:not(:disabled):hover,
+.standard-admin-page input[type="search"]:not(:disabled):hover,
+.form-wrapper input[type="text"]:not(.sd-trigger):not(.search-box):not(:disabled):hover,
+.form-wrapper input[type="number"]:not(:disabled):hover,
+.form-wrapper input[type="password"]:not(:disabled):hover,
+.form-wrapper input[type="search"]:not(:disabled):hover,
+.modal__container input:not([type]):not(.sd-trigger):not(.search-box):not(:disabled):hover,
+.standard-admin-page input:not([type]):not(.sd-trigger):not(.search-box):not(:disabled):hover,
+.form-wrapper input:not([type]):not(.sd-trigger):not(.search-box):not(:disabled):hover {
     box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.2);
 }
 

--- a/app/src/main/resources/css/inputs.css
+++ b/app/src/main/resources/css/inputs.css
@@ -37,6 +37,28 @@
     font-size: 13px;
     font-weight: 600;
     color: #1a1a1a;
+    /* Soft elevation shadow appears on hover/focus (added below). */
+    transition: box-shadow 0.15s ease, border-color 0.15s ease;
+}
+
+/* The shared soft elevation shadow — mirrors the combobox trigger — shown on hover so every text
+   input across all extensions gets the same subtle lift. */
+.modal__container input[type="text"]:not(.sd-trigger):not(.search-box):hover,
+.modal__container input[type="number"]:hover,
+.modal__container input[type="password"]:hover,
+.modal__container input[type="search"]:hover,
+.standard-admin-page input[type="text"]:not(.sd-trigger):not(.search-box):hover,
+.standard-admin-page input[type="number"]:hover,
+.standard-admin-page input[type="password"]:hover,
+.standard-admin-page input[type="search"]:hover,
+.form-wrapper input[type="text"]:not(.sd-trigger):not(.search-box):hover,
+.form-wrapper input[type="number"]:hover,
+.form-wrapper input[type="password"]:hover,
+.form-wrapper input[type="search"]:hover,
+.modal__container input:not([type]):not(.sd-trigger):not(.search-box):hover,
+.standard-admin-page input:not([type]):not(.sd-trigger):not(.search-box):hover,
+.form-wrapper input:not([type]):not(.sd-trigger):not(.search-box):hover {
+    box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.2);
 }
 
 .modal__container input[type="text"]:not(.sd-trigger):not(.search-box):focus,
@@ -56,4 +78,5 @@
 .form-wrapper input:not([type]):not(.sd-trigger):not(.search-box):focus {
     border-color: #1491EB;
     outline: none;
+    box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.2);
 }

--- a/app/src/main/resources/css/searchable-dropdown.css
+++ b/app/src/main/resources/css/searchable-dropdown.css
@@ -23,9 +23,15 @@
     font-size: 13px;
     font-weight: 600;
     color: #1a1a1a;
+    transition: box-shadow 0.15s ease, border-color 0.15s ease;
 }
 
-/* Open state — Polarion JSSelector-ComboOpen (blue border + shadow) */
+/* Soft elevation shadow on hover — same lift as the text inputs (inputs.css). */
+.searchable-dropdown:not(.disabled) > .sd-trigger:hover {
+    box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.2);
+}
+
+/* Open state — Polarion JSSelector-ComboOpen (blue border + stronger shadow) */
 .searchable-dropdown.open > .sd-trigger {
     border-color: #1491EB;
     box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.3);


### PR DESCRIPTION
### Proposed changes

This pull request updates the input and dropdown styling across the application to provide a consistent and modern "soft elevation" shadow effect on hover and focus. The changes ensure that all text inputs and searchable dropdown triggers receive a subtle shadow, improving visual feedback and aligning the UI with current design standards.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
