### PR TITLE
feat: add editable free-text mode to searchable dropdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ node_modules/
 .classpath
 .factorypath
 .settings/
+
+/app/coverage/

--- a/README.md
+++ b/README.md
@@ -449,6 +449,16 @@ its `placeholder`; pairs naturally with `allowEmpty`),
 CSS class onto the rendered option — e.g. the `parent` class renders a global-scope configuration
 with an italic `global` marker).
 
+**Editable (free-text) mode** — `editable: true` turns the single-select into a *creatable*
+combobox: the trigger becomes a typeable field (the popup's separate search box is dropped — the
+trigger itself filters), focus opens the suggestion list, and a value **not** in the list can be
+committed (on Enter and on blur). Picking an option commits the option's `value` (the `label` is
+shown only in the list). Because a free value cannot live in a `<select>`, editable mode wraps a
+plain `<input>` (the already-supported non-`<select>` element mode) or build mode — the wrapped
+`<input>` is kept in sync and receives `change`. Pass `inputFilter: (value) => value` to sanitise
+what is typed (catches typing *and* paste), e.g. digits-only `v => v.replace(/\D/g, '')` or
+Latin-only `v => v.replace(/[^A-Za-z]/g, '')`.
+
 Per-option **icons**: give a source `<option>` a `data-icon="…"` (element mode) or pass a third
 argument to `addOption(value, text, icon)` (build mode); the icon is shown to the left of the label
 in the list and on the closed single-select trigger. For an icon that sits on a coloured tile (e.g.

--- a/app/src/main/resources/css/searchable-dropdown.css
+++ b/app/src/main/resources/css/searchable-dropdown.css
@@ -149,6 +149,16 @@
     pointer-events: none;
 }
 
+/* Editable mode is a free-text field, not a click-to-open combobox: drop the dropdown chevron and
+   reclaim the space it reserved on the right. */
+.searchable-dropdown.editable::after {
+    display: none;
+}
+
+.searchable-dropdown.editable > input.sd-trigger {
+    padding-right: .5rem;
+}
+
 /* Optional clear (×) button — reset a single-select back to its placeholder. Opt-in via the
    `clearable` option; shown only while a value is selected (.has-value). Sits left of the chevron. */
 .searchable-dropdown.clearable.has-value > input.sd-trigger {

--- a/app/src/main/resources/css/searchable-dropdown.css
+++ b/app/src/main/resources/css/searchable-dropdown.css
@@ -31,6 +31,22 @@
     box-shadow: var(--sbb-control-shadow-hover, 0 2px 6px 0 rgba(0, 0, 0, 0.2));
 }
 
+/* An editable (creatable) trigger is a real text field, not a click-to-open button. */
+.searchable-dropdown > input.sd-trigger:not([readonly]) {
+    cursor: text;
+}
+
+/* An editable trigger can be focused while the popup is closed (e.g. free text that matches no
+   suggestion), so it needs its own focus styling — the .open rule below wouldn't apply. Blue border
+   plus the same soft elevation the text inputs use on focus (inputs.css), not the heavier open-state
+   shadow — an editable field stays focused after a pick, so a strong shadow would linger. Suppress
+   the browser's default outline. */
+.searchable-dropdown > input.sd-trigger:not([readonly]):focus {
+    border-color: var(--sbb-control-border-focus, #1491eb);
+    box-shadow: var(--sbb-control-shadow-hover, 0 2px 6px 0 rgba(0, 0, 0, 0.2));
+    outline: none;
+}
+
 /* Open state — Polarion JSSelector-ComboOpen (blue border + stronger shadow) */
 .searchable-dropdown.open > .sd-trigger {
     border-color: var(--sbb-control-border-focus, #1491eb);
@@ -235,6 +251,15 @@
 .sd-portal .items {
     max-height: 180px;
     overflow-y: auto;
+}
+
+/* Empty-state row shown when no options match (notably in editable mode, which has no search row
+   to give the popup height). */
+.sd-portal .sd-empty {
+    padding: 6px 12px;
+    text-align: center;
+    color: var(--sbb-control-placeholder, #7c7c7c);
+    font-size: var(--sbb-control-font-size, 13px);
 }
 
 /* Option item */

--- a/app/src/main/resources/js/modules/SearchableDropdown.js
+++ b/app/src/main/resources/js/modules/SearchableDropdown.js
@@ -161,11 +161,18 @@ export default class SearchableDropdown {
         if (this.buildMode) {
             // Render straight into the consumer-provided container.
             this.container.classList.add('searchable-dropdown');
+            if (this.editable) {
+                this.container.classList.add('editable');
+            }
             return;
         }
 
         this.container = document.createElement('div');
         this.container.className = 'searchable-dropdown';
+        // An editable trigger is a free-text field, not a click-to-open combobox — drop the chevron.
+        if (this.editable) {
+            this.container.classList.add('editable');
+        }
 
         this.originalElement.parentNode.insertBefore(
             this.container,

--- a/app/src/main/resources/js/modules/SearchableDropdown.js
+++ b/app/src/main/resources/js/modules/SearchableDropdown.js
@@ -792,22 +792,26 @@ export default class SearchableDropdown {
         // Editable mode with no suggestion matching the current free text: nothing to show, so stay
         // closed instead of opening an empty popup (keyboard ArrowDown path; _syncEditablePopup
         // guards the focus/input paths).
-        if (this.editable && this._filterItems(this.trigger.value).length === 0) {
+        // The list actually rendered below: the filtered subset in editable mode, all items
+        // otherwise. Compute it once so the pre-highlight index and the render agree.
+        const list = this.editable ? this._filterItems(this.trigger.value) : this.items;
+        if (this.editable && list.length === 0) {
+            // Nothing matches the free text — stay closed (free-text entry, nothing to suggest).
             return;
         }
         this.isOpen = true;
         this.container.classList.add('open');
         this.trigger.setAttribute('aria-expanded', 'true');
         // Highlight the currently selected item on open (single-select only, and only if something
-        // is actually selected). The highlight then follows the mouse/keyboard. Multi-select shows
-        // its state via checkboxes, so nothing is pre-highlighted.
+        // is actually selected). The index must be resolved against `list` — the array that gets
+        // rendered — not the full items array, or a filtered editable list highlights the wrong row.
         this.activeIndex = (!this.multiselect && this.trigger.value)
-            ? this.items.findIndex(item => item.value === this.value)
+            ? list.findIndex(item => item.value === this.value)
             : -1;
         if (this._hasSearchBox) {
             this.searchInput.value = '';
         }
-        this._renderOptions(this.editable ? this._filterItems(this.trigger.value) : this.items);
+        this._renderOptions(list);
         this._show();
         // Reposition the portal while open if the page scrolls or resizes (capture phase catches
         // scrolling in nested containers such as the document side panel).
@@ -1021,6 +1025,16 @@ export default class SearchableDropdown {
         if (this.multiselect) {
             this.items = this._extractItemsFromSelect(this.originalElement);
             this._updateTriggerFromSelection();
+            return;
+        }
+        if (this.editable) {
+            // Editable wraps a free-text <input>: the element's value is authoritative (and may be
+            // text matching no item), so mirror it onto the trigger verbatim. Reading originalElement
+            // (not the trigger) reflects programmatic updates; skipping the label lookup avoids
+            // blanking a free value that isn't in the item list.
+            this.trigger.value = this.originalElement.value || '';
+            this._applyTriggerClass();
+            this._refreshTriggerIcon();
             return;
         }
         if (this.isSelect && !this.allowEmpty && this.originalElement.selectedIndex === -1 && this.originalElement.options.length > 0) {

--- a/app/src/main/resources/js/modules/SearchableDropdown.js
+++ b/app/src/main/resources/js/modules/SearchableDropdown.js
@@ -17,7 +17,9 @@ export default class SearchableDropdown {
                     rememberSelection = true,
                     preserveOptionClasses = false,
                     allowEmpty = false,
-                    clearable = false
+                    clearable = false,
+                    editable = false,
+                    inputFilter = null
                 }) {
         if (!element && !selectContainer) {
             throw new Error('SearchableDropdown: element or selectContainer is required');
@@ -83,6 +85,15 @@ export default class SearchableDropdown {
 
         this.placeholder = placeholder;
         this.searchable = searchable;
+        // Editable (creatable) single-select: the trigger becomes a typeable input, the popup search
+        // box is dropped (the trigger itself is the filter), and a free value not in the list can be
+        // committed on Enter/blur. Meaningless for multi-select. `inputFilter(value) => value`
+        // sanitises what the user types (e.g. digits-only, Latin-only).
+        this.editable = editable && !multiselect;
+        this.inputFilter = typeof inputFilter === 'function' ? inputFilter : null;
+        // The dedicated popup search box exists only when searchable AND not editable (an editable
+        // dropdown filters from the trigger instead).
+        this._hasSearchBox = this.searchable && !this.editable;
         // Mirror each source option's CSS class onto the rendered option (and, in select mode, the
         // trigger when selected) — e.g. a global-scope config is marked with the `parent` class,
         // which renders a small italic "global" marker. Always on in build mode so classes added
@@ -183,34 +194,36 @@ export default class SearchableDropdown {
                 && !Array.from(this.originalElement.options).some(o => o.defaultSelected)) {
                 this.originalElement.selectedIndex = -1;
             }
+        }
 
-            // Mirror the element's current visibility onto the container...
+        // Mirror the element's current visibility onto the container...
+        this.container.style.display = this.originalElement.style.display || '';
+        this.container.style.visibility = this.originalElement.style.visibility || '';
+
+        // ...then visually hide the wrapped element (a <select>, or an <input> in editable mode)
+        // WITHOUT touching display/visibility, so consumer-driven display/visibility changes
+        // (displayIf, visibleIf, inline onchange handlers) stay observable and can be mirrored onto
+        // the container. Remember the original inline style so destroy() can restore the element.
+        this._originalElementCssText = this.originalElement.style.cssText;
+        this.originalElement.style.position = 'absolute';
+        this.originalElement.style.width = '1px';
+        this.originalElement.style.height = '1px';
+        this.originalElement.style.overflow = 'hidden';
+        this.originalElement.style.opacity = '0';
+        this.originalElement.style.pointerEvents = 'none';
+
+        this._visibilityObserver = new MutationObserver(() => {
             this.container.style.display = this.originalElement.style.display || '';
             this.container.style.visibility = this.originalElement.style.visibility || '';
+            this._syncDisabled();
+            this._syncTitle();
+        });
+        this._visibilityObserver.observe(this.originalElement, {
+            attributes: true,
+            attributeFilter: ['style', 'disabled', 'title']
+        });
 
-            // ...then visually hide the native <select> WITHOUT touching display/visibility,
-            // so consumer-driven display/visibility changes (displayIf, visibleIf, inline
-            // onchange handlers) stay observable and can be mirrored onto the container.
-            // Remember the original inline style so destroy() can restore the <select>.
-            this._originalElementCssText = this.originalElement.style.cssText;
-            this.originalElement.style.position = 'absolute';
-            this.originalElement.style.width = '1px';
-            this.originalElement.style.height = '1px';
-            this.originalElement.style.overflow = 'hidden';
-            this.originalElement.style.opacity = '0';
-            this.originalElement.style.pointerEvents = 'none';
-
-            this._visibilityObserver = new MutationObserver(() => {
-                this.container.style.display = this.originalElement.style.display || '';
-                this.container.style.visibility = this.originalElement.style.visibility || '';
-                this._syncDisabled();
-                this._syncTitle();
-            });
-            this._visibilityObserver.observe(this.originalElement, {
-                attributes: true,
-                attributeFilter: ['style', 'disabled', 'title']
-            });
-
+        if (this.isSelect) {
             // Keep in sync when the <select>'s options are (re)populated dynamically
             this._optionsObserver = new MutationObserver(() => {
                 this.items = this._extractItemsFromSelect(this.originalElement);
@@ -262,7 +275,10 @@ export default class SearchableDropdown {
             this.trigger.type = 'text';
             this.trigger.className = 'sd-trigger';
             this.trigger.placeholder = this.placeholder;
-            this.trigger.readOnly = true;
+            this.trigger.readOnly = !this.editable;
+            if (this.editable) {
+                this.trigger.setAttribute('autocomplete', 'off');
+            }
         }
         if (this.buildMode && this.container.id) {
             this.trigger.id = this.container.id + '_sd-trigger';
@@ -287,7 +303,7 @@ export default class SearchableDropdown {
         this.optionsEl = document.createElement('div');
         this.optionsEl.className = 'options';
 
-        if (this.searchable) {
+        if (this._hasSearchBox) {
             // Search row on top of the popup: search box + erase icon
             // (mirrors Polarion's JComboBox-SearchBox / JComboBox-EraseIcon)
             const searchRow = document.createElement('div');
@@ -381,6 +397,9 @@ export default class SearchableDropdown {
             if (selected) {
                 this.trigger.value = selected.label;
             }
+        } else if (this.editable && !this.buildMode && this.originalElement) {
+            // Editable mode wraps a plain <input>; seed the trigger with its current free value.
+            this.trigger.value = this.originalElement.value || '';
         }
         this._applyTriggerClass();
         this._refreshTriggerIcon();
@@ -407,36 +426,59 @@ export default class SearchableDropdown {
     }
 
     _bindEvents() {
-        // Clicking the trigger opens/closes the popup
-        this.trigger.addEventListener('mousedown', e => {
-            e.preventDefault(); // critical: prevents focus-triggered reopen
-            if (this.isOpen) {
+        if (this.editable) {
+            // Editable trigger: focus surfaces the suggestion list only when the field is empty (a
+            // fresh pick). Clicking into a field that already holds a value just places the caret to
+            // edit it — no dropdown of the value the user already chose. Typing then sanitises +
+            // re-filters, and blur commits the free text. Clicking an option preventDefaults its
+            // mousedown, so blur does not fire on a pick — only on a genuine focus-out.
+            this.trigger.addEventListener('focus', () => {
+                if (!this.trigger.value) {
+                    this._syncEditablePopup();
+                }
+            });
+            this.trigger.addEventListener('input', () => {
+                if (this.inputFilter) {
+                    const clean = this.inputFilter(this.trigger.value);
+                    if (clean !== this.trigger.value) {
+                        this.trigger.value = clean;
+                    }
+                }
+                this.activeIndex = -1;
+                this._syncEditablePopup();
+                this._updateClearButton();
+            });
+            this.trigger.addEventListener('blur', () => {
+                this._commitEditableValue();
                 this._close();
-            } else {
-                this._open();
-            }
-        });
+            });
+        } else {
+            // Clicking the trigger opens/closes the popup
+            this.trigger.addEventListener('mousedown', e => {
+                e.preventDefault(); // critical: prevents focus-triggered reopen
+                if (this.isOpen) {
+                    this._close();
+                } else {
+                    this._open();
+                }
+            });
+        }
 
-        // Keyboard navigation. When searchable the focus is on the search box; otherwise it stays on
-        // the trigger — so the trigger also handles keys, both to open the closed popup and to drive
-        // an open one (arrows/enter/escape) when there is no search box.
+        // Keyboard: an open popup is driven by arrows/enter/escape; a closed one opens on ArrowDown
+        // (and, for the non-editable trigger where those keys carry no text, on Enter/Space too).
         this.trigger.addEventListener('keydown', e => {
             if (this.isOpen) {
                 this._handleKeydown(e);
-            } else if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+            } else if (e.key === 'ArrowDown' || (!this.editable && (e.key === 'Enter' || e.key === ' '))) {
                 e.preventDefault();
                 this._open();
             }
         });
 
-        if (this.searchable) {
+        if (this._hasSearchBox) {
             this.searchInput.addEventListener('input', () => {
-                const query = this.searchInput.value.toLowerCase();
-                const filtered = this.items.filter(item =>
-                    item.label.toLowerCase().includes(query)
-                );
                 this.activeIndex = -1;
-                this._renderOptions(filtered);
+                this._renderOptions(this._filterItems(this.searchInput.value));
             });
 
             this.searchInput.addEventListener('keydown', e => this._handleKeydown(e));
@@ -475,9 +517,60 @@ export default class SearchableDropdown {
         }
     }
 
+    // Items whose label contains the query (case-insensitive). Empty query → all items. Shared by
+    // the popup search box and the editable trigger.
+    _filterItems(query) {
+        const q = (query || '').toLowerCase();
+        if (!q) {
+            return this.items;
+        }
+        return this.items.filter(item => item.label.toLowerCase().includes(q));
+    }
+
+    // Editable mode only: reconcile the suggestion popup with the current trigger text. If nothing
+    // matches, the popup closes rather than showing an empty "No matches" box — free text is allowed,
+    // so a non-matching entry (e.g. the column "AA" against an A–Z hint list) is valid, not an error,
+    // and there is simply nothing to suggest. Otherwise it opens (or re-renders) with the matches.
+    _syncEditablePopup() {
+        const matches = this._filterItems(this.trigger.value);
+        if (matches.length === 0) {
+            this._close();
+        } else if (this.isOpen) {
+            this._renderOptions(matches);
+        } else {
+            this._open();
+        }
+    }
+
+    // Editable mode only: mirror the free text currently in the trigger onto the wrapped <input>
+    // (editable wraps an <input>, not a <select>) and fire change so consumers pick it up. No-op if
+    // the value is unchanged.
+    _commitEditableValue() {
+        // Only reached from the editable trigger's blur/Enter. Build-mode editable has no <input> to
+        // mirror onto, so there is nothing to commit.
+        if (!this.originalElement) {
+            return;
+        }
+        if (this.originalElement.value !== this.trigger.value) {
+            this.originalElement.value = this.trigger.value;
+            this.originalElement.dispatchEvent(new Event('change', { bubbles: true }));
+            this._fireChangeListener();
+        }
+    }
+
     _renderOptions(list) {
         this.itemsEl.innerHTML = '';
         this._visibleItems = list;
+
+        // Empty state: with no options the popup would otherwise be an invisible zero-height box
+        // (there is no search row to give it height in editable mode), so it looks like nothing
+        // dropped. Show a placeholder row instead.
+        if (list.length === 0) {
+            const empty = document.createElement('div');
+            empty.className = 'sd-empty';
+            empty.textContent = 'No matches';
+            this.itemsEl.appendChild(empty);
+        }
 
         list.forEach((item, index) => {
             const option = document.createElement('div');
@@ -608,7 +701,7 @@ export default class SearchableDropdown {
     // Point aria-activedescendant (on whichever element has focus) at the highlighted option so
     // screen readers announce it during arrow-key navigation.
     _updateActiveDescendant() {
-        const target = this.searchable ? this.searchInput : this.trigger;
+        const target = this._hasSearchBox ? this.searchInput : this.trigger;
         const active = this.activeIndex >= 0 ? this.itemsEl.children[this.activeIndex] : null;
         if (active && active.id) {
             target.setAttribute('aria-activedescendant', active.id);
@@ -653,6 +746,10 @@ export default class SearchableDropdown {
         const item = this._visibleItems[this.activeIndex];
         if (item) {
             this.selectItem(item);
+        } else if (this.editable) {
+            // No option highlighted → commit the free text in the trigger and close.
+            this._commitEditableValue();
+            this._close();
         }
     }
 
@@ -679,6 +776,12 @@ export default class SearchableDropdown {
         if (this.isSelect && this.originalElement.disabled) {
             return;
         }
+        // Editable mode with no suggestion matching the current free text: nothing to show, so stay
+        // closed instead of opening an empty popup (keyboard ArrowDown path; _syncEditablePopup
+        // guards the focus/input paths).
+        if (this.editable && this._filterItems(this.trigger.value).length === 0) {
+            return;
+        }
         this.isOpen = true;
         this.container.classList.add('open');
         this.trigger.setAttribute('aria-expanded', 'true');
@@ -688,10 +791,10 @@ export default class SearchableDropdown {
         this.activeIndex = (!this.multiselect && this.trigger.value)
             ? this.items.findIndex(item => item.value === this.value)
             : -1;
-        if (this.searchable) {
+        if (this._hasSearchBox) {
             this.searchInput.value = '';
         }
-        this._renderOptions(this.items);
+        this._renderOptions(this.editable ? this._filterItems(this.trigger.value) : this.items);
         this._show();
         // Reposition the portal while open if the page scrolls or resizes (capture phase catches
         // scrolling in nested containers such as the document side panel).
@@ -706,7 +809,7 @@ export default class SearchableDropdown {
         window.addEventListener('resize', this._repositionHandler);
         // Move focus so keyboard navigation works: to the search box if present, otherwise to the
         // trigger itself (the trigger's mousedown preventDefault suppressed the click-focus).
-        if (this.searchable) {
+        if (this._hasSearchBox) {
             this.searchInput.focus();
         } else {
             this.trigger.focus();
@@ -721,7 +824,7 @@ export default class SearchableDropdown {
         this.container.classList.remove('open');
         this.trigger.setAttribute('aria-expanded', 'false');
         this.trigger.removeAttribute('aria-activedescendant');
-        if (this.searchable) {
+        if (this._hasSearchBox) {
             this.searchInput.removeAttribute('aria-activedescendant');
         }
         this._hide();
@@ -960,7 +1063,9 @@ export default class SearchableDropdown {
             this.items.forEach(i => i.selected = !!item && i.value === item.value);
             this._updateTriggerFromSelection();
         } else {
-            this.trigger.value = item ? item.label : '';
+            // An editable trigger shows the committed value (e.g. a revision number), not the label
+            // (which may be "12345 — description"); a plain dropdown shows the label.
+            this.trigger.value = item ? (this.editable ? String(item.value) : item.label) : '';
             this._applyTriggerClass();
             this._refreshTriggerIcon();
         }
@@ -981,6 +1086,10 @@ export default class SearchableDropdown {
             this.originalElement.dispatchEvent(
                 new Event('change', { bubbles: true })
             );
+        } else if (this.editable && this.originalElement) {
+            // Editable wraps a plain <input>: mirror the picked value onto it and fire change.
+            this.originalElement.value = item ? String(item.value) : '';
+            this.originalElement.dispatchEvent(new Event('change', { bubbles: true }));
         }
 
         this._saveSelection(item ? item.value : null);

--- a/app/src/main/resources/js/modules/SearchableDropdown.js
+++ b/app/src/main/resources/js/modules/SearchableDropdown.js
@@ -476,6 +476,12 @@ export default class SearchableDropdown {
         this.trigger.addEventListener('keydown', e => {
             if (this.isOpen) {
                 this._handleKeydown(e);
+            } else if (this.editable && e.key === 'Enter') {
+                // Editable, popup closed (free text that matches no suggestion): _handleEnter only
+                // runs while the popup is open, so commit the typed value here. preventDefault stops
+                // an enclosing <form> from submitting with the stale wrapped-<input> value.
+                e.preventDefault();
+                this._commitEditableValue();
             } else if (e.key === 'ArrowDown' || (!this.editable && (e.key === 'Enter' || e.key === ' '))) {
                 e.preventDefault();
                 this._open();

--- a/app/src/main/resources/js/modules/SearchableDropdown.js
+++ b/app/src/main/resources/js/modules/SearchableDropdown.js
@@ -1278,6 +1278,12 @@ export default class SearchableDropdown {
             }
         } else {
             this.trigger.value = val;
+            if (this.editable && this.originalElement) {
+                // Editable wraps a live <input>: mirror the programmatic value onto it too, so the
+                // backing element isn't left stale until the next blur (and a later syncFromElement
+                // won't revert the trigger to the old element value).
+                this.originalElement.value = val;
+            }
         }
         this._refreshTriggerIcon();
     }

--- a/app/src/test/js/modules/SearchableDropdownTest.js
+++ b/app/src/test/js/modules/SearchableDropdownTest.js
@@ -1175,6 +1175,8 @@ describe('SearchableDropdown', function () {
             expect(dd._hasSearchBox).to.be.false;
             expect(dd.searchInput).to.be.undefined;
             expect(dd.trigger.value).to.equal('42');
+            // The container is flagged .editable so CSS can drop the combobox chevron.
+            expect(dd.container.classList.contains('editable')).to.be.true;
             dd.destroy();
         });
 

--- a/app/src/test/js/modules/SearchableDropdownTest.js
+++ b/app/src/test/js/modules/SearchableDropdownTest.js
@@ -1298,6 +1298,18 @@ describe('SearchableDropdown', function () {
             dd.destroy();
         });
 
+        it('the value setter mirrors onto the wrapped input in editable mode', function () {
+            const input = editableInput('');
+            const dd = new SearchableDropdown({
+                element: input, editable: true, rememberSelection: false,
+                items: [{ value: 'A', label: 'A' }]
+            });
+            dd.value = 'ZZ';
+            expect(dd.trigger.value).to.equal('ZZ');
+            expect(input.value).to.equal('ZZ'); // backing <input> kept in sync, not left stale
+            dd.destroy();
+        });
+
         it('selecting an option commits its value (not label) and mirrors onto the input', function () {
             const input = editableInput('');
             let fired = 0; input.addEventListener('change', () => fired++);

--- a/app/src/test/js/modules/SearchableDropdownTest.js
+++ b/app/src/test/js/modules/SearchableDropdownTest.js
@@ -1302,6 +1302,26 @@ describe('SearchableDropdown', function () {
             dd.destroy();
         });
 
+        it('Enter commits the free text while the popup is closed (no matches)', function () {
+            const input = editableInput('');
+            let fired = 0; input.addEventListener('change', () => fired++);
+            const dd = new SearchableDropdown({
+                element: input, editable: true, rememberSelection: false,
+                items: [{ value: 'A', label: 'A' }]
+            });
+            // Free text matching no suggestion → popup stays closed.
+            dd.trigger.value = 'ZZ';
+            dd.trigger.dispatchEvent(new Event('input'));
+            expect(dd.isOpen).to.be.false;
+            // Enter must still commit (and preventDefault the event so a form can't submit stale).
+            const evt = new KeyboardEvent('keydown', { key: 'Enter', cancelable: true });
+            dd.trigger.dispatchEvent(evt);
+            expect(input.value).to.equal('ZZ');
+            expect(fired).to.equal(1);
+            expect(evt.defaultPrevented).to.be.true;
+            dd.destroy();
+        });
+
         it('blur commits the free text once, and a second blur with no change does nothing', function () {
             const input = editableInput('');
             let fired = 0; input.addEventListener('change', () => fired++);

--- a/app/src/test/js/modules/SearchableDropdownTest.js
+++ b/app/src/test/js/modules/SearchableDropdownTest.js
@@ -1261,6 +1261,43 @@ describe('SearchableDropdown', function () {
             dd.destroy();
         });
 
+        it('_open() pre-highlights the matching option against the FILTERED list, not full items', function () {
+            const dd = new SearchableDropdown({
+                element: editableInput('api'), editable: true, rememberSelection: false,
+                items: [{ value: 'apple', label: 'apple (A)' }, { value: 'api', label: 'api (I)' }]
+            });
+            dd._open();
+            // Only 'api (I)' matches the filter → rendered at index 0. activeIndex must point at it
+            // (using the full-items index 1 would mark nothing active).
+            expect(dd.itemsEl.querySelectorAll('.option').length).to.equal(1);
+            expect(dd.activeIndex).to.equal(0);
+            const active = dd.itemsEl.querySelector('.option.active');
+            expect(active).to.exist;
+            expect(active.textContent).to.contain('api');
+            dd.destroy();
+        });
+
+        it('syncFromElement mirrors the wrapped input value verbatim (free text, not label)', function () {
+            const input = editableInput('');
+            const dd = new SearchableDropdown({
+                element: input, editable: true, rememberSelection: false,
+                items: [{ value: 'A', label: 'Alpha' }]
+            });
+            // Free text not in the item list must survive (old code blanked it to '').
+            input.value = 'ZZ';
+            dd.syncFromElement();
+            expect(dd.trigger.value).to.equal('ZZ');
+            // A value that IS an item shows as its raw value, not the label.
+            input.value = 'A';
+            dd.syncFromElement();
+            expect(dd.trigger.value).to.equal('A');
+            // Clearing the wrapped input clears the trigger.
+            input.value = '';
+            dd.syncFromElement();
+            expect(dd.trigger.value).to.equal('');
+            dd.destroy();
+        });
+
         it('selecting an option commits its value (not label) and mirrors onto the input', function () {
             const input = editableInput('');
             let fired = 0; input.addEventListener('change', () => fired++);

--- a/app/src/test/js/modules/SearchableDropdownTest.js
+++ b/app/src/test/js/modules/SearchableDropdownTest.js
@@ -939,7 +939,8 @@ describe('SearchableDropdown', function () {
             dropdown.addOption('a', 'A');
             dropdown._open();
             dropdown.empty();
-            expect(dropdown.itemsEl.children.length).to.equal(0);
+            expect(dropdown.itemsEl.querySelectorAll('.option').length).to.equal(0);
+            expect(dropdown.itemsEl.querySelector('.sd-empty')).to.exist;
             dropdown.destroy();
         });
     });
@@ -1152,6 +1153,190 @@ describe('SearchableDropdown', function () {
             handle.label.classList.add('parent');
             expect(dropdown.itemsEl.querySelector('.option').classList.contains('parent')).to.be.true;
             dropdown.destroy();
+        });
+    });
+
+    describe('editable (free-text) mode', function () {
+        function editableInput(initial) {
+            const input = document.createElement('input');
+            input.type = 'text';
+            if (initial !== undefined) input.value = initial;
+            document.body.appendChild(input);
+            return input;
+        }
+
+        it('has an editable trigger, no popup search box, and seeds from the input value', function () {
+            const dd = new SearchableDropdown({
+                element: editableInput('42'), editable: true, rememberSelection: false,
+                items: [{ value: '1', label: 'One' }, { value: '2', label: 'Two' }]
+            });
+            expect(dd.editable).to.be.true;
+            expect(dd.trigger.readOnly).to.be.false;
+            expect(dd._hasSearchBox).to.be.false;
+            expect(dd.searchInput).to.be.undefined;
+            expect(dd.trigger.value).to.equal('42');
+            dd.destroy();
+        });
+
+        it('focus opens the full list', function () {
+            const dd = new SearchableDropdown({
+                element: editableInput(''), editable: true, rememberSelection: false,
+                items: [{ value: '1', label: 'One' }, { value: '2', label: 'Two' }]
+            });
+            dd.trigger.dispatchEvent(new Event('focus'));
+            expect(dd.isOpen).to.be.true;
+            expect(dd.itemsEl.children.length).to.equal(2);
+            dd.destroy();
+        });
+
+        it('focus on a field that already holds a value does not open the popup', function () {
+            const dd = new SearchableDropdown({
+                element: editableInput('A'), editable: true, rememberSelection: false,
+                items: [{ value: 'A', label: 'A' }, { value: 'B', label: 'B' }]
+            });
+            dd.trigger.dispatchEvent(new Event('focus'));
+            expect(dd.isOpen).to.be.false;
+            dd.destroy();
+        });
+
+        it('typing sanitises via inputFilter and filters the list', function () {
+            const dd = new SearchableDropdown({
+                element: editableInput(''), editable: true, rememberSelection: false,
+                inputFilter: v => v.replace(/\D/g, ''),
+                items: [{ value: '10', label: '10 ten' }, { value: '22', label: '22 two' }]
+            });
+            dd.trigger.value = '1a0';
+            dd.trigger.dispatchEvent(new Event('input'));
+            expect(dd.trigger.value).to.equal('10');
+            expect(dd.isOpen).to.be.true;
+            expect(dd.itemsEl.children.length).to.equal(1);
+            dd.destroy();
+        });
+
+        it('typing without an inputFilter still filters', function () {
+            const dd = new SearchableDropdown({
+                element: editableInput(''), editable: true, rememberSelection: false,
+                items: [{ value: 'a', label: 'Apple' }, { value: 'b', label: 'Banana' }]
+            });
+            dd.trigger.value = 'ban';
+            dd.trigger.dispatchEvent(new Event('input'));
+            expect(dd.trigger.value).to.equal('ban');
+            expect(dd.itemsEl.children.length).to.equal(1);
+            dd.destroy();
+        });
+
+        it('typing a value matching no suggestion closes the popup (no "No matches" box)', function () {
+            const az = Array.from({ length: 26 }, (_, i) => {
+                const l = String.fromCharCode(65 + i);
+                return { value: l, label: l };
+            });
+            const dd = new SearchableDropdown({
+                element: editableInput(''), editable: true, rememberSelection: false,
+                inputFilter: v => v.replace(/[^A-Za-z]/g, '').toUpperCase(),
+                items: az
+            });
+            // "A" matches an A–Z hint → popup open with the single suggestion.
+            dd.trigger.value = 'A';
+            dd.trigger.dispatchEvent(new Event('input'));
+            expect(dd.isOpen).to.be.true;
+            expect(dd.itemsEl.children.length).to.equal(1);
+            // Extend to "AA" — valid free text, no single-letter hint matches → popup closes, and it
+            // must NOT show the "No matches" empty state.
+            dd.trigger.value = 'AA';
+            dd.trigger.dispatchEvent(new Event('input'));
+            expect(dd.isOpen).to.be.false;
+            expect(dd.itemsEl.querySelector('.sd-empty')).to.equal(null);
+            dd.destroy();
+        });
+
+        it('_open() stays closed when no suggestion matches the seeded free text', function () {
+            const dd = new SearchableDropdown({
+                element: editableInput('AA'), editable: true, rememberSelection: false,
+                items: [{ value: 'A', label: 'A' }, { value: 'B', label: 'B' }]
+            });
+            dd._open();
+            expect(dd.isOpen).to.be.false;
+            dd.destroy();
+        });
+
+        it('selecting an option commits its value (not label) and mirrors onto the input', function () {
+            const input = editableInput('');
+            let fired = 0; input.addEventListener('change', () => fired++);
+            const dd = new SearchableDropdown({
+                element: input, editable: true, rememberSelection: false,
+                items: [{ value: '12345', label: '12345 revision' }]
+            });
+            dd.selectItem(dd.items[0]);
+            expect(dd.trigger.value).to.equal('12345');
+            expect(input.value).to.equal('12345');
+            expect(fired).to.equal(1);
+            dd.destroy();
+        });
+
+        it('Enter on a highlighted option selects it', function () {
+            const input = editableInput('');
+            const dd = new SearchableDropdown({
+                element: input, editable: true, rememberSelection: false,
+                items: [{ value: 'x', label: 'X' }]
+            });
+            dd._open();
+            dd.activeIndex = 0;
+            dd._handleEnter();
+            expect(input.value).to.equal('x');
+            dd.destroy();
+        });
+
+        it('Enter with no highlighted option commits the free text', function () {
+            const input = editableInput('');
+            const dd = new SearchableDropdown({
+                element: input, editable: true, rememberSelection: false,
+                items: [{ value: '1', label: 'One' }]
+            });
+            dd._open();
+            dd.trigger.value = '999';
+            dd.activeIndex = -1;
+            dd._handleEnter();
+            expect(input.value).to.equal('999');
+            dd.destroy();
+        });
+
+        it('blur commits the free text once, and a second blur with no change does nothing', function () {
+            const input = editableInput('');
+            let fired = 0; input.addEventListener('change', () => fired++);
+            const dd = new SearchableDropdown({ element: input, editable: true, rememberSelection: false, items: [] });
+            dd.trigger.value = 'abc';
+            dd.trigger.dispatchEvent(new Event('blur'));
+            expect(input.value).to.equal('abc');
+            expect(fired).to.equal(1);
+            dd.trigger.dispatchEvent(new Event('blur'));
+            expect(fired).to.equal(1);
+            dd.destroy();
+        });
+
+        it('selectItem(null) clears the editable field and the wrapped input', function () {
+            const input = editableInput('');
+            const dd = new SearchableDropdown({
+                element: input, editable: true, rememberSelection: false,
+                items: [{ value: '7', label: 'Seven' }]
+            });
+            dd.selectItem(dd.items[0]);
+            expect(input.value).to.equal('7');
+            dd.selectItem(null);
+            expect(dd.trigger.value).to.equal('');
+            expect(input.value).to.equal('');
+            dd.destroy();
+        });
+
+        it('build-mode editable has no <input> to mirror onto — blur is a no-op', function () {
+            const dd = new SearchableDropdown({
+                selectContainer: document.getElementById('build-container'),
+                editable: true, rememberSelection: false
+            });
+            dd.addOption('a', 'Apple');
+            expect(dd.originalElement).to.equal(null);
+            dd.trigger.value = 'free';
+            expect(() => dd.trigger.dispatchEvent(new Event('blur'))).to.not.throw();
+            dd.destroy();
         });
     });
 });


### PR DESCRIPTION
### Proposed changes

Introduce an editable mode for the searchable dropdown that allows users to input free text directly into the trigger. This mode enhances user experience by enabling the selection of values not present in the list.

- The trigger becomes a typeable input field
- The popup search box is removed; the trigger itself filters options
- Users can commit free values on Enter or blur
- Input sanitization can be applied via an optional inputFilter function

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
