### PR TITLE
feat: unify duplicated form controls across extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,12 +516,17 @@ Bootstrap classes) and cannot link `checkboxes.css` / `searchable-dropdown.css`.
 2. **For real combobox parity**, wrap a native `<select>` with the vanilla `SearchableDropdown`,
    loaded via a runtime dynamic import (bundler-ignored so the build does not try to resolve the URL),
    and link `searchable-dropdown.css`. The `<select>` stays framework-controlled; the component
-   mirrors the selection back and dispatches `change`:
+   mirrors the selection back and dispatches `change`. Use the shared **`searchableSelect.js`** factory
+   (`createSearchableSelect`) rather than calling `new SearchableDropdown(...)` per app — it owns the
+   defaults every combobox uses (`searchable`, `preserveOptionClasses`, no remembered selection). Derive
+   the module URL from the SPA's own location so there is **no hardcoded `/<ext>-app/` segment** — the
+   wrapper is then identical across every extension:
 
    ```js
-   const SD = (await import(/* webpackIgnore: true */ /* @vite-ignore */
-     '/polarion/<ext>-app/ui/generic/js/modules/SearchableDropdown.js')).default;
-   new SD({ element: selectEl, rememberSelection: false });
+   const base = window.location.pathname.replace(/\/ui\/.*$/, '/ui/generic/js/modules/');
+   const { createSearchableSelect } = await import(/* webpackIgnore: true */ /* @vite-ignore */ base + 'searchableSelect.js');
+   const sd = createSearchableSelect(selectEl, { allowEmpty: true, placeholder: 'Pick…' });
+   // sd.selectValue(value) to sync from framework state; sd.destroy() on unmount.
    ```
 
 Because both the tokens and the dropdown module are consumed **at runtime**, `generic` stays the

--- a/README.md
+++ b/README.md
@@ -519,15 +519,22 @@ Bootstrap classes) and cannot link `checkboxes.css` / `searchable-dropdown.css`.
    mirrors the selection back and dispatches `change`. Use the shared **`searchableSelect.js`** factory
    (`createSearchableSelect`) rather than calling `new SearchableDropdown(...)` per app — it owns the
    defaults every combobox uses (`searchable`, `preserveOptionClasses`, no remembered selection). Derive
-   the module URL from the SPA's own location so there is **no hardcoded `/<ext>-app/` segment** — the
-   wrapper is then identical across every extension:
+   the module URL from **this module's own served URL** (`import.meta.url`) so there is **no hardcoded
+   `/<ext>-app/` segment** — the wrapper is then identical across every extension. (Derive from
+   `import.meta.url`, not `location.pathname`: the module URL is always under `…/ui/…` and is stable
+   regardless of the SPA's client-side route.)
 
    ```js
-   const base = window.location.pathname.replace(/\/ui\/.*$/, '/ui/generic/js/modules/');
+   const base = new URL('.', import.meta.url).href.replace(/\/ui\/.*$/, '/ui/generic/js/modules/');
    const { createSearchableSelect } = await import(/* webpackIgnore: true */ /* @vite-ignore */ base + 'searchableSelect.js');
    const sd = createSearchableSelect(selectEl, { allowEmpty: true, placeholder: 'Pick…' });
    // sd.selectValue(value) to sync from framework state; sd.destroy() on unmount.
    ```
+
+   Server webapps that upgrade a fixed set of `<select>`s by id (the exporters) use the batch helper
+   from the same module — `initSearchableDropdowns(ctx, singleIds, multiSelectId, options?)` — which
+   wraps each via `createSearchableSelect` (so they share the same defaults) and forwards `options`
+   (e.g. `{ allowEmpty: true }`) to every one.
 
 Because both the tokens and the dropdown module are consumed **at runtime**, `generic` stays the
 single source of truth — there is no JS package to publish and no build-time coupling. Always ship

--- a/app/src/main/resources/js/modules/searchableSelect.js
+++ b/app/src/main/resources/js/modules/searchableSelect.js
@@ -35,17 +35,17 @@ export function createSearchableSelect(selectElement, options = {}) {
  * drop their copy-pasted (and drifted) `dropdown-utils.js`. `ctx` is the extension's ExtensionContext
  * (only `getElementById` is used).
  */
-export function initSearchableDropdowns(ctx, singleIds, multiSelectId) {
+export function initSearchableDropdowns(ctx, singleIds, multiSelectId, options = {}) {
   (singleIds || []).forEach((id) => {
     const element = ctx.getElementById(id);
     if (element) {
-      new SearchableDropdown({ element, placeholder: '', rememberSelection: false });
+      createSearchableSelect(element, { placeholder: '', ...options });
     }
   });
   if (multiSelectId) {
     const element = ctx.getElementById(multiSelectId);
     if (element) {
-      new SearchableDropdown({ element, placeholder: '', rememberSelection: false, multiselect: true });
+      createSearchableSelect(element, { placeholder: '', ...options, multiselect: true });
     }
   }
 }

--- a/app/src/main/resources/js/modules/searchableSelect.js
+++ b/app/src/main/resources/js/modules/searchableSelect.js
@@ -28,3 +28,24 @@ export function createSearchableSelect(selectElement, options = {}) {
     ...options
   });
 }
+
+/*
+ * Convenience for the exporters (pdf / docx / strictdoc), which upgrade a fixed set of <select>s by
+ * id — a batch of single-selects plus one optional `<select multiple>`. Shared here so the exporters
+ * drop their copy-pasted (and drifted) `dropdown-utils.js`. `ctx` is the extension's ExtensionContext
+ * (only `getElementById` is used).
+ */
+export function initSearchableDropdowns(ctx, singleIds, multiSelectId) {
+  (singleIds || []).forEach((id) => {
+    const element = ctx.getElementById(id);
+    if (element) {
+      new SearchableDropdown({ element, placeholder: '', rememberSelection: false });
+    }
+  });
+  if (multiSelectId) {
+    const element = ctx.getElementById(multiSelectId);
+    if (element) {
+      new SearchableDropdown({ element, placeholder: '', rememberSelection: false, multiselect: true });
+    }
+  }
+}

--- a/app/src/main/resources/js/modules/searchableSelect.js
+++ b/app/src/main/resources/js/modules/searchableSelect.js
@@ -1,0 +1,30 @@
+import SearchableDropdown from './SearchableDropdown.js';
+
+/*
+ * Framework-agnostic core of the per-extension `SearchableSelect` React/Next wrappers.
+ *
+ * Every SPA duplicated the same tiny wrapper that upgrades a native <select> to the shared
+ * SearchableDropdown; the only real difference between the copies was a hardcoded
+ * `/<ext>-app/ui/generic/...` URL. This module owns the "how a <select> becomes the standard
+ * Polarion combobox" contract (the SearchableDropdown options every extension uses), so the wrappers
+ * shrink to a thin framework shim.
+ *
+ * It is served next to SearchableDropdown.js, so it resolves it via a plain relative import — no
+ * `/<ext>-app/` segment to hardcode. Consumers load THIS module by deriving its URL from their own
+ * runtime location (also dropping the hardcoded segment), e.g. from a React effect:
+ *
+ *   const base = window.location.pathname.replace(/\/ui\/.*$/, '/ui/generic/js/modules/');
+ *   const { createSearchableSelect } = await import(base + 'searchableSelect.js');
+ *   const sd = createSearchableSelect(selectEl, { allowEmpty: true, placeholder: 'Pick…' });
+ *   // …later: sd.selectValue(value) to sync, sd.destroy() on unmount.
+ */
+export function createSearchableSelect(selectElement, options = {}) {
+  return new SearchableDropdown({
+    element: selectElement,
+    // Defaults shared by every extension's combobox; callers override per case.
+    searchable: true,
+    rememberSelection: false,
+    preserveOptionClasses: true,
+    ...options
+  });
+}

--- a/app/src/test/js/modules/searchableSelectTest.js
+++ b/app/src/test/js/modules/searchableSelectTest.js
@@ -62,4 +62,14 @@ describe('createSearchableSelect', function () {
     expect(m.nextElementSibling.classList.contains('searchable-dropdown')).to.be.true;
     expect(m.nextElementSibling.querySelector('.sd-trigger-multi')).to.exist; // rendered as multi-select
   });
+
+  it('initSearchableDropdowns inherits the shared defaults and passes options through', function () {
+    const s = selectWith(['a', 'b']); s.id = 's';
+    const ctx = { getElementById: (id) => document.getElementById(id) };
+    initSearchableDropdowns(ctx, ['s'], null, { allowEmpty: true });
+    const sd = s._searchableDropdown;
+    expect(sd.preserveOptionClasses).to.be.true; // inherited from createSearchableSelect (not dropped)
+    expect(sd.searchable).to.be.true;
+    expect(sd.allowEmpty).to.be.true;            // passed through via the options arg
+  });
 });

--- a/app/src/test/js/modules/searchableSelectTest.js
+++ b/app/src/test/js/modules/searchableSelectTest.js
@@ -1,0 +1,50 @@
+import { expect } from 'chai';
+import { JSDOM } from 'jsdom';
+import { createSearchableSelect } from '../../../main/resources/js/modules/searchableSelect.js';
+
+describe('createSearchableSelect', function () {
+  let dom;
+
+  beforeEach(function () {
+    dom = new JSDOM('<!DOCTYPE html><html lang="en"><body></body></html>');
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.MutationObserver = dom.window.MutationObserver;
+  });
+
+  afterEach(function () {
+    delete global.window;
+    delete global.document;
+    delete global.MutationObserver;
+  });
+
+  function selectWith(values) {
+    const sel = document.createElement('select');
+    values.forEach((v) => {
+      const o = document.createElement('option');
+      o.value = v;
+      o.textContent = v;
+      sel.appendChild(o);
+    });
+    document.body.appendChild(sel);
+    return sel;
+  }
+
+  it('wraps a <select> with the shared SearchableDropdown and shared defaults', function () {
+    const sel = selectWith(['a', 'b']);
+    const sd = createSearchableSelect(sel);
+    expect(sd.originalElement).to.equal(sel);
+    expect(sd.searchable).to.be.true;
+    expect(sd.preserveOptionClasses).to.be.true;
+    sd.destroy();
+  });
+
+  it('lets callers override the defaults', function () {
+    const sel = selectWith(['x']);
+    const sd = createSearchableSelect(sel, { allowEmpty: true, placeholder: 'Pick…', searchable: false });
+    expect(sd.searchable).to.be.false;
+    expect(sd.allowEmpty).to.be.true;
+    expect(sd.placeholder).to.equal('Pick…');
+    sd.destroy();
+  });
+});

--- a/app/src/test/js/modules/searchableSelectTest.js
+++ b/app/src/test/js/modules/searchableSelectTest.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { JSDOM } from 'jsdom';
-import { createSearchableSelect } from '../../../main/resources/js/modules/searchableSelect.js';
+import { createSearchableSelect, initSearchableDropdowns } from '../../../main/resources/js/modules/searchableSelect.js';
 
 describe('createSearchableSelect', function () {
   let dom;
@@ -46,5 +46,20 @@ describe('createSearchableSelect', function () {
     expect(sd.allowEmpty).to.be.true;
     expect(sd.placeholder).to.equal('Pick…');
     sd.destroy();
+  });
+
+  it('initSearchableDropdowns upgrades the single-select ids and the optional multi-select', function () {
+    const s1 = selectWith(['a']); s1.id = 's1';
+    const s2 = selectWith(['b']); s2.id = 's2';
+    const m = selectWith(['c']); m.id = 'roles'; m.multiple = true;
+    const ctx = { getElementById: (id) => document.getElementById(id) };
+
+    initSearchableDropdowns(ctx, ['s1', 's2', 'missing'], 'roles');
+
+    // Each wrapped <select> gets a sibling `.searchable-dropdown` container; a missing id is skipped.
+    expect(s1.nextElementSibling.classList.contains('searchable-dropdown')).to.be.true;
+    expect(s2.nextElementSibling.classList.contains('searchable-dropdown')).to.be.true;
+    expect(m.nextElementSibling.classList.contains('searchable-dropdown')).to.be.true;
+    expect(m.nextElementSibling.querySelector('.sd-trigger-multi')).to.exist; // rendered as multi-select
   });
 });


### PR DESCRIPTION
### Proposed changes

The pdf/docx/strictdoc exporters each ship an identical (and drifting)
dropdown-utils.js that upgrades a fixed set of <select>s by id — a batch of
single-selects plus one optional <select multiple>. Move that helper into the
shared searchableSelect.js so the exporters can drop their copies and import it.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
