### PR TITLE
feat: introduce control design tokens for consistent styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,47 @@ UI wrappers `.modal__container` (popups), `.standard-admin-page` (admin pages) a
 (document-properties side panels) so they never restyle Polarion's own controls — put the matching
 wrapper class on your surface.
 
+#### Design tokens & reuse in React SPAs (`control-tokens.css`)
+
+The 2606 control look is defined once as CSS custom properties in `css/control-tokens.css`
+(`:root { --sbb-* }`: border / focus colors, control height, radius, the soft hover/active
+elevation shadows, checkbox images, radio dot, combobox chevron, popup border, option hover tint,
+chips, and typography). `common.css` `@import`s it, and the class-based stylesheets above consume it
+via `var(--sbb-*, <literal fallback>)` — so restyling every native control across the ecosystem is a
+one-file edit, and each fallback equals the previous literal so the stylesheets still render if the
+token file is ever missing.
+
+This is also the **reuse path for extensions whose UI is not built from our class-based CSS** — the
+React SPAs (Vite / Next), which render their own markup (custom components, native `<select>`,
+Bootstrap classes) and cannot link `checkboxes.css` / `searchable-dropdown.css`. Instead they:
+
+1. **Link the tokens at runtime** from the embedded `generic.app` (served by `GenericUiServlet`), and
+   reference `var(--sbb-*)` in their own component CSS:
+
+   ```html
+   <link rel="stylesheet" href="/polarion/<ext>-app/ui/generic/css/control-tokens.css" />
+   ```
+   ```css
+   .my-combo        { border: 1px solid var(--sbb-control-border, #c9c9c9); border-radius: var(--sbb-control-radius, 0); }
+   .my-combo:hover  { box-shadow: var(--sbb-control-shadow-hover, 0 2px 6px 0 rgba(0, 0, 0, .2)); }
+   ```
+
+2. **For real combobox parity**, wrap a native `<select>` with the vanilla `SearchableDropdown`,
+   loaded via a runtime dynamic import (bundler-ignored so the build does not try to resolve the URL),
+   and link `searchable-dropdown.css`. The `<select>` stays framework-controlled; the component
+   mirrors the selection back and dispatches `change`:
+
+   ```js
+   const SD = (await import(/* webpackIgnore: true */ /* @vite-ignore */
+     '/polarion/<ext>-app/ui/generic/js/modules/SearchableDropdown.js')).default;
+   new SD({ element: selectEl, rememberSelection: false });
+   ```
+
+Because both the tokens and the dropdown module are consumed **at runtime**, `generic` stays the
+single source of truth — there is no JS package to publish and no build-time coupling. Always ship
+the literal fallback in the SPA's `var()` calls so it still renders in a dev server running outside
+Polarion (where `/polarion/*` 404s).
+
 #### Shared control CSS is self-provided by `SearchableDropdown` (versioned)
 
 The shared control CSS reaches a page as global `<link>`s. Historically that only happened via an

--- a/app/src/main/resources/css/checkboxes.css
+++ b/app/src/main/resources/css/checkboxes.css
@@ -16,19 +16,19 @@
 .form-wrapper input[type="checkbox"] {
     -webkit-appearance: none;
     appearance: none;
-    width: 15px;
-    height: 15px;
+    width: var(--sbb-toggle-size, 15px);
+    height: var(--sbb-toggle-size, 15px);
     margin: 0 4px 0 0;
     vertical-align: middle;
     cursor: pointer;
-    background: url(/polarion/ria/images/checkbox/unchecked.png) no-repeat center;
-    background-size: 15px 15px;
+    background: var(--sbb-checkbox-unchecked, url(/polarion/ria/images/checkbox/unchecked.png)) no-repeat center;
+    background-size: var(--sbb-toggle-size, 15px) var(--sbb-toggle-size, 15px);
 }
 
 .modal__container input[type="checkbox"]:checked,
 .standard-admin-page input[type="checkbox"]:checked,
 .form-wrapper input[type="checkbox"]:checked {
-    background-image: url(/polarion/ria/images/checkbox/checked.png);
+    background-image: var(--sbb-checkbox-checked, url(/polarion/ria/images/checkbox/checked.png));
 }
 
 /* Keep the checkbox vertically centered with its label text. */

--- a/app/src/main/resources/css/checkboxes.css
+++ b/app/src/main/resources/css/checkboxes.css
@@ -31,6 +31,12 @@
     background-image: var(--sbb-checkbox-checked, url(/polarion/ria/images/checkbox/checked.png));
 }
 
+.modal__container input[type="checkbox"]:indeterminate,
+.standard-admin-page input[type="checkbox"]:indeterminate,
+.form-wrapper input[type="checkbox"]:indeterminate {
+    background-image: var(--sbb-checkbox-indeterminate, url(/polarion/ria/images/checkbox/grayed.png));
+}
+
 /* Keep the checkbox vertically centered with its label text. */
 .modal__container label:has(input[type="checkbox"]),
 .standard-admin-page label:has(input[type="checkbox"]),

--- a/app/src/main/resources/css/common.css
+++ b/app/src/main/resources/css/common.css
@@ -1,3 +1,4 @@
+@import url("control-tokens.css");
 @import url("checkboxes.css");
 @import url("radios.css");
 @import url("inputs.css");

--- a/app/src/main/resources/css/control-tokens.css
+++ b/app/src/main/resources/css/control-tokens.css
@@ -46,14 +46,13 @@
     /* Combobox popup + options */
     --sbb-combo-chevron: url(/polarion/ria/images/combo_box_old.png);
     --sbb-combo-popup-border: #ccccd4;
-    --sbb-option-hover: #ebf7f8;
+    /* Light teal hover / selection tint — the base that --sbb-option-hover and --sbb-chip-bg
+       derive from, and the token the React SPAs reference for dropdown-row hovers. */
+    --sbb-hover-tint: #ebf7f8;
+    --sbb-option-hover: var(--sbb-hover-tint, #ebf7f8);
 
     /* Multi-select chips */
-    --sbb-chip-bg: #ebf7f8;
+    --sbb-chip-bg: var(--sbb-hover-tint, #ebf7f8);
     --sbb-chip-border: #b6dfe3;
     --sbb-chip-remove: #5c8a90;
-
-    /* Accent (selection / focus emphasis) */
-    --sbb-accent: #1491eb;
-    --sbb-hover-tint: #ebf7f8;
 }

--- a/app/src/main/resources/css/control-tokens.css
+++ b/app/src/main/resources/css/control-tokens.css
@@ -1,0 +1,59 @@
+/*
+ * Control design tokens — the single source of the Polarion 2606 control look.
+ *
+ * generic's own control stylesheets (checkboxes.css, radios.css, inputs.css,
+ * searchable-dropdown.css) consume these variables, so this file is the one place
+ * to restyle every native control across the whole extension ecosystem.
+ *
+ * It is also meant to be reused by extensions whose UI is NOT built from our
+ * class-based CSS — notably the React SPAs (xml-repair, integrity-scanner,
+ * diff-tool), which render their own markup (custom IconSelect, native <select>)
+ * and therefore cannot simply link checkboxes.css/searchable-dropdown.css. Those
+ * apps link THIS file at runtime (/polarion/<ext>/ui/generic/css/control-tokens.css)
+ * and reference the same var(--sbb-*) values, so a restyle here propagates to them.
+ *
+ * Every token ships with a literal fallback (var(--x, <literal>)) so any consumer
+ * that fails to load this file — e.g. a Vite dev server running outside Polarion,
+ * where /polarion/* 404s — still renders the intended look.
+ */
+:root {
+    /* Typography (shared by every control) */
+    --sbb-control-font-family: "Segoe UI", "Selawik", "Open Sans", Arial, sans-serif;
+    --sbb-control-font-size: 13px;
+    --sbb-control-font-weight: 600;
+    --sbb-control-text: #1a1a1a;
+    --sbb-control-placeholder: #7c7c7c;
+
+    /* Text inputs + combobox trigger */
+    --sbb-control-height: 23px;
+    --sbb-control-bg: #ffffff;
+    --sbb-control-border: #c9c9c9;
+    --sbb-control-border-focus: #1491eb;
+    --sbb-control-radius: 0;
+
+    /* Elevation */
+    --sbb-control-shadow-hover: 0 2px 6px 0 rgba(0, 0, 0, 0.2);
+    --sbb-control-shadow-active: 0 3px 6px 0 rgba(0, 0, 0, 0.3);
+
+    /* Checkbox (Polarion images) + radio (CSS-drawn) */
+    --sbb-toggle-size: 15px;
+    --sbb-checkbox-unchecked: url(/polarion/ria/images/checkbox/unchecked.png);
+    --sbb-checkbox-checked: url(/polarion/ria/images/checkbox/checked.png);
+    --sbb-checkbox-indeterminate: url(/polarion/ria/images/checkbox/grayed.png);
+    --sbb-radio-border: #c9c9c9;
+    --sbb-radio-dot: #595959;
+
+    /* Combobox popup + options */
+    --sbb-combo-chevron: url(/polarion/ria/images/combo_box_old.png);
+    --sbb-combo-popup-border: #ccccd4;
+    --sbb-option-hover: #ebf7f8;
+
+    /* Multi-select chips */
+    --sbb-chip-bg: #ebf7f8;
+    --sbb-chip-border: #b6dfe3;
+    --sbb-chip-remove: #5c8a90;
+
+    /* Accent (selection / focus emphasis) */
+    --sbb-accent: #1491eb;
+    --sbb-hover-tint: #ebf7f8;
+}

--- a/app/src/main/resources/css/inputs.css
+++ b/app/src/main/resources/css/inputs.css
@@ -27,16 +27,16 @@
 .standard-admin-page input:not([type]):not(.sd-trigger):not(.search-box),
 .form-wrapper input:not([type]):not(.sd-trigger):not(.search-box) {
     box-sizing: border-box;
-    height: 23px;
-    border: 1px solid #c9c9c9;
+    height: var(--sbb-control-height, 23px);
+    border: 1px solid var(--sbb-control-border, #c9c9c9);
     /* Square corners to match Polarion's own text inputs (its inputs are not rounded). */
-    border-radius: 0;
+    border-radius: var(--sbb-control-radius, 0);
     padding: 2px 6px;
-    background-color: #fff;
-    font-family: "Segoe UI", "Selawik", "Open Sans", Arial, sans-serif;
-    font-size: 13px;
-    font-weight: 600;
-    color: #1a1a1a;
+    background-color: var(--sbb-control-bg, #fff);
+    font-family: var(--sbb-control-font-family, "Segoe UI", "Selawik", "Open Sans", Arial, sans-serif);
+    font-size: var(--sbb-control-font-size, 13px);
+    font-weight: var(--sbb-control-font-weight, 600);
+    color: var(--sbb-control-text, #1a1a1a);
     /* Soft elevation shadow appears on hover/focus (added below). */
     transition: box-shadow 0.15s ease, border-color 0.15s ease;
 }
@@ -58,7 +58,7 @@
 .modal__container input:not([type]):not(.sd-trigger):not(.search-box):not(:disabled):hover,
 .standard-admin-page input:not([type]):not(.sd-trigger):not(.search-box):not(:disabled):hover,
 .form-wrapper input:not([type]):not(.sd-trigger):not(.search-box):not(:disabled):hover {
-    box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.2);
+    box-shadow: var(--sbb-control-shadow-hover, 0 2px 6px 0 rgba(0, 0, 0, 0.2));
 }
 
 .modal__container input[type="text"]:not(.sd-trigger):not(.search-box):focus,
@@ -76,7 +76,7 @@
 .modal__container input:not([type]):not(.sd-trigger):not(.search-box):focus,
 .standard-admin-page input:not([type]):not(.sd-trigger):not(.search-box):focus,
 .form-wrapper input:not([type]):not(.sd-trigger):not(.search-box):focus {
-    border-color: #1491EB;
+    border-color: var(--sbb-control-border-focus, #1491eb);
     outline: none;
-    box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.2);
+    box-shadow: var(--sbb-control-shadow-hover, 0 2px 6px 0 rgba(0, 0, 0, 0.2));
 }

--- a/app/src/main/resources/css/radios.css
+++ b/app/src/main/resources/css/radios.css
@@ -19,21 +19,21 @@
 .form-wrapper input[type="radio"] {
     -webkit-appearance: none;
     appearance: none;
-    width: 15px;
-    height: 15px;
+    width: var(--sbb-toggle-size, 15px);
+    height: var(--sbb-toggle-size, 15px);
     margin: 0 4px 0 0;
     vertical-align: middle;
     cursor: pointer;
     box-sizing: border-box;
-    border: 1px solid #c9c9c9;
+    border: 1px solid var(--sbb-radio-border, #c9c9c9);
     border-radius: 50%;
-    background-color: #fff;
+    background-color: var(--sbb-control-bg, #fff);
 }
 
 .modal__container input[type="radio"]:checked,
 .standard-admin-page input[type="radio"]:checked,
 .form-wrapper input[type="radio"]:checked {
-    background-image: radial-gradient(circle, #595959 0 34%, transparent 38%);
+    background-image: radial-gradient(circle, var(--sbb-radio-dot, #595959) 0 34%, transparent 38%);
 }
 
 /* Keep the radio vertically centered with its label text. */

--- a/app/src/main/resources/css/searchable-dropdown.css
+++ b/app/src/main/resources/css/searchable-dropdown.css
@@ -65,12 +65,12 @@
    selections stay visible instead of being truncated into a single comma-joined line. */
 .searchable-dropdown > .sd-trigger-multi {
     width: 100%;
-    min-height: 23px;
+    min-height: var(--sbb-control-height, 23px);
     box-sizing: border-box;
     padding: 1px 2rem 1px 3px;
-    border: 1px solid #c9c9c9;
-    border-radius: 0;
-    background-color: #fff;
+    border: 1px solid var(--sbb-control-border, #c9c9c9);
+    border-radius: var(--sbb-control-radius, 0);
+    background-color: var(--sbb-control-bg, #fff);
     cursor: pointer;
     display: flex;
     flex-wrap: wrap;
@@ -78,9 +78,9 @@
     /* Uniform spacing between chips (row and column). */
     gap: 4px;
     font-family: inherit;
-    font-size: 13px;
-    font-weight: 600;
-    color: #1a1a1a;
+    font-size: var(--sbb-control-font-size, 13px);
+    font-weight: var(--sbb-control-font-weight, 600);
+    color: var(--sbb-control-text, #1a1a1a);
 }
 
 .searchable-dropdown > .sd-trigger-multi .sd-placeholder {
@@ -216,10 +216,10 @@
     padding: 4px 6px;
     border: 1px solid var(--sbb-control-border-focus, #1491eb);
     border-radius: var(--sbb-control-radius, 0);
-    background-color: #fff;
+    background-color: var(--sbb-control-bg, #fff);
     font-family: inherit;
-    font-size: 13px;
-    color: #1a1a1a;
+    font-size: var(--sbb-control-font-size, 13px);
+    color: var(--sbb-control-text, #1a1a1a);
     outline: none;
 }
 

--- a/app/src/main/resources/css/searchable-dropdown.css
+++ b/app/src/main/resources/css/searchable-dropdown.css
@@ -10,31 +10,31 @@
 /* Trigger — the closed combobox (Polarion JSSelector-Combo) */
 .searchable-dropdown > input.sd-trigger {
     width: 100%;
-    height: 23px;
+    height: var(--sbb-control-height, 23px);
     box-sizing: border-box;
     padding: 2px 2rem 2px .5rem;
-    border: 1px solid #c9c9c9;
-    border-radius: 0;
-    background-color: #fff;
+    border: 1px solid var(--sbb-control-border, #c9c9c9);
+    border-radius: var(--sbb-control-radius, 0);
+    background-color: var(--sbb-control-bg, #fff);
     cursor: pointer;
     overflow: hidden;
     text-overflow: ellipsis;
     font-family: inherit;
-    font-size: 13px;
-    font-weight: 600;
-    color: #1a1a1a;
+    font-size: var(--sbb-control-font-size, 13px);
+    font-weight: var(--sbb-control-font-weight, 600);
+    color: var(--sbb-control-text, #1a1a1a);
     transition: box-shadow 0.15s ease, border-color 0.15s ease;
 }
 
 /* Soft elevation shadow on hover — same lift as the text inputs (inputs.css). */
 .searchable-dropdown:not(.disabled) > .sd-trigger:hover {
-    box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.2);
+    box-shadow: var(--sbb-control-shadow-hover, 0 2px 6px 0 rgba(0, 0, 0, 0.2));
 }
 
 /* Open state — Polarion JSSelector-ComboOpen (blue border + stronger shadow) */
 .searchable-dropdown.open > .sd-trigger {
-    border-color: #1491EB;
-    box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.3);
+    border-color: var(--sbb-control-border-focus, #1491eb);
+    box-shadow: var(--sbb-control-shadow-active, 0 3px 6px 0 rgba(0, 0, 0, 0.3));
     outline: none;
 }
 
@@ -95,8 +95,8 @@
     max-width: 100%;
     box-sizing: border-box;
     padding: 0 3px 0 5px;
-    background: #ebf7f8;
-    border: 1px solid #b6dfe3;
+    background: var(--sbb-chip-bg, #ebf7f8);
+    border: 1px solid var(--sbb-chip-border, #b6dfe3);
     border-radius: 0;
     font-size: 12px;
     font-weight: 600;
@@ -129,7 +129,7 @@
     transform: translateY(-50%);
     width: 16px;
     height: 16px;
-    background: transparent url("/polarion/ria/images/combo_box_old.png") center / contain no-repeat;
+    background: var(--sbb-combo-chevron, url("/polarion/ria/images/combo_box_old.png")) center / contain no-repeat;
     pointer-events: none;
 }
 
@@ -184,9 +184,9 @@
     /* Popup width is driven by the longest option, but never narrower than the trigger + 35px */
     min-width: calc(100% + 35px);
     width: max-content;
-    background: #fff;
-    border: 1px solid #CCCCD4;
-    border-radius: 0;
+    background: var(--sbb-control-bg, #fff);
+    border: 1px solid var(--sbb-combo-popup-border, #ccccd4);
+    border-radius: var(--sbb-control-radius, 0);
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
 }
 
@@ -214,8 +214,8 @@
     min-width: 0;
     box-sizing: border-box;
     padding: 4px 6px;
-    border: 1px solid #1491EB;
-    border-radius: 0;
+    border: 1px solid var(--sbb-control-border-focus, #1491eb);
+    border-radius: var(--sbb-control-radius, 0);
     background-color: #fff;
     font-family: inherit;
     font-size: 13px;
@@ -253,7 +253,7 @@
 /* Highlight — exact Polarion .polarion-JComboBox-ItemOver colour.
    Only one option is highlighted at a time (follows mouse/keyboard), managed via the .active class. */
 .sd-portal .option.active {
-    background-color: #ebf7f8;
+    background-color: var(--sbb-option-hover, #ebf7f8);
 }
 
 /* Disabled option (<option disabled>): dimmed and non-interactive; keyboard nav skips it. */
@@ -296,12 +296,12 @@
     appearance: none;
     width: 15px;
     height: 15px;
-    background: url(/polarion/ria/images/checkbox/unchecked.png) no-repeat center;
-    background-size: 15px 15px;
+    background: var(--sbb-checkbox-unchecked, url(/polarion/ria/images/checkbox/unchecked.png)) no-repeat center;
+    background-size: var(--sbb-toggle-size, 15px) var(--sbb-toggle-size, 15px);
 }
 
 .sd-portal .option.multiselect-option input[type="checkbox"]:checked {
-    background-image: url(/polarion/ria/images/checkbox/checked.png);
+    background-image: var(--sbb-checkbox-checked, url(/polarion/ria/images/checkbox/checked.png));
 }
 
 .sd-portal .option.multiselect-option .option-label {

--- a/app/src/main/resources/css/searchable-dropdown.css
+++ b/app/src/main/resources/css/searchable-dropdown.css
@@ -117,7 +117,7 @@
 }
 
 .searchable-dropdown .sd-chip-remove:hover {
-    color: #1a1a1a;
+    color: var(--sbb-control-text, #1a1a1a);
 }
 
 /* Arrow on the trigger — Polarion combo_box_old.png */
@@ -157,7 +157,7 @@
 }
 
 .searchable-dropdown .sd-clear:hover {
-    color: #1a1a1a;
+    color: var(--sbb-control-text, #1a1a1a);
     background: #e6e6e6;
 }
 
@@ -242,9 +242,9 @@
     padding: 6px 12px;
     cursor: pointer;
     font-family: inherit;
-    font-size: 13px;
-    font-weight: 600;
-    color: #1a1a1a;
+    font-size: var(--sbb-control-font-size, 13px);
+    font-weight: var(--sbb-control-font-weight, 600);
+    color: var(--sbb-control-text, #1a1a1a);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/app/src/main/resources/css/searchable-dropdown.css
+++ b/app/src/main/resources/css/searchable-dropdown.css
@@ -84,7 +84,7 @@
 }
 
 .searchable-dropdown > .sd-trigger-multi .sd-placeholder {
-    color: #7c7c7c;
+    color: var(--sbb-control-placeholder, #7c7c7c);
     padding-left: 3px;
 }
 
@@ -111,7 +111,7 @@
 
 .searchable-dropdown .sd-chip-remove {
     cursor: pointer;
-    color: #5c8a90;
+    color: var(--sbb-chip-remove, #5c8a90);
     font-weight: 700;
     line-height: 1;
 }


### PR DESCRIPTION
### Proposed changes

Add control design tokens to standardize the appearance of form controls across the application. This allows for easier styling and maintenance, particularly for React SPAs that utilize these tokens for rendering.

- Create control-tokens.css with variables for typography, colors, and sizes
- Update existing CSS files to use these variables for checkboxes, radios, inputs, and dropdowns
- Ensure fallbacks are in place for environments that may not load the tokens

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
