### PR TITLE
feat: add optional icon background support in searchable dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,7 +451,10 @@ with an italic `global` marker).
 
 Per-option **icons**: give a source `<option>` a `data-icon="…"` (element mode) or pass a third
 argument to `addOption(value, text, icon)` (build mode); the icon is shown to the left of the label
-in the list and on the closed single-select trigger.
+in the list and on the closed single-select trigger. For an icon that sits on a coloured tile (e.g.
+an entity/project icon on a dark background), add `data-icon-bg="#1a3a5c"` on the `<option>` or pass
+it as the fourth argument, `addOption(value, text, icon, iconBg)`; the colour is applied behind the
+icon in both the list and the trigger.
 
 The popup is portalled into `document.body` so it is never clipped by an ancestor's `overflow`
 (narrow side panels, scrollable modals). It integrates with `ExtensionContext` (`setSelector` /

--- a/app/src/main/resources/css/searchable-dropdown.css
+++ b/app/src/main/resources/css/searchable-dropdown.css
@@ -277,6 +277,17 @@
     object-fit: contain;
 }
 
+/* Optional coloured tile behind an icon (<option data-icon-bg> / addOption's 4th arg). The tile
+   colour is per-option, so it is set inline in JS (_applyIconBg); this only adds the padding and
+   radius that turn the icon's own background into a neat little tile — matching the entity/project
+   icon tiles the React pickers use. */
+.searchable-dropdown .sd-trigger-icon.has-icon-bg,
+.sd-portal .option .option-icon.has-icon-bg {
+    padding: 2px;
+    border-radius: 2px;
+    box-sizing: content-box;
+}
+
 /* Multi-select option: a checkbox in front of the label (toggles without closing the popup). */
 .sd-portal .option.multiselect-option {
     display: flex;
@@ -294,8 +305,8 @@
        scopes to, so replicate the image styling here — only for in-list multi-select checkboxes). */
     -webkit-appearance: none;
     appearance: none;
-    width: 15px;
-    height: 15px;
+    width: var(--sbb-toggle-size, 15px);
+    height: var(--sbb-toggle-size, 15px);
     background: var(--sbb-checkbox-unchecked, url(/polarion/ria/images/checkbox/unchecked.png)) no-repeat center;
     background-size: var(--sbb-toggle-size, 15px) var(--sbb-toggle-size, 15px);
 }

--- a/app/src/main/resources/js/modules/SearchableDropdown.js
+++ b/app/src/main/resources/js/modules/SearchableDropdown.js
@@ -140,7 +140,9 @@ export default class SearchableDropdown {
                 selected: option.selected,
                 disabled: option.disabled,
                 // Optional per-option icon: <option data-icon="/polarion/…/icon.svg">Label</option>
-                icon: option.getAttribute('data-icon') || ''
+                icon: option.getAttribute('data-icon') || '',
+                // Optional coloured tile behind the icon: <option data-icon-bg="#1a3a5c">Label</option>
+                iconBg: option.getAttribute('data-icon-bg') || ''
             }));
     }
 
@@ -397,6 +399,7 @@ export default class SearchableDropdown {
             this.triggerIcon.src = item.icon;
             this.triggerIcon.style.display = '';
             this.trigger.classList.add('has-icon');
+            this._applyIconBg(this.triggerIcon, item.iconBg);
         } else {
             this.triggerIcon.style.display = 'none';
             this.trigger.classList.remove('has-icon');
@@ -490,7 +493,7 @@ export default class SearchableDropdown {
                 checkbox.tabIndex = -1;
                 option.appendChild(checkbox);
                 if (item.icon) {
-                    option.appendChild(this._createOptionIcon(item.icon));
+                    option.appendChild(this._createOptionIcon(item.icon, item.iconBg));
                 }
                 const labelSpan = document.createElement('span');
                 labelSpan.className = 'option-label';
@@ -498,7 +501,7 @@ export default class SearchableDropdown {
                 option.appendChild(labelSpan);
             } else if (item.icon) {
                 option.classList.add('has-icon');
-                option.appendChild(this._createOptionIcon(item.icon));
+                option.appendChild(this._createOptionIcon(item.icon, item.iconBg));
                 const labelSpan = document.createElement('span');
                 labelSpan.className = 'option-label';
                 labelSpan.textContent = item.label;
@@ -555,12 +558,25 @@ export default class SearchableDropdown {
         this._updateActiveDescendant();
     }
 
-    _createOptionIcon(src) {
+    _createOptionIcon(src, iconBg) {
         const icon = document.createElement('img');
         icon.className = 'option-icon';
         icon.src = src;
         icon.alt = '';
+        this._applyIconBg(icon, iconBg);
         return icon;
+    }
+
+    // Optional coloured tile behind an icon. The CSS class (.has-icon-bg) supplies the padding and
+    // radius; the colour is per-option so it is set inline. A falsy bg clears any previous tile.
+    _applyIconBg(icon, iconBg) {
+        if (iconBg) {
+            icon.classList.add('has-icon-bg');
+            icon.style.backgroundColor = iconBg;
+        } else {
+            icon.classList.remove('has-icon-bg');
+            icon.style.backgroundColor = '';
+        }
     }
 
     // Accessible name for the combobox — from the passed label, the <select>'s aria-label, or the
@@ -977,13 +993,14 @@ export default class SearchableDropdown {
     // Append a selectable option. Returns lightweight handles whose classList mutations are
     // mirrored onto the rendered option — this preserves the CustomSelect contract where callers do
     // `addOption(...).label.classList.add('parent')` to mark a global-scope config.
-    addOption(value, text, icon) {
+    addOption(value, text, icon, iconBg) {
         const item = {
             value,
             label: text !== undefined && text !== null ? text : value,
             className: '',
             selected: false,
-            icon: icon || ''
+            icon: icon || '',
+            iconBg: iconBg || ''
         };
         this.items.push(item);
         // Single-select defaults to the first option (no empty/placeholder state), matching a

--- a/app/src/test/js/modules/SearchableDropdownTest.js
+++ b/app/src/test/js/modules/SearchableDropdownTest.js
@@ -642,6 +642,42 @@ describe('SearchableDropdown', function () {
             dropdown.destroy();
         });
 
+        it('applies an icon background tile from data-icon-bg (element mode)', function () {
+            const select = document.createElement('select');
+            select.innerHTML =
+                '<option value="a" data-icon="/i/a.svg" data-icon-bg="#1a3a5c">A</option>' +
+                '<option value="b" data-icon="/i/b.svg">B</option>';
+            document.body.appendChild(select);
+            const dropdown = new SearchableDropdown({ element: select, rememberSelection: false });
+            // Option "a" is selected first, so its tile shows on the trigger icon.
+            expect(dropdown.triggerIcon.classList.contains('has-icon-bg')).to.be.true;
+            expect(dropdown.triggerIcon.style.backgroundColor).to.not.equal('');
+            // In the list: "a" gets a tile, "b" (no data-icon-bg) does not.
+            dropdown._renderOptions(dropdown.items);
+            const iconA = dropdown.itemsEl.children[0].querySelector('img.option-icon');
+            const iconB = dropdown.itemsEl.children[1].querySelector('img.option-icon');
+            expect(iconA.classList.contains('has-icon-bg')).to.be.true;
+            expect(iconA.style.backgroundColor).to.not.equal('');
+            expect(iconB.classList.contains('has-icon-bg')).to.be.false;
+            dropdown.destroy();
+        });
+
+        it('accepts an icon background as the 4th addOption argument (build mode)', function () {
+            const dropdown = new SearchableDropdown({
+                selectContainer: document.getElementById('build-container'),
+                rememberSelection: false
+            });
+            dropdown.addOption('a', 'A', '/i/a.svg', '#1a3a5c');
+            dropdown.addOption('b', 'B', '/i/b.svg');
+            dropdown._renderOptions(dropdown.items);
+            const iconA = dropdown.itemsEl.children[0].querySelector('img.option-icon');
+            const iconB = dropdown.itemsEl.children[1].querySelector('img.option-icon');
+            expect(iconA.classList.contains('has-icon-bg')).to.be.true;
+            expect(iconA.style.backgroundColor).to.not.equal('');
+            expect(iconB.classList.contains('has-icon-bg')).to.be.false;
+            dropdown.destroy();
+        });
+
         it('mirrors an option CSS class onto the rendered option when preserveOptionClasses', function () {
             const select = document.createElement('select');
             select.innerHTML = '<option value="a" class="parent">A</option>';


### PR DESCRIPTION
### Proposed changes

Enhance the searchable dropdown component to support an optional colored tile behind icons. This allows for better visual distinction of options, especially for entities or projects with dark backgrounds.

- Introduce `data-icon-bg` attribute for `<option>` elements
- Update `addOption` method to accept an icon background parameter
- Modify rendering logic to apply background color to icons

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
