### PR TITLE
feat: add shared styling for data tables and loading spinner

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ automatically, so a pane that re-initialises its dropdowns won't stack duplicate
 #### Shared control styling
 
 `css/common.css` (`@import` it, or link it from admin JSPs) pulls in the neutral, Polarion-matched
-styles for `checkboxes.css`, `radios.css`, `inputs.css` and `searchable-dropdown.css`, plus the
+styles for `checkboxes.css`, `radios.css`, `inputs.css`, `searchable-dropdown.css` and `tables.css`, plus the
 `.toolbar-button` styling. The checkbox / radio / input rules are intentionally **scoped** to the
 UI wrappers `.modal__container` (popups), `.standard-admin-page` (admin pages) and `.form-wrapper`
 (document-properties side panels) so they never restyle Polarion's own controls — put the matching
@@ -535,6 +535,25 @@ Bootstrap classes) and cannot link `checkboxes.css` / `searchable-dropdown.css`.
    from the same module — `initSearchableDropdowns(ctx, singleIds, multiSelectId, options?)` — which
    wraps each via `createSearchableSelect` (so they share the same defaults) and forwards `options`
    (e.g. `{ allowEmpty: true }`) to every one.
+
+   For an **editable / free-text** field (type a value or pick a filtered suggestion), the same module
+   exports `createEditableSelect(inputEl, { inputFilter, items, placeholder })` — it wraps a text
+   `<input>` as an editable dropdown (`editable: true`). It is the shared core of the React
+   `SearchableInput` and the vanilla excel `ColumnInput`.
+
+3. **Loading spinner**: reference `var(--sbb-spinner)` (the Polarion progress wheel) or add the
+   `.sbb-spinner` class instead of hardcoding `/polarion/ria/images/progressWheel48.svg`, so the asset
+   is swappable in one place (both are defined in `control-tokens.css`).
+
+4. **Data tables**: give a results/list `<table>` the `sbb-table` class (`css/tables.css`, also
+   `@import`ed by `common.css`) for the shared Polarion look — outer frame, tinted header, row
+   separators and a hover tint, all driven by the `--sbb-table-*` tokens. Add `sbb-table--grid` for
+   full spreadsheet cell borders or `sbb-table--compact` for denser rows; the extension keeps only its
+   own column widths and row-state highlights. React SPAs link it at runtime like the other sheets:
+
+   ```html
+   <link rel="stylesheet" href="/polarion/<ext>-app/ui/generic/css/tables.css" />
+   ```
 
 Because both the tokens and the dropdown module are consumed **at runtime**, `generic` stays the
 single source of truth — there is no JS package to publish and no build-time coupling. Always ship

--- a/app/src/main/resources/css/common.css
+++ b/app/src/main/resources/css/common.css
@@ -3,6 +3,7 @@
 @import url("radios.css");
 @import url("inputs.css");
 @import url("searchable-dropdown.css");
+@import url("tables.css");
 
 @font-face {
     font-family: "Selawik";

--- a/app/src/main/resources/css/control-tokens.css
+++ b/app/src/main/resources/css/control-tokens.css
@@ -55,4 +55,23 @@
     --sbb-chip-bg: var(--sbb-hover-tint, #ebf7f8);
     --sbb-chip-border: #b6dfe3;
     --sbb-chip-remove: #5c8a90;
+
+    /* Loading spinner — the Polarion 2606 progress wheel, so extensions stop hardcoding the asset
+       path and can swap it in one place. Use via `background: var(--sbb-spinner)` or the .sbb-spinner
+       class below. */
+    --sbb-spinner: url(/polarion/ria/images/progressWheel48.svg);
+
+    /* Data tables — the shared list/results table look (see tables.css), so extensions stop
+       re-deriving the same header tint / border color for every results grid. */
+    --sbb-table-header-bg: #e8e8e3;
+    --sbb-table-header-text: #495057;
+    --sbb-table-border: #dddddd;
+    --sbb-table-row-hover: var(--sbb-hover-tint, #ebf7f8);
+}
+
+/* Spinner utility: a CSS-background progress wheel (prefer this over an <img> so the markup stays
+   semantic and the asset is swappable in one place). Size it via width/height on the element. */
+.sbb-spinner {
+    display: inline-block;
+    background: var(--sbb-spinner, url(/polarion/ria/images/progressWheel48.svg)) center / contain no-repeat;
 }

--- a/app/src/main/resources/css/tables.css
+++ b/app/src/main/resources/css/tables.css
@@ -1,0 +1,64 @@
+/*
+ * Shared data-table look for extension list/results grids.
+ *
+ * Opt in by adding the `sbb-table` class to a `<table>`; the extension keeps owning its
+ * layout-specific rules (column widths, row-state highlights, nested rows). Colors come from
+ * control-tokens.css so the header tint and borders are tuned in one place.
+ *
+ * Base           — horizontal row separators + outer frame (the modern Polarion 2606 list look).
+ * `sbb-table--grid`    — full cell borders (spreadsheet style), for dense multi-column grids.
+ * `sbb-table--compact` — smaller font + tighter padding, for high-row-count tables.
+ */
+
+.sbb-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+    background: #fff;
+    border: 1px solid var(--sbb-table-border, #dddddd);
+    border-radius: 3px;
+}
+
+.sbb-table th {
+    padding: 7px 10px;
+    text-align: left;
+    font-weight: 600;
+    color: var(--sbb-table-header-text, #495057);
+    background: var(--sbb-table-header-bg, #e8e8e3);
+    border-bottom: 1px solid var(--sbb-table-border, #dddddd);
+}
+
+.sbb-table td {
+    padding: 7px 10px;
+    vertical-align: top;
+    border-bottom: 1px solid var(--sbb-table-border, #dddddd);
+}
+
+.sbb-table tbody tr:last-child > td {
+    border-bottom: none;
+}
+
+.sbb-table tbody tr:hover > td {
+    background: var(--sbb-table-row-hover, #ebf7f8);
+}
+
+/* Spreadsheet-style full cell borders. */
+.sbb-table--grid,
+.sbb-table--grid th,
+.sbb-table--grid td {
+    border: 1px solid var(--sbb-table-border, #dddddd);
+}
+
+.sbb-table--grid {
+    border-radius: 0;
+}
+
+/* Denser variant for long lists. */
+.sbb-table--compact {
+    font-size: 12px;
+}
+
+.sbb-table--compact th,
+.sbb-table--compact td {
+    padding: 6px 8px;
+}

--- a/app/src/main/resources/js/modules/SearchableDropdown.js
+++ b/app/src/main/resources/js/modules/SearchableDropdown.js
@@ -243,15 +243,22 @@ export default class SearchableDropdown {
         }
     }
 
-    // Mirror the wrapped <select>'s disabled state onto the container (dimmed + non-interactive via
+    // Mirror the wrapped element's disabled state onto the container (dimmed + non-interactive via
     // the .disabled CSS class). Driven by the visibility MutationObserver when the attribute toggles.
+    // The select trigger is readonly (click-to-open), so the .disabled class is enough; the editable
+    // trigger is a real text <input>, so it must also be natively disabled or the user could still
+    // type into it while the wrapped <input disabled> is hidden.
     _syncDisabled() {
-        if (!this.isSelect) {
+        // Build-mode dropdowns have no wrapped element to mirror from.
+        if (!this.originalElement) {
             return;
         }
         const disabled = this.originalElement.disabled;
         this.container.classList.toggle('disabled', disabled);
         this.trigger.setAttribute('aria-disabled', disabled ? 'true' : 'false');
+        if (this.editable) {
+            this.trigger.disabled = disabled;
+        }
         if (disabled && this.isOpen) {
             this._close();
         }

--- a/app/src/main/resources/js/modules/searchableSelect.js
+++ b/app/src/main/resources/js/modules/searchableSelect.js
@@ -30,6 +30,21 @@ export function createSearchableSelect(selectElement, options = {}) {
 }
 
 /*
+ * Editable (free-text / creatable) sibling of createSearchableSelect: wraps a text <input> so the
+ * user can type a free value OR pick from a filtered suggestion list. The framework-agnostic core of
+ * the React `SearchableInput` and the vanilla excel `ColumnInput`. Callers pass an `inputFilter`
+ * (value => sanitised value) and `items`/`placeholder` as needed.
+ */
+export function createEditableSelect(inputElement, options = {}) {
+  return new SearchableDropdown({
+    element: inputElement,
+    editable: true,
+    rememberSelection: false,
+    ...options
+  });
+}
+
+/*
  * Convenience for the exporters (pdf / docx / strictdoc), which upgrade a fixed set of <select>s by
  * id — a batch of single-selects plus one optional `<select multiple>`. Shared here so the exporters
  * drop their copy-pasted (and drifted) `dropdown-utils.js`. `ctx` is the extension's ExtensionContext

--- a/app/src/test/js/modules/searchableSelectTest.js
+++ b/app/src/test/js/modules/searchableSelectTest.js
@@ -78,6 +78,24 @@ describe('createSearchableSelect', function () {
     sd.destroy();
   });
 
+  it('createEditableSelect mirrors the wrapped input disabled state onto the editable trigger', function () {
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.disabled = true;
+    document.body.appendChild(input);
+    const sd = createEditableSelect(input, { items: [{ value: '1', label: 'One' }] });
+    // The editable trigger is a real text input, so a disabled wrapped <input> must disable it too
+    // (otherwise the hidden input is disabled but the visible trigger stays typeable).
+    expect(sd.trigger.disabled).to.be.true;
+    expect(sd.container.classList.contains('disabled')).to.be.true;
+    // Re-enabling the wrapped input propagates through _syncDisabled (the observer's handler).
+    input.disabled = false;
+    sd._syncDisabled();
+    expect(sd.trigger.disabled).to.be.false;
+    expect(sd.container.classList.contains('disabled')).to.be.false;
+    sd.destroy();
+  });
+
   it('initSearchableDropdowns inherits the shared defaults and passes options through', function () {
     const s = selectWith(['a', 'b']); s.id = 's';
     const ctx = { getElementById: (id) => document.getElementById(id) };

--- a/app/src/test/js/modules/searchableSelectTest.js
+++ b/app/src/test/js/modules/searchableSelectTest.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { JSDOM } from 'jsdom';
-import { createSearchableSelect, initSearchableDropdowns } from '../../../main/resources/js/modules/searchableSelect.js';
+import { createSearchableSelect, createEditableSelect, initSearchableDropdowns } from '../../../main/resources/js/modules/searchableSelect.js';
 
 describe('createSearchableSelect', function () {
   let dom;
@@ -61,6 +61,21 @@ describe('createSearchableSelect', function () {
     expect(s2.nextElementSibling.classList.contains('searchable-dropdown')).to.be.true;
     expect(m.nextElementSibling.classList.contains('searchable-dropdown')).to.be.true;
     expect(m.nextElementSibling.querySelector('.sd-trigger-multi')).to.exist; // rendered as multi-select
+  });
+
+  it('createEditableSelect wraps an <input> as an editable free-text dropdown', function () {
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.value = '';
+    document.body.appendChild(input);
+    const sd = createEditableSelect(input, {
+      inputFilter: (v) => v.replace(/\D/g, ''),
+      items: [{ value: '1', label: 'One' }]
+    });
+    expect(sd.editable).to.be.true;
+    expect(sd.originalElement).to.equal(input);
+    expect(typeof sd.inputFilter).to.equal('function');
+    sd.destroy();
   });
 
   it('initSearchableDropdowns inherits the shared defaults and passes options through', function () {


### PR DESCRIPTION
### Proposed changes

Introduce a consistent look for data tables across extensions by adding a new `tables.css` file. This allows extensions to use the `sbb-table` class for a unified design.

- Add CSS variables for table header and row styles
- Implement a loading spinner utility for better asset management

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
