### PR TITLE
refactor: scope --sbb-*  tokens and control rules to prevent cross extension clobbering

### DIFF
--- a/app/src/main/resources/css/buttons.css
+++ b/app/src/main/resources/css/buttons.css
@@ -13,8 +13,10 @@
  * .editor-buttons button) are aliased here, so existing markup gets the unified look with NO change
  * and the duplicated local copies can simply be deleted downstream.
  *
- * Self-contained: every token carries a literal fallback (var(--x, <literal>)), so this file works
- * standalone in popups (no common.css :root) and can be linked directly by the React SPAs.
+ * Tokens: this sheet consumes the --sbb-* custom properties from control-tokens.css (no literal
+ * fallbacks — single source). Every load path guarantees control-tokens.css alongside it:
+ * ensureSharedStyles.js injects it first, common.css @imports it first, and standalone pages link
+ * it explicitly. A new consumer must do the same (or @import control-tokens.css) before linking this.
  */
 
 /* ==================================== Control (default) ==================================== */

--- a/app/src/main/resources/css/common.css
+++ b/app/src/main/resources/css/common.css
@@ -242,7 +242,7 @@ code-input {
 /* Alert triangle icon via ::before, so JS-populated alerts (exporter popups set textContent) get it
    too. Floated left → the message text wraps beside it. Warning may be standalone (interceptor);
    error only appears inside .notifications (exporter popups / the generic notifications block).
-   Outlined SVGs; literal fallbacks so they render where control-tokens.css is not linked. */
+   The --sbb-*-icon tokens come from control-tokens.css, which common.css @imports at its top. */
 .alert-warning::before,
 .notifications .alert-error::before {
     content: "";

--- a/app/src/main/resources/css/control-tokens.css
+++ b/app/src/main/resources/css/control-tokens.css
@@ -16,7 +16,19 @@
  * that fails to load this file — e.g. a Vite dev server running outside Polarion,
  * where /polarion/* 404s — still renders the intended look.
  */
-:root {
+/* Tokens are declared on the shared UI scopes (not only :root) so that on a page where several
+   extensions load their OWN bundled generic at DIFFERENT versions (the Polarion document page), each
+   extension's controls read the tokens from the closest scoped ancestor — its own bundle's copy —
+   instead of whichever extension's :root declaration happened to load last. Custom properties
+   inherit downward, so a `.sbb-ui` (or existing .modal__container / .standard-admin-page /
+   .form-wrapper) wrapper shadows any foreign :root value for its subtree.
+   :root is kept for backward-compat during rollout (consumers not yet carrying a scope class); it
+   can be dropped once every consumer wraps its UI roots in .sbb-ui. See issue #515. */
+:root,
+.modal__container,
+.standard-admin-page,
+.form-wrapper,
+.sbb-ui {
     /* Typography (shared by every control) */
     --sbb-control-font-family: "Segoe UI", "Selawik", "Open Sans", Arial, sans-serif;
     --sbb-control-font-size: 13px;

--- a/app/src/main/resources/css/micromodal.css
+++ b/app/src/main/resources/css/micromodal.css
@@ -1,3 +1,10 @@
+/* Pull in the --sbb-* design tokens this sheet consumes. Self-declaring the dependency (as
+   common.css does) makes micromodal.css genuinely self-contained: a consumer can link it alone
+   and the dialog-button tokens still resolve — no reliance on the page separately loading
+   control-tokens.css, and no need for literal fallbacks. Identical @import URLs are de-duped by
+   the browser, so this costs nothing where control-tokens.css is already present. */
+@import url("control-tokens.css");
+
 /**************************\
   Basic Modal Styles — shared micromodal base for all extension popups.
   Single source in generic; each extension loads /<ext>/ui/generic/css/micromodal.css.
@@ -116,8 +123,9 @@
 }
 
 .modal__btn-primary {
-  /* Fallback to the literal accent: micromodal.css is loaded standalone in popups, where
-     common.css's :root tokens are not present. */
+  /* --polarion-accent is Polarion's own platform token, not one of our --sbb-* (which the @import
+     above guarantees). It may be absent outside the platform theme, so keep the literal #007993
+     fallback here. */
   background-color: var(--polarion-accent, #007993);
   color: #fff;
 }
@@ -169,7 +177,8 @@
 
 /* Teal outline (secondary) / filled (primary) — the Polarion JSWizard dialog look, sourced from the
    shared button tokens (see buttons.css / control-tokens.css) so admin dialogs match the platform
-   exactly. Fallbacks are literal because micromodal.css is loaded standalone in popups. */
+   exactly. No literal fallbacks: the --sbb-* tokens are guaranteed by the control-tokens.css @import
+   at the top of this file. */
 .modal__container.standard-dialog .modal__btn {
   background-color: #fff;
   color: var(--sbb-btn-accent);

--- a/app/src/main/resources/js/modules/SearchableDropdown.js
+++ b/app/src/main/resources/js/modules/SearchableDropdown.js
@@ -395,7 +395,12 @@ export default class SearchableDropdown {
         // panels, scrollable modals) and its width is driven in JS from the trigger, so it always
         // shows in full. Hidden until opened.
         this.portal = document.createElement('div');
-        this.portal.className = 'sd-portal';
+        // The portal lives under <body> (below), outside the trigger's scoped wrapper, so it would
+        // otherwise read --sbb-* tokens from :root — clobber-prone on a page where several extensions
+        // load their own generic at different versions (issue #515). `.sbb-ui` is a token scope, so
+        // tagging the portal with it keeps the popup on the same design tokens as the control that
+        // opened it, mirroring the trigger's own scoped wrapper.
+        this.portal.className = 'sd-portal sbb-ui';
         this.portal.style.display = 'none';
         this.portal.appendChild(this.optionsEl);
         document.body.appendChild(this.portal);


### PR DESCRIPTION
### Proposed changes

This pull request updates how CSS design tokens are loaded and scoped across the codebase, improving consistency and modularity for UI theming. The main changes ensure that all CSS files consuming `--sbb-*` custom properties explicitly import or expect `control-tokens.css` to be present, eliminate redundant literal fallbacks, and introduce better scoping for design tokens to support multiple versions on the same page.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
