### PR TITLE
feat: add shared BreadcrumbBridge module

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,36 +589,50 @@ outline (secondary) / filled (primary) buttons — add **`standard-dialog`** to 
 The `.standard-dialog` rules live in `css/micromodal.css` and are **opt-in**, so exporter popups —
 which scope their own look under `.modal__container.<ext>` (e.g. `.pdf-exporter`) — are unaffected.
 
-#### `BreadcrumbBridge` — app-header breadcrumb for SPA extensions
+#### `BreadcrumbBridge` — app-header breadcrumb for topic extensions
 
 `js/modules/BreadcrumbBridge.js` replaces the GWT app-header breadcrumb
-(`.polarion-ApplicationHeader-breadcrumb`) with the extension's own title/icon while the app's URL is
-active. Polarion renders that breadcrumb in the **top** window, but an extension SPA runs in an
-iframe, so the SPA injects this **classic** script into the parent document (it needs
-`document.currentScript` to read its config, so it is deliberately *not* an ES module). It is the
-single shared implementation of what used to be a copy-pasted `<ext>-breadcrumb-bridge.js` per
-extension.
+(`.polarion-ApplicationHeader-breadcrumb`) — which shows a generic "home" for an extension topic —
+with the extension's own name/icon while the extension's URL is active. It mirrors Polarion's own
+breadcrumb shape:
 
-Inject it into the parent and configure it via `data-*` attributes (auto-install):
+- a **root** topic → `[icon] Title` (30px icon)
+- a **sub** topic → `Parent › [small icon] Title` (17px icon)
+
+Polarion renders that breadcrumb in the shell window, but an extension topic runs in a frame, so the
+topic page injects this **classic** script into the shell (it needs `document.currentScript` to read
+its config, so it is deliberately *not* an ES module). It is the single shared implementation of what
+used to be a copy-pasted `<ext>-breadcrumb-bridge.js` per extension. It **never** activates on
+Polarion's own Administration pages (`#/administration/…`), which render their breadcrumb correctly.
+
+Inject it into the shell and configure it via `data-*` attributes (auto-install), or — once loaded —
+call `install()` directly so a sub-topic can re-label without re-loading the module:
 
 ```js
-// From the SPA (e.g. a small React effect), running inside the iframe:
-const doc = window.parent.document;
-if (doc?.head && !doc.getElementById('breadcrumb-bridge-<ext>')) {
+// From the topic page (React effect in the SPA, or an inline script in a topic JSP):
+const shell = window.top;
+const cfg = { marker: '<ext>', title: 'My Extension',
+              // parent: 'My Extension',                 // set for a sub-topic → "Parent › title"
+              icon: '/polarion/<ext>-admin/ui/images/menu/30x30/_parent.svg' };
+if (shell.SbbBreadcrumbBridge) {
+  shell.SbbBreadcrumbBridge.install(cfg);                // already loaded → install/update in place
+} else {
+  const doc = shell.document;
   const s = doc.createElement('script');
-  s.id = 'breadcrumb-bridge-<ext>';
-  s.src = '/polarion/<ext>-app/ui/generic/js/modules/BreadcrumbBridge.js';
-  s.dataset.marker = '<ext>';                 // substring identifying the app in the URL/hash
-  s.dataset.title = 'My Extension';           // breadcrumb title text
-  s.dataset.icon = '/polarion/<ext>-admin/ui/images/menu/30x30/_parent.svg'; // optional
+  s.id = 'sbb-breadcrumb-bridge-loader';
+  s.src = '/polarion/<ext>/ui/generic/js/modules/BreadcrumbBridge.js';
+  s.dataset.marker = cfg.marker;
+  s.dataset.title = cfg.title;
+  if (cfg.parent) s.dataset.parent = cfg.parent;
+  if (cfg.icon) s.dataset.icon = cfg.icon;
   doc.head.appendChild(s);
 }
 ```
 
-It is idempotent per `marker` (re-injecting is a no-op) and waits for the GWT breadcrumb via a
-`MutationObserver`, so it is safe to inject early. It also exposes
-`window.SbbBreadcrumbBridge.install({ marker, title, icon })` for direct callers, returning an
-`{ sync, destroy }` handle.
+Re-installing with the same `marker` **updates** the title/parent/icon (so navigating between an
+extension's sub-topics re-labels the breadcrumb). It hides the real breadcrumb with a `!important`
+stylesheet rule (surviving GWT re-renders) and keeps a `MutationObserver` connected, so it is safe to
+inject early. `install(...)` returns an `{ sync, update, destroy }` handle.
 
 #### Deprecated components
 

--- a/README.md
+++ b/README.md
@@ -589,6 +589,37 @@ outline (secondary) / filled (primary) buttons — add **`standard-dialog`** to 
 The `.standard-dialog` rules live in `css/micromodal.css` and are **opt-in**, so exporter popups —
 which scope their own look under `.modal__container.<ext>` (e.g. `.pdf-exporter`) — are unaffected.
 
+#### `BreadcrumbBridge` — app-header breadcrumb for SPA extensions
+
+`js/modules/BreadcrumbBridge.js` replaces the GWT app-header breadcrumb
+(`.polarion-ApplicationHeader-breadcrumb`) with the extension's own title/icon while the app's URL is
+active. Polarion renders that breadcrumb in the **top** window, but an extension SPA runs in an
+iframe, so the SPA injects this **classic** script into the parent document (it needs
+`document.currentScript` to read its config, so it is deliberately *not* an ES module). It is the
+single shared implementation of what used to be a copy-pasted `<ext>-breadcrumb-bridge.js` per
+extension.
+
+Inject it into the parent and configure it via `data-*` attributes (auto-install):
+
+```js
+// From the SPA (e.g. a small React effect), running inside the iframe:
+const doc = window.parent.document;
+if (doc?.head && !doc.getElementById('breadcrumb-bridge-<ext>')) {
+  const s = doc.createElement('script');
+  s.id = 'breadcrumb-bridge-<ext>';
+  s.src = '/polarion/<ext>-app/ui/generic/js/modules/BreadcrumbBridge.js';
+  s.dataset.marker = '<ext>';                 // substring identifying the app in the URL/hash
+  s.dataset.title = 'My Extension';           // breadcrumb title text
+  s.dataset.icon = '/polarion/<ext>-admin/ui/images/menu/30x30/_parent.svg'; // optional
+  doc.head.appendChild(s);
+}
+```
+
+It is idempotent per `marker` (re-injecting is a no-op) and waits for the GWT breadcrumb via a
+`MutationObserver`, so it is safe to inject early. It also exposes
+`window.SbbBreadcrumbBridge.install({ marker, title, icon })` for direct callers, returning an
+`{ sync, destroy }` handle.
+
 #### Deprecated components
 
 The following are kept only for backward compatibility and should not be used in new code:

--- a/app/src/main/resources/css/searchable-dropdown.css
+++ b/app/src/main/resources/css/searchable-dropdown.css
@@ -323,6 +323,13 @@
     box-sizing: content-box;
 }
 
+/* An icon tile (has-icon-bg) is a few px wider than a bare icon, so on the single-select trigger —
+   where the icon is absolutely positioned and the text just gets left padding — the value would sit
+   flush against the tile. Give it the same gap the popup options get from their flex `gap`. */
+.searchable-dropdown:has(.sd-trigger-icon.has-icon-bg) > input.sd-trigger.has-icon {
+    padding-left: 33px;
+}
+
 /* Multi-select option: a checkbox in front of the label (toggles without closing the popup). */
 .sd-portal .option.multiselect-option {
     display: flex;

--- a/app/src/main/resources/js/modules/BreadcrumbBridge.js
+++ b/app/src/main/resources/js/modules/BreadcrumbBridge.js
@@ -38,15 +38,26 @@
 
     var customId = 'sbb-breadcrumb-' + marker;
 
-    function show(el) {
-      if (el && el.style.display === 'none') {
-        el.style.display = '';
+    var styleId = 'sbb-breadcrumb-style-' + marker;
+
+    // Hide the real GWT breadcrumb(s) with a stylesheet rule rather than a per-element inline style:
+    // GWT re-renders and resets its own element's inline style, which would revive a JS display:none
+    // and leave both breadcrumbs showing. A `!important` rule survives that. Our own replacement
+    // carries data-sbb-bridge and is excluded from the rule.
+    function enableHiding() {
+      if (document.getElementById(styleId)) {
+        return;
       }
+      var style = document.createElement('style');
+      style.id = styleId;
+      style.textContent = '.polarion-ApplicationHeader-breadcrumb:not([data-sbb-bridge]){display:none !important;}';
+      (document.head || document.documentElement).appendChild(style);
     }
 
-    function hide(el) {
-      if (el && el.style.display !== 'none') {
-        el.style.display = 'none';
+    function disableHiding() {
+      var style = document.getElementById(styleId);
+      if (style && style.parentNode) {
+        style.parentNode.removeChild(style);
       }
     }
 
@@ -124,29 +135,35 @@
     }
 
     function sync() {
+      if (!isAppUrl()) {
+        // Not our page: stop hiding the GWT breadcrumb and tuck our replacement away.
+        disableHiding();
+        var existing = document.getElementById(customId);
+        if (existing) {
+          existing.style.display = 'none';
+        }
+        return;
+      }
+
+      // Our page: hide the real breadcrumb (the rule applies even before GWT renders it, so there is
+      // no flash) and mount our replacement once there is a real breadcrumb to anchor it to.
+      enableHiding();
       var original = findOriginal();
       if (!original) {
-        return;
+        return; // GWT hasn't rendered the breadcrumb yet — the observer re-runs sync when it does.
       }
       var custom = ensureCustom(original);
       if (!custom) {
         return;
       }
-
-      if (isAppUrl()) {
-        hide(original);
-        show(custom);
-        if (!builtBreadcrumb) {
-          builtBreadcrumb = buildBreadcrumb();
-        }
-        if (custom.firstChild !== builtBreadcrumb) {
-          custom.textContent = '';
-          custom.appendChild(builtBreadcrumb);
-        }
-      } else {
-        show(original);
-        hide(custom);
+      if (!builtBreadcrumb) {
+        builtBreadcrumb = buildBreadcrumb();
       }
+      if (custom.firstChild !== builtBreadcrumb) {
+        custom.textContent = '';
+        custom.appendChild(builtBreadcrumb);
+      }
+      custom.style.display = '';
     }
 
     window.addEventListener('popstate', sync);
@@ -169,6 +186,8 @@
         window.removeEventListener('popstate', sync);
         window.removeEventListener('hashchange', sync);
         observer.disconnect();
+        // Remove the hiding rule so the GWT breadcrumb comes back (rather than leaving a blank slot).
+        disableHiding();
         var custom = document.getElementById(customId);
         if (custom && custom.parentNode) {
           custom.parentNode.removeChild(custom);

--- a/app/src/main/resources/js/modules/BreadcrumbBridge.js
+++ b/app/src/main/resources/js/modules/BreadcrumbBridge.js
@@ -1,43 +1,55 @@
 /*
- * Shared breadcrumb bridge for React/SPA extensions.
+ * Shared breadcrumb bridge for SPA / topic-page extensions.
  *
  * Polarion renders the app-header breadcrumb (`.polarion-ApplicationHeader-breadcrumb`) with GWT in
- * the TOP window. An extension SPA lives in an iframe, so to show its own breadcrumb it injects this
- * classic script into the parent document; the script then swaps the GWT breadcrumb for the app's
- * own while the app's URL is active. Previously every extension shipped a copy-pasted
- * `<ext>-breadcrumb-bridge.js`; this is the single shared implementation.
+ * the parent window, but for an extension topic opened in the project navigation it shows a generic
+ * "home" instead of the extension's own name. This script, injected into the parent document, swaps
+ * that breadcrumb for the extension's own while the extension's URL is active. It replaces what used
+ * to be a copy-pasted `<ext>-breadcrumb-bridge.js` per extension.
+ *
+ * It mirrors Polarion's own breadcrumb shape:
+ *   - a ROOT topic   ->  [icon] Title                       (30px icon)
+ *   - a SUB topic     ->  Parent  ›  [small icon] Title       (17px icon)
  *
  * NOTE: this is intentionally NOT an ES module (no import/export) — it is injected into the parent
  * page as a classic <script> so that `document.currentScript` is available to read its config.
  *
  * Two ways to use it:
- *   1. Classic-script auto-install — inject it with data-* attributes; it configures itself from the
- *      injecting <script>:
- *        data-marker (required) substring identifying the app in the URL/hash (e.g. "xml-repair")
+ *   1. Classic-script auto-install — inject it with data-* attributes:
+ *        data-marker (required) substring identifying the app in the URL/hash (e.g. "diff-tool")
  *        data-title  (required) breadcrumb title text
+ *        data-parent (optional) parent topic name; when set, renders "parent › [icon] title"
  *        data-icon   (optional) icon URL shown left of the title
- *   2. Direct call — `window.SbbBreadcrumbBridge.install({ marker, title, icon })`.
+ *   2. Direct call — `window.SbbBreadcrumbBridge.install({ marker, title, parent, icon })`.
  *
- * install() is idempotent per marker (re-installing returns the existing instance) and returns an
- * { sync, destroy } handle.
+ * Re-installing/re-injecting with the same marker UPDATES the title/parent/icon (so navigating
+ * between an extension's sub-topics re-labels the breadcrumb) and returns the existing instance.
+ * install() returns an { sync, update, destroy } handle. It never activates on Polarion's own
+ * Administration pages (URL under `#/administration`), which render their breadcrumb correctly.
  */
 (function () {
   function installBreadcrumbBridge(config) {
     config = config || {};
     var marker = config.marker;
-    var title = config.title;
-    var iconSrc = config.icon || '';
-    if (!marker || !title) {
+    if (!marker || !config.title) {
       return null;
     }
 
     var installedFlag = '__sbbBreadcrumbBridge_' + marker;
     if (window[installedFlag]) {
+      window[installedFlag].update(config);
       return window[installedFlag];
     }
 
-    var customId = 'sbb-breadcrumb-' + marker;
+    // Mutable config so re-injection (e.g. navigating to a sub-topic) can re-label without a fresh
+    // install.
+    var current = {
+      title: config.title,
+      parent: config.parent || '',
+      icon: config.icon || ''
+    };
 
+    var customId = 'sbb-breadcrumb-' + marker;
     var styleId = 'sbb-breadcrumb-style-' + marker;
 
     // Hide the real GWT breadcrumb(s) with a stylesheet rule rather than a per-element inline style:
@@ -68,9 +80,32 @@
       return document.querySelector('.polarion-ApplicationHeader-breadcrumb:not([data-sbb-bridge])');
     }
 
-    // Build the replacement breadcrumb once, via the DOM (no innerHTML), so the app-supplied title
-    // and icon can never be interpreted as markup.
+    // Build the replacement breadcrumb, via the DOM (no innerHTML), so the app-supplied title and
+    // icon can never be interpreted as markup. Rebuilt whenever the config changes.
     var builtBreadcrumb = null;
+
+    function appendIconAndTitle(wrap, iconSize) {
+      if (current.icon) {
+        var imagePanel = document.createElement('div');
+        imagePanel.className = 'polarion-ApplicationHeader-imagePanel';
+        var img = document.createElement('img');
+        img.src = current.icon;
+        img.alt = '';
+        img.className = 'gwt-Image';
+        img.style.width = iconSize;
+        img.style.height = iconSize;
+        imagePanel.appendChild(img);
+        wrap.appendChild(imagePanel);
+      }
+      var titlePanel = document.createElement('div');
+      titlePanel.className = 'polarion-ApplicationHeader-breadcrumbTitlePanel';
+      var titleEl = document.createElement('div');
+      titleEl.className = 'polarion-ApplicationHeader-breadcrumbTitle';
+      titleEl.title = current.title;
+      titleEl.textContent = current.title;
+      titlePanel.appendChild(titleEl);
+      wrap.appendChild(titlePanel);
+    }
 
     function buildBreadcrumb() {
       var wrap = document.createElement('div');
@@ -78,28 +113,28 @@
       // Marks this as our replacement so findOriginal() never mistakes it for the GWT element.
       wrap.setAttribute('data-sbb-bridge', '');
 
-      if (iconSrc) {
-        var imagePanel = document.createElement('div');
-        imagePanel.className = 'polarion-ApplicationHeader-imagePanel';
-        var img = document.createElement('img');
-        img.src = iconSrc;
-        img.alt = '';
-        img.className = 'gwt-Image';
-        img.style.width = '30px';
-        img.style.height = '30px';
-        imagePanel.appendChild(img);
-        wrap.appendChild(imagePanel);
+      var isSub = !!current.parent;
+      if (isSub) {
+        // Parent name, then a separator, matching Polarion's "Parent › child" sub-topic breadcrumb.
+        var parentPanel = document.createElement('div');
+        parentPanel.className = 'polarion-ApplicationHeader-breadcrumbTitlePanel';
+        var parentTitle = document.createElement('div');
+        parentTitle.className = 'polarion-ApplicationHeader-breadcrumbTitle';
+        parentTitle.title = current.parent;
+        parentTitle.textContent = current.parent;
+        parentPanel.appendChild(parentTitle);
+        wrap.appendChild(parentPanel);
+
+        var sep = document.createElement('div');
+        sep.className = 'polarion-ApplicationHeader-breadcrumbSeparator';
+        sep.textContent = '›'; // ›
+        sep.style.margin = '0 8px';
+        sep.style.opacity = '0.75';
+        wrap.appendChild(sep);
       }
 
-      var titlePanel = document.createElement('div');
-      titlePanel.className = 'polarion-ApplicationHeader-breadcrumbTitlePanel';
-      var titleEl = document.createElement('div');
-      titleEl.className = 'polarion-ApplicationHeader-breadcrumbTitle';
-      titleEl.title = title;
-      titleEl.textContent = title;
-      titlePanel.appendChild(titleEl);
-      wrap.appendChild(titlePanel);
-
+      // Sub-topics use a small icon (like Polarion's topic icons); roots use the large one.
+      appendIconAndTitle(wrap, isSub ? '17px' : '30px');
       return wrap;
     }
 
@@ -128,10 +163,13 @@
 
     function isAppUrl() {
       var loc = window.location;
-      return (
-        (loc.hash && loc.hash.indexOf(marker) !== -1) ||
-        loc.href.indexOf(marker) !== -1
-      );
+      var hash = loc.hash || '';
+      // Polarion's Administration renders the correct breadcrumb itself — never override it there
+      // (the admin URL is `#/administration/<ext>/...`, which also contains our marker).
+      if (hash.indexOf('/administration') !== -1 || loc.href.indexOf('/#/administration') !== -1) {
+        return false;
+      }
+      return hash.indexOf(marker) !== -1 || loc.href.indexOf(marker) !== -1;
     }
 
     function sync() {
@@ -166,6 +204,17 @@
       custom.style.display = '';
     }
 
+    function update(cfg) {
+      cfg = cfg || {};
+      if (cfg.title) {
+        current.title = cfg.title;
+      }
+      current.parent = cfg.parent || '';
+      current.icon = cfg.icon || '';
+      builtBreadcrumb = null; // force a rebuild with the new config on the next sync
+      sync();
+    }
+
     window.addEventListener('popstate', sync);
     window.addEventListener('hashchange', sync);
 
@@ -182,6 +231,7 @@
 
     var api = {
       sync: sync,
+      update: update,
       destroy: function () {
         window.removeEventListener('popstate', sync);
         window.removeEventListener('hashchange', sync);
@@ -208,6 +258,7 @@
     installBreadcrumbBridge({
       marker: script.getAttribute('data-marker'),
       title: script.getAttribute('data-title'),
+      parent: script.getAttribute('data-parent') || '',
       icon: script.getAttribute('data-icon') || ''
     });
   }

--- a/app/src/main/resources/js/modules/BreadcrumbBridge.js
+++ b/app/src/main/resources/js/modules/BreadcrumbBridge.js
@@ -1,0 +1,191 @@
+/*
+ * Shared breadcrumb bridge for React/SPA extensions.
+ *
+ * Polarion renders the app-header breadcrumb (`.polarion-ApplicationHeader-breadcrumb`) with GWT in
+ * the TOP window. An extension SPA lives in an iframe, so to show its own breadcrumb it injects this
+ * classic script into the parent document; the script then swaps the GWT breadcrumb for the app's
+ * own while the app's URL is active. Previously every extension shipped a copy-pasted
+ * `<ext>-breadcrumb-bridge.js`; this is the single shared implementation.
+ *
+ * NOTE: this is intentionally NOT an ES module (no import/export) — it is injected into the parent
+ * page as a classic <script> so that `document.currentScript` is available to read its config.
+ *
+ * Two ways to use it:
+ *   1. Classic-script auto-install — inject it with data-* attributes; it configures itself from the
+ *      injecting <script>:
+ *        data-marker (required) substring identifying the app in the URL/hash (e.g. "xml-repair")
+ *        data-title  (required) breadcrumb title text
+ *        data-icon   (optional) icon URL shown left of the title
+ *   2. Direct call — `window.SbbBreadcrumbBridge.install({ marker, title, icon })`.
+ *
+ * install() is idempotent per marker (re-installing returns the existing instance) and returns an
+ * { sync, destroy } handle.
+ */
+(function () {
+  function installBreadcrumbBridge(config) {
+    config = config || {};
+    var marker = config.marker;
+    var title = config.title;
+    var iconSrc = config.icon || '';
+    if (!marker || !title) {
+      return null;
+    }
+
+    var installedFlag = '__sbbBreadcrumbBridge_' + marker;
+    if (window[installedFlag]) {
+      return window[installedFlag];
+    }
+
+    var customId = 'sbb-breadcrumb-' + marker;
+
+    function show(el) {
+      if (el && el.style.display === 'none') {
+        el.style.display = '';
+      }
+    }
+
+    function hide(el) {
+      if (el && el.style.display !== 'none') {
+        el.style.display = 'none';
+      }
+    }
+
+    function findOriginal() {
+      return document.querySelector('.polarion-ApplicationHeader-breadcrumb');
+    }
+
+    // Build the replacement breadcrumb once, via the DOM (no innerHTML), so the app-supplied title
+    // and icon can never be interpreted as markup.
+    var builtBreadcrumb = null;
+
+    function buildBreadcrumb() {
+      var wrap = document.createElement('div');
+      wrap.className = 'polarion-ApplicationHeader-breadcrumb';
+
+      if (iconSrc) {
+        var imagePanel = document.createElement('div');
+        imagePanel.className = 'polarion-ApplicationHeader-imagePanel';
+        var img = document.createElement('img');
+        img.src = iconSrc;
+        img.alt = '';
+        img.className = 'gwt-Image';
+        img.style.width = '30px';
+        img.style.height = '30px';
+        imagePanel.appendChild(img);
+        wrap.appendChild(imagePanel);
+      }
+
+      var titlePanel = document.createElement('div');
+      titlePanel.className = 'polarion-ApplicationHeader-breadcrumbTitlePanel';
+      var titleEl = document.createElement('div');
+      titleEl.className = 'polarion-ApplicationHeader-breadcrumbTitle';
+      titleEl.title = title;
+      titleEl.textContent = title;
+      titlePanel.appendChild(titleEl);
+      wrap.appendChild(titlePanel);
+
+      return wrap;
+    }
+
+    function ensureCustom(original) {
+      var custom = document.getElementById(customId);
+      if (!custom) {
+        if (!original || !original.parentNode) {
+          return null;
+        }
+        custom = document.createElement('div');
+        custom.id = customId;
+        original.insertAdjacentElement('afterend', custom);
+        custom.style.font = 'inherit';
+        custom.style.whiteSpace = 'nowrap';
+        custom.style.display = 'none';
+      }
+
+      // Match the original's flex order so the replacement sits in the same slot.
+      var originalOrder = window.getComputedStyle(original).order;
+      if (originalOrder && originalOrder !== '0') {
+        custom.style.order = originalOrder;
+      }
+
+      return custom;
+    }
+
+    function isAppUrl() {
+      var loc = window.location;
+      return (
+        (loc.hash && loc.hash.indexOf(marker) !== -1) ||
+        loc.href.indexOf(marker) !== -1
+      );
+    }
+
+    function sync() {
+      var original = findOriginal();
+      if (!original) {
+        return;
+      }
+      var custom = ensureCustom(original);
+      if (!custom) {
+        return;
+      }
+
+      if (isAppUrl()) {
+        hide(original);
+        show(custom);
+        if (!builtBreadcrumb) {
+          builtBreadcrumb = buildBreadcrumb();
+        }
+        if (custom.firstChild !== builtBreadcrumb) {
+          custom.textContent = '';
+          custom.appendChild(builtBreadcrumb);
+        }
+      } else {
+        show(original);
+        hide(custom);
+      }
+    }
+
+    window.addEventListener('popstate', sync);
+    window.addEventListener('hashchange', sync);
+
+    // The original breadcrumb is rendered by GWT and may not exist yet — observe until it appears,
+    // then sync (and keep syncing on later re-renders while the app URL is active).
+    var observer = new MutationObserver(function () {
+      if (findOriginal()) {
+        observer.disconnect();
+        sync();
+      }
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    sync();
+
+    var api = {
+      sync: sync,
+      destroy: function () {
+        window.removeEventListener('popstate', sync);
+        window.removeEventListener('hashchange', sync);
+        observer.disconnect();
+        var custom = document.getElementById(customId);
+        if (custom && custom.parentNode) {
+          custom.parentNode.removeChild(custom);
+        }
+        delete window[installedFlag];
+      }
+    };
+    window[installedFlag] = api;
+    return api;
+  }
+
+  // Expose for direct callers (and unit tests). In the browser globalThis === window.
+  globalThis.SbbBreadcrumbBridge = { install: installBreadcrumbBridge };
+
+  // Auto-install when injected as a classic <script> carrying data-* config.
+  var script = (typeof document !== 'undefined') ? document.currentScript : null;
+  if (script && script.getAttribute('data-marker')) {
+    installBreadcrumbBridge({
+      marker: script.getAttribute('data-marker'),
+      title: script.getAttribute('data-title'),
+      icon: script.getAttribute('data-icon') || ''
+    });
+  }
+})();

--- a/app/src/main/resources/js/modules/BreadcrumbBridge.js
+++ b/app/src/main/resources/js/modules/BreadcrumbBridge.js
@@ -51,7 +51,10 @@
     }
 
     function findOriginal() {
-      return document.querySelector('.polarion-ApplicationHeader-breadcrumb');
+      // Exclude our own replacement (built with the same GWT class, see buildBreadcrumb): otherwise,
+      // while GWT has transiently removed its node, this would match the built one nested in `custom`
+      // and sync() would hide it, blanking the breadcrumb.
+      return document.querySelector('.polarion-ApplicationHeader-breadcrumb:not([data-sbb-bridge])');
     }
 
     // Build the replacement breadcrumb once, via the DOM (no innerHTML), so the app-supplied title
@@ -61,6 +64,8 @@
     function buildBreadcrumb() {
       var wrap = document.createElement('div');
       wrap.className = 'polarion-ApplicationHeader-breadcrumb';
+      // Marks this as our replacement so findOriginal() never mistakes it for the GWT element.
+      wrap.setAttribute('data-sbb-bridge', '');
 
       if (iconSrc) {
         var imagePanel = document.createElement('div');
@@ -147,15 +152,14 @@
     window.addEventListener('popstate', sync);
     window.addEventListener('hashchange', sync);
 
-    // The original breadcrumb is rendered by GWT and may not exist yet — observe until it appears,
-    // then sync (and keep syncing on later re-renders while the app URL is active).
+    // The original breadcrumb is rendered by GWT and may not exist yet, and GWT can re-render it
+    // later without a URL change. So keep the observer connected and re-sync on every mutation
+    // (sync() is a cheap no-op once the state already matches, so this cannot loop). Falls back to
+    // documentElement in case the script runs before <body> is parsed.
     var observer = new MutationObserver(function () {
-      if (findOriginal()) {
-        observer.disconnect();
-        sync();
-      }
+      sync();
     });
-    observer.observe(document.body, { childList: true, subtree: true });
+    observer.observe(document.body || document.documentElement, { childList: true, subtree: true });
 
     sync();
 

--- a/app/src/test/js/modules/BreadcrumbBridgeTest.js
+++ b/app/src/test/js/modules/BreadcrumbBridgeTest.js
@@ -1,0 +1,140 @@
+import { expect } from 'chai';
+import { JSDOM } from 'jsdom';
+
+// The module is a classic (non-module) script that self-registers on globalThis; importing it for
+// its side effect exposes window.SbbBreadcrumbBridge.install for the tests.
+import '../../../main/resources/js/modules/BreadcrumbBridge.js';
+
+const install = globalThis.SbbBreadcrumbBridge.install;
+
+const ORIGINAL_CLASS = 'polarion-ApplicationHeader-breadcrumb';
+const MARKER = 'xml-repair';
+const CONFIG = { marker: MARKER, title: 'XML-Repair', icon: '/polarion/xml-repair-admin/icon.svg' };
+
+describe('BreadcrumbBridge', function () {
+  let dom;
+  let handle;
+
+  function boot(url) {
+    dom = new JSDOM('<!DOCTYPE html><html lang="en"><head></head><body></body></html>', { url });
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.MutationObserver = dom.window.MutationObserver;
+  }
+
+  function addOriginal() {
+    const original = document.createElement('div');
+    original.className = ORIGINAL_CLASS;
+    original.textContent = 'Polarion';
+    document.body.appendChild(original);
+    return original;
+  }
+
+  afterEach(function () {
+    if (handle) {
+      handle.destroy();
+      handle = null;
+    }
+    delete global.window;
+    delete global.document;
+    delete global.MutationObserver;
+  });
+
+  it('does nothing without a marker or title', function () {
+    boot('https://host/polarion/xml-repair-app/');
+    expect(install({})).to.equal(null);
+    expect(install({ marker: MARKER })).to.equal(null);
+    expect(install({ title: 'X' })).to.equal(null);
+  });
+
+  it('replaces the GWT breadcrumb while the app URL is active', function () {
+    boot('https://host/polarion/xml-repair-app/');
+    const original = addOriginal();
+    handle = install(CONFIG);
+
+    const custom = document.getElementById('sbb-breadcrumb-' + MARKER);
+    expect(custom).to.exist;
+    expect(original.previousElementSibling === null || custom.previousElementSibling).to.exist; // custom sits after original
+    expect(custom.previousElementSibling).to.equal(original);
+    expect(original.style.display).to.equal('none');
+    expect(custom.style.display).to.not.equal('none');
+
+    const titleEl = custom.querySelector('.polarion-ApplicationHeader-breadcrumbTitle');
+    expect(titleEl.textContent).to.equal('XML-Repair');
+    expect(titleEl.title).to.equal('XML-Repair');
+    const img = custom.querySelector('img');
+    expect(img).to.exist;
+    expect(img.getAttribute('src')).to.equal('/polarion/xml-repair-admin/icon.svg');
+  });
+
+  it('keeps the GWT breadcrumb when the app URL is not active', function () {
+    boot('https://host/polarion/some-other-app/');
+    const original = addOriginal();
+    handle = install(CONFIG);
+
+    const custom = document.getElementById('sbb-breadcrumb-' + MARKER);
+    expect(original.style.display).to.not.equal('none');
+    expect(custom.style.display).to.equal('none');
+    expect(custom.querySelector('.polarion-ApplicationHeader-breadcrumbTitle')).to.equal(null);
+  });
+
+  it('omits the icon when none is configured', function () {
+    boot('https://host/polarion/xml-repair-app/');
+    addOriginal();
+    handle = install({ marker: MARKER, title: 'XML-Repair' });
+    const custom = document.getElementById('sbb-breadcrumb-' + MARKER);
+    expect(custom.querySelector('img')).to.equal(null);
+    expect(custom.querySelector('.polarion-ApplicationHeader-breadcrumbTitle').textContent).to.equal('XML-Repair');
+  });
+
+  it('is idempotent per marker (re-install returns the same handle)', function () {
+    boot('https://host/polarion/xml-repair-app/');
+    addOriginal();
+    handle = install(CONFIG);
+    const again = install(CONFIG);
+    expect(again).to.equal(handle);
+  });
+
+  it('waits for a late-rendered GWT breadcrumb via MutationObserver', async function () {
+    boot('https://host/polarion/xml-repair-app/');
+    handle = install(CONFIG);
+    // Original not there yet → nothing injected.
+    expect(document.getElementById('sbb-breadcrumb-' + MARKER)).to.equal(null);
+
+    addOriginal();
+    await new Promise((resolve) => setTimeout(resolve, 0)); // flush the observer callback
+
+    const custom = document.getElementById('sbb-breadcrumb-' + MARKER);
+    expect(custom).to.exist;
+    expect(custom.querySelector('.polarion-ApplicationHeader-breadcrumbTitle').textContent).to.equal('XML-Repair');
+  });
+
+  it('re-syncs on hashchange', function () {
+    boot('https://host/polarion/shell/'); // no marker in the URL yet
+    const original = addOriginal();
+    handle = install(CONFIG);
+    expect(original.style.display).to.not.equal('none');
+
+    dom.window.location.hash = '#/xml-repair/scan';
+    dom.window.dispatchEvent(new dom.window.Event('hashchange'));
+
+    const custom = document.getElementById('sbb-breadcrumb-' + MARKER);
+    expect(original.style.display).to.equal('none');
+    expect(custom.style.display).to.not.equal('none');
+  });
+
+  it('destroy() removes the custom breadcrumb and lets a fresh install run again', function () {
+    boot('https://host/polarion/xml-repair-app/');
+    addOriginal();
+    const first = install(CONFIG);
+    expect(document.getElementById('sbb-breadcrumb-' + MARKER)).to.exist;
+
+    first.destroy();
+    expect(document.getElementById('sbb-breadcrumb-' + MARKER)).to.equal(null);
+
+    // Flag cleared → a new install is a fresh instance, not the destroyed one.
+    handle = install(CONFIG);
+    expect(handle).to.not.equal(first);
+    expect(document.getElementById('sbb-breadcrumb-' + MARKER)).to.exist;
+  });
+});

--- a/app/src/test/js/modules/BreadcrumbBridgeTest.js
+++ b/app/src/test/js/modules/BreadcrumbBridgeTest.js
@@ -164,6 +164,56 @@ describe('BreadcrumbBridge', function () {
     expect(customEl().querySelector('.polarion-ApplicationHeader-breadcrumbTitle')).to.exist;
   });
 
+  it('does not activate on Polarion Administration pages', function () {
+    // The admin URL is `#/administration/<ext>/...`, which also contains the marker — but Polarion
+    // renders the correct breadcrumb there, so the bridge must stay out.
+    boot('https://host/polarion/#/administration/xml-repair/settings');
+    addOriginal();
+    handle = install(CONFIG);
+    expect(styleTag()).to.equal(null);
+    expect(customEl()).to.equal(null);
+  });
+
+  it('renders a sub-topic as "parent › small-icon title"', function () {
+    boot('https://host/polarion/#/project/x/xml-repair/details');
+    addOriginal();
+    handle = install({ marker: MARKER, title: 'Details', parent: 'XML-Repair', icon: '/i.svg' });
+
+    const custom = customEl();
+    const titles = custom.querySelectorAll('.polarion-ApplicationHeader-breadcrumbTitle');
+    expect(titles.length).to.equal(2);
+    expect(titles[0].textContent).to.equal('XML-Repair'); // parent segment
+    expect(titles[1].textContent).to.equal('Details');    // current topic
+    expect(custom.querySelector('.polarion-ApplicationHeader-breadcrumbSeparator')).to.exist;
+    expect(custom.querySelector('img').style.width).to.equal('17px'); // small sub icon
+  });
+
+  it('root topics use the large icon and no parent segment', function () {
+    boot('https://host/polarion/xml-repair-app/');
+    addOriginal();
+    handle = install(CONFIG);
+    const custom = customEl();
+    expect(custom.querySelectorAll('.polarion-ApplicationHeader-breadcrumbTitle').length).to.equal(1);
+    expect(custom.querySelector('.polarion-ApplicationHeader-breadcrumbSeparator')).to.equal(null);
+    expect(custom.querySelector('img').style.width).to.equal('30px');
+  });
+
+  it('re-installing with the same marker re-labels (sub-topic switch) and reuses the instance', function () {
+    boot('https://host/polarion/xml-repair-app/');
+    addOriginal();
+    handle = install({ marker: MARKER, title: 'Root', icon: '/i.svg' });
+    let titles = customEl().querySelectorAll('.polarion-ApplicationHeader-breadcrumbTitle');
+    expect(titles.length).to.equal(1);
+    expect(titles[0].textContent).to.equal('Root');
+
+    const same = install({ marker: MARKER, title: 'Child', parent: 'Root', icon: '/i.svg' });
+    expect(same).to.equal(handle); // same instance, updated in place
+    titles = customEl().querySelectorAll('.polarion-ApplicationHeader-breadcrumbTitle');
+    expect(titles.length).to.equal(2);
+    expect(titles[0].textContent).to.equal('Root');  // parent
+    expect(titles[1].textContent).to.equal('Child'); // new current topic
+  });
+
   it('destroy() restores the GWT breadcrumb and lets a fresh install run again', function () {
     boot('https://host/polarion/xml-repair-app/');
     addOriginal();

--- a/app/src/test/js/modules/BreadcrumbBridgeTest.js
+++ b/app/src/test/js/modules/BreadcrumbBridgeTest.js
@@ -123,6 +123,39 @@ describe('BreadcrumbBridge', function () {
     expect(custom.style.display).to.not.equal('none');
   });
 
+  it('re-applies the swap when GWT re-renders the breadcrumb (observer stays connected)', async function () {
+    boot('https://host/polarion/xml-repair-app/');
+    const original = addOriginal();
+    handle = install(CONFIG);
+    expect(original.style.display).to.equal('none');
+
+    // GWT re-render: the old node is replaced by a fresh one that defaults to visible.
+    original.remove();
+    const fresh = addOriginal();
+    await new Promise((resolve) => setTimeout(resolve, 0)); // flush the observer
+
+    expect(fresh.style.display).to.equal('none');
+    const custom = document.getElementById('sbb-breadcrumb-' + MARKER);
+    expect(custom.style.display).to.not.equal('none');
+  });
+
+  it('never mistakes its own built breadcrumb for the GWT element', function () {
+    boot('https://host/polarion/xml-repair-app/');
+    const original = addOriginal();
+    handle = install(CONFIG);
+    const custom = document.getElementById('sbb-breadcrumb-' + MARKER);
+    expect(custom.querySelector('.polarion-ApplicationHeader-breadcrumbTitle').textContent).to.equal('XML-Repair');
+
+    // GWT momentarily removes its node; a sync fires meanwhile. The built breadcrumb carries the
+    // same class but is excluded via [data-sbb-bridge], so findOriginal() returns null and sync()
+    // leaves the custom breadcrumb untouched instead of hiding its own content.
+    original.remove();
+    handle.sync();
+
+    expect(custom.style.display).to.not.equal('none');
+    expect(custom.querySelector('.polarion-ApplicationHeader-breadcrumbTitle')).to.exist;
+  });
+
   it('destroy() removes the custom breadcrumb and lets a fresh install run again', function () {
     boot('https://host/polarion/xml-repair-app/');
     addOriginal();

--- a/app/src/test/js/modules/BreadcrumbBridgeTest.js
+++ b/app/src/test/js/modules/BreadcrumbBridgeTest.js
@@ -10,6 +10,8 @@ const install = globalThis.SbbBreadcrumbBridge.install;
 const ORIGINAL_CLASS = 'polarion-ApplicationHeader-breadcrumb';
 const MARKER = 'xml-repair';
 const CONFIG = { marker: MARKER, title: 'XML-Repair', icon: '/polarion/xml-repair-admin/icon.svg' };
+const STYLE_ID = 'sbb-breadcrumb-style-' + MARKER;
+const CUSTOM_ID = 'sbb-breadcrumb-' + MARKER;
 
 describe('BreadcrumbBridge', function () {
   let dom;
@@ -30,6 +32,9 @@ describe('BreadcrumbBridge', function () {
     return original;
   }
 
+  const styleTag = () => document.getElementById(STYLE_ID);
+  const customEl = () => document.getElementById(CUSTOM_ID);
+
   afterEach(function () {
     if (handle) {
       handle.destroy();
@@ -47,42 +52,45 @@ describe('BreadcrumbBridge', function () {
     expect(install({ title: 'X' })).to.equal(null);
   });
 
-  it('replaces the GWT breadcrumb while the app URL is active', function () {
+  it('hides the GWT breadcrumb via a stylesheet rule and mounts its own while active', function () {
     boot('https://host/polarion/xml-repair-app/');
     const original = addOriginal();
     handle = install(CONFIG);
 
-    const custom = document.getElementById('sbb-breadcrumb-' + MARKER);
+    // The real breadcrumb is hidden by a !important rule (survives GWT resetting its inline style),
+    // not by touching the element itself.
+    expect(styleTag()).to.exist;
+    expect(styleTag().textContent).to.contain(':not([data-sbb-bridge])');
+    expect(styleTag().textContent).to.contain('display:none !important');
+    expect(original.style.display).to.equal(''); // we never touch the GWT element's inline style
+
+    const custom = customEl();
     expect(custom).to.exist;
-    expect(original.previousElementSibling === null || custom.previousElementSibling).to.exist; // custom sits after original
     expect(custom.previousElementSibling).to.equal(original);
-    expect(original.style.display).to.equal('none');
     expect(custom.style.display).to.not.equal('none');
 
     const titleEl = custom.querySelector('.polarion-ApplicationHeader-breadcrumbTitle');
     expect(titleEl.textContent).to.equal('XML-Repair');
     expect(titleEl.title).to.equal('XML-Repair');
-    const img = custom.querySelector('img');
-    expect(img).to.exist;
-    expect(img.getAttribute('src')).to.equal('/polarion/xml-repair-admin/icon.svg');
+    expect(custom.querySelector('img').getAttribute('src')).to.equal('/polarion/xml-repair-admin/icon.svg');
+    // The built breadcrumb carries data-sbb-bridge so the hide rule never matches it.
+    expect(custom.querySelector('[data-sbb-bridge]')).to.exist;
   });
 
-  it('keeps the GWT breadcrumb when the app URL is not active', function () {
+  it('does not hide anything when the app URL is not active', function () {
     boot('https://host/polarion/some-other-app/');
-    const original = addOriginal();
+    addOriginal();
     handle = install(CONFIG);
 
-    const custom = document.getElementById('sbb-breadcrumb-' + MARKER);
-    expect(original.style.display).to.not.equal('none');
-    expect(custom.style.display).to.equal('none');
-    expect(custom.querySelector('.polarion-ApplicationHeader-breadcrumbTitle')).to.equal(null);
+    expect(styleTag()).to.equal(null);
+    expect(customEl()).to.equal(null);
   });
 
   it('omits the icon when none is configured', function () {
     boot('https://host/polarion/xml-repair-app/');
     addOriginal();
     handle = install({ marker: MARKER, title: 'XML-Repair' });
-    const custom = document.getElementById('sbb-breadcrumb-' + MARKER);
+    const custom = customEl();
     expect(custom.querySelector('img')).to.equal(null);
     expect(custom.querySelector('.polarion-ApplicationHeader-breadcrumbTitle').textContent).to.equal('XML-Repair');
   });
@@ -95,79 +103,82 @@ describe('BreadcrumbBridge', function () {
     expect(again).to.equal(handle);
   });
 
-  it('waits for a late-rendered GWT breadcrumb via MutationObserver', async function () {
+  it('starts hiding immediately and mounts once a late GWT breadcrumb appears', async function () {
     boot('https://host/polarion/xml-repair-app/');
     handle = install(CONFIG);
-    // Original not there yet → nothing injected.
-    expect(document.getElementById('sbb-breadcrumb-' + MARKER)).to.equal(null);
+    // Hiding rule is applied even before GWT renders (no flash); the custom waits for an anchor.
+    expect(styleTag()).to.exist;
+    expect(customEl()).to.equal(null);
 
     addOriginal();
-    await new Promise((resolve) => setTimeout(resolve, 0)); // flush the observer callback
+    await new Promise((resolve) => setTimeout(resolve, 0)); // flush the observer
 
-    const custom = document.getElementById('sbb-breadcrumb-' + MARKER);
+    const custom = customEl();
     expect(custom).to.exist;
     expect(custom.querySelector('.polarion-ApplicationHeader-breadcrumbTitle').textContent).to.equal('XML-Repair');
   });
 
   it('re-syncs on hashchange', function () {
     boot('https://host/polarion/shell/'); // no marker in the URL yet
-    const original = addOriginal();
+    addOriginal();
     handle = install(CONFIG);
-    expect(original.style.display).to.not.equal('none');
+    expect(styleTag()).to.equal(null);
 
     dom.window.location.hash = '#/xml-repair/scan';
     dom.window.dispatchEvent(new dom.window.Event('hashchange'));
 
-    const custom = document.getElementById('sbb-breadcrumb-' + MARKER);
-    expect(original.style.display).to.equal('none');
-    expect(custom.style.display).to.not.equal('none');
+    expect(styleTag()).to.exist;
+    expect(customEl().style.display).to.not.equal('none');
   });
 
-  it('re-applies the swap when GWT re-renders the breadcrumb (observer stays connected)', async function () {
+  it('keeps hiding across a GWT re-render (observer stays connected)', async function () {
     boot('https://host/polarion/xml-repair-app/');
     const original = addOriginal();
     handle = install(CONFIG);
-    expect(original.style.display).to.equal('none');
+    expect(styleTag()).to.exist;
 
-    // GWT re-render: the old node is replaced by a fresh one that defaults to visible.
+    // GWT re-render: the old node is replaced by a fresh one. The stylesheet rule keeps hiding any
+    // real breadcrumb regardless, and the custom stays mounted.
     original.remove();
-    const fresh = addOriginal();
+    addOriginal();
     await new Promise((resolve) => setTimeout(resolve, 0)); // flush the observer
 
-    expect(fresh.style.display).to.equal('none');
-    const custom = document.getElementById('sbb-breadcrumb-' + MARKER);
-    expect(custom.style.display).to.not.equal('none');
+    expect(styleTag()).to.exist;
+    expect(customEl().style.display).to.not.equal('none');
   });
 
   it('never mistakes its own built breadcrumb for the GWT element', function () {
     boot('https://host/polarion/xml-repair-app/');
     const original = addOriginal();
     handle = install(CONFIG);
-    const custom = document.getElementById('sbb-breadcrumb-' + MARKER);
-    expect(custom.querySelector('.polarion-ApplicationHeader-breadcrumbTitle').textContent).to.equal('XML-Repair');
+    expect(customEl().querySelector('.polarion-ApplicationHeader-breadcrumbTitle').textContent).to.equal('XML-Repair');
 
     // GWT momentarily removes its node; a sync fires meanwhile. The built breadcrumb carries the
-    // same class but is excluded via [data-sbb-bridge], so findOriginal() returns null and sync()
-    // leaves the custom breadcrumb untouched instead of hiding its own content.
+    // same class but is excluded via [data-sbb-bridge], so findOriginal() returns null and the
+    // custom breadcrumb is left intact.
     original.remove();
     handle.sync();
 
-    expect(custom.style.display).to.not.equal('none');
-    expect(custom.querySelector('.polarion-ApplicationHeader-breadcrumbTitle')).to.exist;
+    expect(styleTag()).to.exist;
+    expect(customEl().style.display).to.not.equal('none');
+    expect(customEl().querySelector('.polarion-ApplicationHeader-breadcrumbTitle')).to.exist;
   });
 
-  it('destroy() removes the custom breadcrumb and lets a fresh install run again', function () {
+  it('destroy() restores the GWT breadcrumb and lets a fresh install run again', function () {
     boot('https://host/polarion/xml-repair-app/');
     addOriginal();
     const first = install(CONFIG);
-    expect(document.getElementById('sbb-breadcrumb-' + MARKER)).to.exist;
+    expect(styleTag()).to.exist;
+    expect(customEl()).to.exist;
 
     first.destroy();
-    expect(document.getElementById('sbb-breadcrumb-' + MARKER)).to.equal(null);
+    // Hiding rule gone (GWT breadcrumb visible again) and our element removed — no blank slot.
+    expect(styleTag()).to.equal(null);
+    expect(customEl()).to.equal(null);
 
-    // Flag cleared → a new install is a fresh instance, not the destroyed one.
     handle = install(CONFIG);
     expect(handle).to.not.equal(first);
-    expect(document.getElementById('sbb-breadcrumb-' + MARKER)).to.exist;
+    expect(styleTag()).to.exist;
+    expect(customEl()).to.exist;
   });
 });


### PR DESCRIPTION
### Proposed changes

Extract the copy-pasted per-extension breadcrumb bridge into one generic module. It swaps Polarion's GWT app-header breadcrumb for an SPA extension's own title/icon while the app URL is active: injected as a classic script into the parent window and configured via data-* attributes (or the exposed window.SbbBreadcrumbBridge.install). Idempotent per marker; waits for the GWT breadcrumb via MutationObserver.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
