### PR TITLE
tests for JS components 

### DIFF
--- a/app/src/test/js/modules/BreadcrumbBridgeTest.js
+++ b/app/src/test/js/modules/BreadcrumbBridgeTest.js
@@ -131,6 +131,24 @@ describe('BreadcrumbBridge', function () {
     expect(customEl().style.display).to.not.equal('none');
   });
 
+  it('copies the original breadcrumb flex order onto its replacement', function () {
+    boot('https://host/polarion/xml-repair-app/#/xml-repair/scan');
+    const original = addOriginal();
+    original.style.order = '2'; // sit the replacement in the same flex slot
+    handle = install(CONFIG);
+    expect(customEl().style.order).to.equal('2');
+  });
+
+  it('hides its replacement when navigating away from the app page', function () {
+    boot('https://host/polarion/xml-repair-app/#/xml-repair/scan');
+    addOriginal();
+    handle = install(CONFIG);
+    expect(customEl().style.display).to.not.equal('none'); // mounted on the app page
+    dom.reconfigure({ url: 'https://host/polarion/other-page/' }); // marker no longer in the URL
+    handle.sync();
+    expect(customEl().style.display).to.equal('none');
+  });
+
   it('keeps hiding across a GWT re-render (observer stays connected)', async function () {
     boot('https://host/polarion/xml-repair-app/');
     const original = addOriginal();

--- a/app/src/test/js/modules/ConfigurationsPaneTest.js
+++ b/app/src/test/js/modules/ConfigurationsPaneTest.js
@@ -17,6 +17,8 @@ describe('ConfigurationsPane', function () {
                 <input id="edit-configuration-input"/>
                 <select id="configurations-select"></select>
                 <div id="configurations-label"></div>
+                <span class="configuration-label"></span>
+                <span class="configuration-label-capitalized"></span>
                 <div id="configurations-load-error" style="display:none"></div>
                 <div id="configuration-save-error" style="display:none"></div>
                 <div id="configuration-delete-error" style="display:none"></div>
@@ -136,5 +138,269 @@ describe('ConfigurationsPane', function () {
         input.value = '   ';
         input.dispatchEvent(new global.Event('input'));
         expect(ctxMock.disableIf.lastCall.args).to.deep.equal(['configurations-button-update', true]);
+    });
+
+    // Add an element with the given id/classes to the admin page (helper for the DOM the methods touch).
+    function addEl(idOrClass, tag = 'div') {
+        const el = document.createElement(tag);
+        if (idOrClass.startsWith('.')) { el.className = idOrClass.slice(1); } else { el.id = idOrClass; }
+        document.querySelector('.standard-admin-page').appendChild(el);
+        return el;
+    }
+
+    it('containsInvalidCharacters accepts alphanumerics/dash/underscore/space and rejects the rest', function () {
+        expect(configPane.containsInvalidCharacters('My config-1_x')).to.be.false;
+        expect(configPane.containsInvalidCharacters('bad/name!')).to.be.true;
+    });
+
+    it('nameClashes detects a duplicate, ignores the renamed item and inherited (parent) options', function () {
+        const sel = configPane.configSelectElement;
+        sel.innerHTML = '<option value="A"></option><option value="B"></option><option value="G" class="parent"></option>';
+        expect(configPane.nameClashes('A', null)).to.be.true;   // A already exists
+        expect(configPane.nameClashes('A', 'A')).to.be.false;   // renaming A to A — ignore itself
+        expect(configPane.nameClashes('G', null)).to.be.false;  // inherited option is not a clash
+        expect(configPane.nameClashes('Z', null)).to.be.false;  // brand-new name
+    });
+
+    it('saveConfiguration shows the invalid-value error and does not call the backend', function () {
+        addEl('invalid-value-error');
+        configPane.newConfigurationInput.value = 'bad/name';
+        configPane.saveConfiguration();
+        expect(document.getElementById('invalid-value-error').style.display).to.equal('block');
+        expect(ctxMock.callAsync.called).to.be.false;
+    });
+
+    it('saveConfiguration shows the clash error when the name already exists', function () {
+        addEl('configuration-clashes-error');
+        configPane.configSelectElement.innerHTML = '<option value="dup"></option>';
+        configPane.newConfigurationInput.value = 'dup';
+        configPane.saveConfiguration();
+        expect(document.getElementById('configuration-clashes-error').style.display).to.equal('block');
+        expect(ctxMock.callAsync.called).to.be.false;
+    });
+
+    it('saveConfiguration PUTs the new configuration and reloads on success', function () {
+        configPane.newConfigurationInput.value = 'fresh';
+        configPane.loadConfigurationNames = sinon.spy();
+        ctxMock.callAsync.callsFake(({ onOk }) => onOk());
+        configPane.saveConfiguration();
+        expect(ctxMock.callAsync.calledOnce).to.be.true;
+        expect(ctxMock.setCookie.called).to.be.true;
+        expect(configPane.newConfigurationInput.value).to.equal('');
+        expect(configPane.loadConfigurationNames.calledOnce).to.be.true;
+    });
+
+    it('saveConfiguration shows the save error on backend failure', function () {
+        addEl('configuration-save-error');
+        configPane.newConfigurationInput.value = 'fresh';
+        ctxMock.callAsync.callsFake(({ onError }) => onError());
+        configPane.saveConfiguration();
+        expect(document.getElementById('configuration-save-error').style.display).to.equal('block');
+    });
+
+    it('updateConfiguration POSTs the rename and reloads on success', function () {
+        configPane.editConfigurationInput.value = 'renamed';
+        configPane.getSelectedConfiguration = sinon.stub().returns('old');
+        configPane.loadConfigurationNames = sinon.spy();
+        ctxMock.callAsync.callsFake(({ onOk }) => onOk());
+        configPane.updateConfiguration();
+        expect(ctxMock.setCookie.called).to.be.true;
+        expect(configPane.loadConfigurationNames.calledOnce).to.be.true;
+    });
+
+    it('loadConfigurationNames renders the options, marking inherited ones as parent', function () {
+        configPane.setContentAreaEnabled = sinon.spy();
+        configPane.configurationChanged = sinon.spy();
+        ctxMock.callAsync.callsFake(({ onOk }) => onOk(JSON.stringify([
+            { name: 'A', scope: 'testScope' },
+            { name: 'G', scope: '' } // inherited from a broader scope
+        ])));
+        configPane.loadConfigurationNames();
+        const options = configPane.configSelectElement.querySelectorAll('option');
+        expect(options.length).to.equal(2);
+        expect(options[1].classList.contains('parent')).to.be.true;
+        expect(ctxMock.disableIf.calledWith('configurations-button-edit', false)).to.be.true;
+    });
+
+    it('loadConfigurationNames shows the load error on backend failure', function () {
+        ctxMock.callAsync.callsFake(({ onError }) => onError());
+        configPane.loadConfigurationNames();
+        expect(document.getElementById('configurations-load-error').style.display).to.equal('block');
+    });
+
+    it('configurationChanged loads content, shows the Default note and disables actions', function () {
+        addEl('default-note'); addEl('global-note');
+        const btn = addEl('.toolbar-button');
+        document.getElementById('configurations-pane').appendChild(btn); // action button under the pane
+        ctxMock.scope = '';
+        configPane.loadConfigurationContent = sinon.spy();
+        const checkbox = document.createElement('option');
+        checkbox.value = 'Default';
+        configPane.configurationChanged(checkbox);
+        expect(configPane.loadConfigurationContent.calledWith('Default')).to.be.true;
+        expect(document.getElementById('default-note').style.display).to.equal('block');
+    });
+
+    it('configurationChanged with no selection clears the html inputs', function () {
+        const htmlInput = addEl('.html-input', 'input');
+        htmlInput.value = 'stale';
+        configPane.configurationChanged(null);
+        expect(htmlInput.value).to.equal('');
+    });
+
+    it('loadConfigurationContent applies the content and fills revisions on success', function () {
+        configPane.setConfigurationContentCallback = sinon.spy();
+        configPane.setContentAreaEnabled = sinon.spy();
+        ctxMock.callAsync.callsFake(({ onOk }) => onOk('{"a":1}'));
+        configPane.loadConfigurationContent('cfg');
+        expect(configPane.setConfigurationContentCallback.calledWith('{"a":1}')).to.be.true;
+        expect(ctxMock.readAndFillRevisions.calledOnce).to.be.true;
+    });
+
+    it('loadConfigurationContent re-enables the content area on failure', function () {
+        configPane.setContentAreaEnabled = sinon.spy();
+        ctxMock.callAsync.callsFake(({ onError }) => onError());
+        configPane.loadConfigurationContent('cfg');
+        expect(configPane.setContentAreaEnabled.calledWith(true)).to.be.true;
+    });
+
+    it('setContentAreaEnabled(false) dims inputs, disables controls and hides content below the config panel', function () {
+        const container = addEl('.input-container');
+        addEl('.common-configuration-panel');
+        const below = addEl('.some-content');
+        addEl('.hide-on-edit-configuration');
+        // controls the method toggles
+        const htmlInput = addEl('.html-input');
+        const textarea = document.createElement('textarea'); htmlInput.appendChild(textarea);
+        const contentArea = addEl('.content-area');
+        const select = document.createElement('select'); contentArea.appendChild(select);
+        const saveArea = addEl('.save-area');
+        const saveBtn = document.createElement('button'); saveBtn.className = 'toolbar-button'; saveArea.appendChild(saveBtn);
+        configPane.setContentAreaEnabledCallback = sinon.spy();
+
+        configPane.setContentAreaEnabled(false);
+        expect(container.style.opacity).to.equal('30%');
+        expect(textarea.disabled).to.be.true;
+        expect(select.disabled).to.be.true;
+        expect(saveBtn.disabled).to.be.true;
+        expect(below.classList.contains('hidden-on-edit-configuration')).to.be.true;
+        expect(configPane.setContentAreaEnabledCallback.calledWith(false)).to.be.true;
+        // re-enabling clears the hidden marker and re-enables the controls
+        configPane.setContentAreaEnabled(true);
+        expect(below.classList.contains('hidden-on-edit-configuration')).to.be.false;
+        expect(textarea.disabled).to.be.false;
+    });
+
+    it('hideConfigurationErrors and hideConfigurationNotes hide their elements', function () {
+        const err = addEl('.configuration-error'); err.style.display = 'block';
+        const note = addEl('.note'); note.style.display = 'block';
+        configPane.hideConfigurationErrors();
+        configPane.hideConfigurationNotes();
+        expect(err.style.display).to.equal('none');
+        expect(note.style.display).to.equal('none');
+    });
+
+    it('deleteConfiguration shows the delete error when the backend fails', function () {
+        sinon.stub(global, 'confirm').returns(true);
+        configPane.getSelectedConfiguration = sinon.stub().returns('cfg');
+        ctxMock.callAsync.callsFake(({ onError }) => onError());
+        configPane.deleteConfiguration();
+        expect(document.getElementById('configuration-delete-error').style.display).to.equal('block');
+    });
+
+    it('deleteConfiguration shows the delete error when the pre-delete callback rejects', function () {
+        sinon.stub(global, 'confirm').returns(true);
+        configPane.getSelectedConfiguration = sinon.stub().returns('cfg');
+        configPane.preDeleteCallback = () => Promise.reject(new Error('nope'));
+        return Promise.resolve().then(() => {
+            configPane.deleteConfiguration();
+            return new Promise(r => setTimeout(r, 0)); // let the rejected promise settle
+        }).then(() => {
+            expect(document.getElementById('configuration-delete-error').style.display).to.equal('block');
+            expect(ctxMock.callAsync.called).to.be.false;
+        });
+    });
+
+    it('updateConfiguration shows validation errors and does not call the backend', function () {
+        addEl('invalid-value-error');
+        addEl('configuration-clashes-error');
+        configPane.getSelectedConfiguration = sinon.stub().returns('old');
+        configPane.editConfigurationInput.value = 'bad/name';
+        configPane.updateConfiguration();
+        expect(document.getElementById('invalid-value-error').style.display).to.equal('block');
+        configPane.configSelectElement.innerHTML = '<option value="dup"></option>';
+        configPane.editConfigurationInput.value = 'dup';
+        configPane.updateConfiguration();
+        expect(document.getElementById('configuration-clashes-error').style.display).to.equal('block');
+        expect(ctxMock.callAsync.called).to.be.false;
+    });
+
+    it('loadConfigurationNames preselects the cookie value when it matches an option', function () {
+        configPane.setContentAreaEnabled = sinon.spy();
+        configPane.configurationChanged = sinon.spy();
+        ctxMock.getCookie.returns('B');
+        ctxMock.callAsync.callsFake(({ onOk }) => onOk(JSON.stringify([
+            { name: 'A', scope: 'testScope' }, { name: 'B', scope: 'testScope' }
+        ])));
+        configPane.loadConfigurationNames();
+        expect(configPane.configSelectElement.value).to.equal('B');
+    });
+
+    it('loadConfigurationNames clears the selection and disables actions for an empty list', function () {
+        configPane.setContentAreaEnabled = sinon.spy();
+        configPane.configurationChanged = sinon.spy();
+        ctxMock.callAsync.callsFake(({ onOk }) => onOk('[]'));
+        configPane.loadConfigurationNames();
+        expect(configPane.configSelectElement.value).to.equal('');
+        expect(configPane.configurationChanged.calledWith(null)).to.be.true;
+        expect(ctxMock.disableIf.calledWith('configurations-button-edit', true)).to.be.true;
+    });
+
+    it('newConfiguration shows the new inputs and hides the edit inputs', function () {
+        const editInput = document.createElement('input'); editInput.className = 'edit-configuration';
+        const newInput = document.createElement('input'); newInput.className = 'new-configuration';
+        document.getElementById('edit-configuration-pane').append(editInput, newInput);
+        configPane.newConfiguration();
+        expect(editInput.style.display).to.equal('none');
+        expect(newInput.style.display).to.equal('inline-block');
+    });
+
+    it('editConfiguration shows the edit inputs and hides the new inputs', function () {
+        const editInput = document.createElement('input'); editInput.className = 'edit-configuration';
+        const newInput = document.createElement('input'); newInput.className = 'new-configuration';
+        document.getElementById('edit-configuration-pane').append(editInput, newInput);
+        configPane.getSelectedConfiguration = sinon.stub().returns('cfg');
+        configPane.editConfiguration();
+        expect(editInput.style.display).to.equal('inline-block');
+        expect(newInput.style.display).to.equal('none');
+    });
+
+    it('configurationChanged shows the global note for an inherited config on a project scope', function () {
+        addEl('default-note'); addEl('global-note');
+        ctxMock.scope = 'projectX';
+        configPane.loadConfigurationContent = sinon.spy();
+        const checkbox = document.createElement('option');
+        checkbox.value = 'Inherited';
+        checkbox.classList.add('parent');
+        configPane.configurationChanged(checkbox);
+        expect(document.getElementById('global-note').style.display).to.equal('block');
+    });
+
+    it('getSelectedConfiguration returns the select value', function () {
+        configPane.configSelectElement.innerHTML = '<option value="picked" selected></option>';
+        expect(configPane.getSelectedConfiguration()).to.equal('picked');
+    });
+
+    it('deleteConfiguration deletes without a pre-delete callback and reloads on success', function () {
+        sinon.stub(global, 'confirm').returns(true);
+        configPane.getSelectedConfiguration = sinon.stub().returns('cfg');
+        configPane.preDeleteCallback = null; // no pre-delete hook → Promise.resolve()
+        configPane.loadConfigurationNames = sinon.spy();
+        ctxMock.callAsync.callsFake(({ onOk }) => onOk());
+        configPane.deleteConfiguration();
+        return new Promise(r => setTimeout(r, 0)).then(() => {
+            expect(ctxMock.callAsync.calledOnce).to.be.true;
+            expect(configPane.loadConfigurationNames.calledOnce).to.be.true;
+        });
     });
 });

--- a/app/src/test/js/modules/CustomSelectTest.js
+++ b/app/src/test/js/modules/CustomSelectTest.js
@@ -75,4 +75,96 @@ describe('CustomSelect', () => {
         select.selectMultipleValues(['1', '2']);
         expect(select.getSelectedValue()).to.deep.equal(['1', '2']);
     });
+
+    it('containsOption reports whether an option value exists', () => {
+        const selectContainer = document.createElement('div');
+        document.body.appendChild(selectContainer);
+        const select = new CustomSelect({ selectContainer });
+        select.addOption('a', 'A');
+        expect(select.containsOption('a')).to.be.true;
+        expect(select.containsOption('missing')).to.be.false;
+    });
+
+    it('multiselect: reflects selection in value, text and fires the change listener', () => {
+        const selectContainer = document.createElement('div');
+        document.body.appendChild(selectContainer);
+        let fired = 0;
+        const select = new CustomSelect({ selectContainer, multiselect: true, changeListener: () => fired++ });
+        select.addOption('a', 'A');
+        select.addOption('b', 'B');
+        select.selectMultipleValues(['a', 'b']);
+        expect(select.getSelectedValue()).to.deep.equal(['a', 'b']);
+        expect(select.getSelectedText()).to.deep.equal(['A', 'B']);
+        expect(fired).to.be.greaterThan(0);
+    });
+
+    it('single-select: selectValue picks one and getSelectedText returns its label', () => {
+        const selectContainer = document.createElement('div');
+        document.body.appendChild(selectContainer);
+        const select = new CustomSelect({ selectContainer });
+        select.addOption('a', 'A');
+        select.addOption('b', 'B');
+        select.selectValue('b');
+        expect(select.getSelectedValue()).to.equal('b');
+        expect(select.getSelectedText()).to.equal('B');
+    });
+
+    it('single-select: empty selection reads as "", and un-checking the last option re-selects it', () => {
+        const selectContainer = document.createElement('div');
+        document.body.appendChild(selectContainer);
+        let last = null;
+        const select = new CustomSelect({ selectContainer, changeListener: (cb) => { last = cb; } });
+        select.addOption('a', 'A');
+        select.addOption('b', 'B');
+        expect(select.getSelectedValue()).to.equal(''); // nothing selected yet
+        expect(select.getSelectedText()).to.equal('');
+        const [cbA, cbB] = select.getAllCheckboxes();
+        cbA.checked = true;
+        cbA.dispatchEvent(new window.Event('change'));
+        expect(select.getSelectedValue()).to.equal('a');
+        expect(last).to.equal(cbA);
+        // selecting B enforces single selection (A is un-checked)
+        cbB.checked = true;
+        cbB.dispatchEvent(new window.Event('change'));
+        expect(cbA.checked).to.be.false;
+        expect(select.getSelectedValue()).to.equal('b');
+        // clearing the last one is not allowed — it is re-checked
+        cbB.checked = false;
+        cbB.dispatchEvent(new window.Event('change'));
+        expect(cbB.checked).to.be.true;
+    });
+
+    it('wires the <label for> to the hidden select when a label is given', () => {
+        const selectContainer = document.createElement('div');
+        document.body.appendChild(selectContainer);
+        const label = document.createElement('label');
+        const select = new CustomSelect({ selectContainer, label });
+        expect(label.htmlFor).to.equal(select.selectElement.getAttribute('id') || '');
+    });
+
+    it('closes on an outside click, stays open on an inside click, and empty() clears the options', () => {
+        const selectContainer = document.createElement('div');
+        document.body.appendChild(selectContainer);
+        const select = new CustomSelect({ selectContainer });
+        select.addOption('a', 'A');
+        select.toggleCheckboxContainer(); // open
+        expect(select.checkboxContainer.style.display).to.equal('block');
+        // click inside the container → treated as a child → stays open
+        select.checkboxContainer.dispatchEvent(new window.Event('click', { bubbles: true }));
+        expect(select.checkboxContainer.style.display).to.equal('block');
+        // click outside → not a child → closes
+        document.body.dispatchEvent(new window.Event('click', { bubbles: true }));
+        expect(select.checkboxContainer.style.display).to.equal('none');
+        // empty() removes all options
+        select.empty();
+        expect(select.getAllCheckboxes().length).to.equal(0);
+    });
+
+    it('defaults a missing container to a new element and an option without text to its value', () => {
+        const select = new CustomSelect({}); // no selectContainer → one is created
+        expect(select.selectContainer).to.exist;
+        select.addOption('only-value'); // no text → the label falls back to the value
+        const [cb] = select.getAllCheckboxes();
+        expect(cb.parentElement.textContent).to.equal('only-value');
+    });
 });

--- a/app/src/test/js/modules/ExtensionContextTest.js
+++ b/app/src/test/js/modules/ExtensionContextTest.js
@@ -91,6 +91,7 @@ describe('ExtensionContext', function () {
 // Real-DOM coverage of the DOM/alert/cookie/revisions helpers (no querySelector stub).
 describe('ExtensionContext — DOM-backed helpers', function () {
     let dom, window, document, ctx, requests, clock;
+    const NATIVE_URL = global.URL; // Node's native URL; the downloadBlob test swaps in the JSDOM one
 
     beforeEach(function () {
         clock = sinon.useFakeTimers(); // control showActionAlert's 5s auto-hide so no real timer leaks
@@ -130,6 +131,7 @@ describe('ExtensionContext — DOM-backed helpers', function () {
         delete global.codeInput;
         delete global.Prism;
         delete global.$;
+        global.URL = NATIVE_URL; // restore Node's native URL (downloadBlob test points it at the JSDOM one)
     });
 
     it('reads/writes input, checkbox, selector and toggles visibility', function () {

--- a/app/src/test/js/modules/ExtensionContextTest.js
+++ b/app/src/test/js/modules/ExtensionContextTest.js
@@ -87,3 +87,264 @@ describe('ExtensionContext', function () {
         }, 10);
     });
 });
+
+// Real-DOM coverage of the DOM/alert/cookie/revisions helpers (no querySelector stub).
+describe('ExtensionContext — DOM-backed helpers', function () {
+    let dom, window, document, ctx, requests, clock;
+
+    beforeEach(function () {
+        clock = sinon.useFakeTimers(); // control showActionAlert's 5s auto-hide so no real timer leaks
+        dom = new JSDOM(`<!DOCTYPE html><html lang="en"><body><div id="root">
+            <input id="inputId" value="init"/>
+            <input id="checkId" type="checkbox"/>
+            <select id="selId"><option value="a">A</option><option value="Default">Default</option></select>
+            <div id="box"></div>
+            <div id="newer-version-warning"></div>
+            <div id="data-loading-error"></div>
+            <div id="revisions-loading-error"></div>
+            <div id="revisions-expand-container" style="display:none"></div>
+            <div class="action-alerts"><div id="action-success" class="alert"></div><div id="action-error" class="alert"></div></div>
+            <table id="revisions-table"><tbody></tbody></table>
+        </div></body></html>`, { url: 'http://localhost/' });
+        window = dom.window;
+        document = window.document;
+        global.window = window;
+        global.document = document;
+        global.alert = sinon.stub();
+        global.confirm = sinon.stub().returns(false);
+        global.XMLHttpRequest = nise.fakeXhr.useFakeXMLHttpRequest();
+        requests = [];
+        global.XMLHttpRequest.onCreate = (xhr) => requests.push(xhr);
+        ctx = new ExtensionContext({ extension: 'ext', setting: 'set', rootComponentSelector: '#root', scope: 's' });
+    });
+
+    afterEach(function () {
+        sinon.restore();
+        delete global.window;
+        delete global.document;
+        delete global.alert;
+        delete global.confirm;
+        delete global.XMLHttpRequest;
+    });
+
+    it('reads/writes input, checkbox, selector and toggles visibility', function () {
+        ctx.setValue('inputId', 'x');
+        expect(ctx.getValue('inputId')).to.equal('x');
+        ctx.setCheckbox('checkId', true);
+        expect(ctx.getCheckbox('checkId')).to.be.true;
+        expect(ctx.containsOption(ctx.getElementById('selId'), 'a')).to.be.true;
+        ctx.setSelector('selId', 'a');
+        expect(ctx.getValue('selId')).to.equal('a');
+        ctx.setSelector('selId', 'missing'); // unknown → DEFAULT
+        expect(ctx.getValue('selId')).to.equal('Default');
+        ctx.selectOptionByValue('selId', 'a');
+        expect(ctx.getValue('selId')).to.equal('a');
+        ctx.displayIf('box', false); expect(ctx.getElementById('box').style.display).to.equal('none');
+        ctx.displayIf('box', true); expect(ctx.getElementById('box').style.display).to.equal('block');
+        ctx.visibleIf('box', false); expect(ctx.getElementById('box').style.visibility).to.equal('hidden');
+        ctx.disableIf('inputId', true); expect(ctx.getElementById('inputId').disabled).to.be.true;
+        expect(ctx.querySelectorAll('.alert')).to.have.length(2);
+        expect(ctx.isWindowDefined()).to.be.true;
+    });
+
+    it('syncs a wrapped SearchableDropdown when the value is set programmatically', function () {
+        const sync = sinon.spy();
+        ctx.getElementById('inputId')._searchableDropdown = { syncFromElement: sync };
+        ctx.setValueById('inputId', 'y');
+        expect(sync.calledOnce).to.be.true;
+        ctx.getElementById('selId')._searchableDropdown = { syncFromElement: sync };
+        ctx.setSelector('selId', 'a');
+        expect(sync.calledTwice).to.be.true;
+    });
+
+    it('adds listeners, warns for a missing element and errors on an invalid pair', function () {
+        const onClick = sinon.spy();
+        ctx.onClick('box', onClick);
+        ctx.getElementById('box').dispatchEvent(new window.Event('click'));
+        expect(onClick.calledOnce).to.be.true;
+        const warn = sinon.stub(console, 'log');
+        ctx.onChange('does-not-exist', () => {});
+        expect(warn.calledOnce).to.be.true;
+        const err = sinon.stub(console, 'error');
+        ctx.onBlur(42, 'not-a-function'); // invalid pair
+        expect(err.calledOnce).to.be.true;
+    });
+
+    it('shows and auto-hides action alerts, and delegates the canned alerts', function () {
+        ctx.showActionAlert({ containerId: 'action-success', message: 'hi' });
+        expect(document.getElementById('action-success').style.display).to.equal('inline-block');
+        clock.tick(5000);
+        expect(document.getElementById('action-success').style.display).to.equal('none');
+        ctx.showActionAlert({ containerId: 'nope', message: '' }); // no container/message → no throw
+        ctx.showRevertedToRevisionAlert({ name: '123' });
+        expect(document.getElementById('action-success').innerHTML).to.contain('123');
+        ctx.showRevertedToDefaultAlert();
+        ctx.showSaveSuccessAlert();
+        ctx.showSaveErrorAlert();
+        expect(document.getElementById('action-error').innerHTML).to.contain('Error');
+    });
+
+    it('toggles the three notification banners', function () {
+        ctx.setNewerVersionNotificationVisible(true);
+        expect(ctx.getElementById('newer-version-warning').style.display).to.equal('block');
+        ctx.setLoadingErrorNotificationVisible(false);
+        expect(ctx.getElementById('data-loading-error').style.display).to.equal('none');
+        ctx.setRevisionsLoadingErrorNotificationVisible(true);
+        expect(ctx.getElementById('revisions-loading-error').style.display).to.equal('block');
+    });
+
+    it('cancelEdit reloads only when confirmed', function () {
+        // jsdom's location.reload is not stubbable and just logs "Not implemented"; exercise both
+        // branches (confirm false → no-op, confirm true → reload path) via the confirm stub.
+        global.confirm.returns(false);
+        ctx.cancelEdit();
+        expect(global.confirm.calledOnce).to.be.true;
+        global.confirm.returns(true);
+        ctx.cancelEdit(); // takes the reload branch
+    });
+
+    it('toggleRevisions flips the panel display', function () {
+        ctx.toggleRevisions(); // was none → block
+        expect(document.getElementById('revisions-expand-container').style.display).to.equal('block');
+    });
+
+    it('insertRevisionSpaces groups digits in threes from the right', function () {
+        expect(ctx.insertRevisionSpaces('12345')).to.equal('12 345');
+    });
+
+    it('sets, reads and deletes cookies (trimming the leading space of later cookies)', function () {
+        ctx.setCookie('k', 'v v');
+        ctx.setCookie('k2', '2'); // a second cookie is stored after "; " → its leading space is trimmed
+        expect(ctx.getCookie('k')).to.equal('v v');
+        expect(ctx.getCookie('k2')).to.equal('2');
+        expect(ctx.getCookie('absent')).to.equal(null);
+        ctx.deleteCookie('k');
+        expect(ctx.getCookie('k')).to.equal(null);
+    });
+
+    it('constructor wires code-input highlighting when requested', function () {
+        global.codeInput = { registerTemplate: sinon.spy(), templates: { prism: sinon.stub().returns({}) } };
+        global.Prism = { languages: {} };
+        new ExtensionContext({ initCodeInput: true, propertiesHighlighting: true });
+        expect(global.codeInput.registerTemplate.calledOnce).to.be.true;
+        expect(global.Prism.languages.properties).to.exist;
+        delete global.codeInput;
+        delete global.Prism;
+    });
+
+    it('getJQueryElement and querySelector delegate to the root-scoped selectors', function () {
+        global.$ = sinon.stub().returns('jq');
+        expect(ctx.getJQueryElement('.x')).to.equal('jq');
+        expect(global.$.calledWith('#root .x')).to.be.true;
+        delete global.$;
+        expect(ctx.querySelector('.alert')).to.equal(document.querySelector('#root .alert'));
+    });
+
+    it('callAsync honours a responseType and still calls onOk on success', function () {
+        const onOk = sinon.spy();
+        ctx.callAsync({ method: 'GET', url: '/x', responseType: 'text', onOk });
+        requests[0].respond(200, {}, 'ok');
+        expect(onOk.calledOnce).to.be.true;
+    });
+
+    it('callAsync falls back to a plain alert when the error alert itself throws', function () {
+        sinon.stub(ctx, 'showActionAlert').throws(new Error('boom'));
+        ctx.callAsync({ method: 'GET', url: '/x' });
+        requests[0].respond(400, {}, 'x');
+        expect(global.alert.called).to.be.true;
+    });
+
+    it('covers the remaining conditional branches', function () {
+        // scopeFieldId path in the constructor derives the scope from the field's value
+        const c = new ExtensionContext({ rootComponentSelector: '#root', scopeFieldId: 'inputId' });
+        expect(c.scope).to.equal('init');
+        // visibleIf(true) and the "off" side of the notification toggles
+        ctx.visibleIf('box', true);
+        expect(ctx.getElementById('box').style.visibility).to.equal('visible');
+        ctx.setNewerVersionNotificationVisible(false);
+        expect(ctx.getElementById('newer-version-warning').style.display).to.equal('none');
+        ctx.setLoadingErrorNotificationVisible(true);
+        expect(ctx.getElementById('data-loading-error').style.display).to.equal('block');
+        ctx.setRevisionsLoadingErrorNotificationVisible(false);
+        // toggleRevisions the other way (block → none)
+        ctx.toggleRevisions();
+        ctx.toggleRevisions();
+        expect(document.getElementById('revisions-expand-container').style.display).to.equal('none');
+        // createRevisionRow renders an empty baseline cell when the revision has none
+        const tbody = document.querySelector('#revisions-table tbody');
+        ctx.createRevisionRow(tbody, { name: '1', date: 'd', author: 'a', description: 'x' }, document.createElement('button'));
+        expect(tbody.querySelectorAll('tr').length).to.equal(1);
+        // a network error without onError falls back to alert
+        ctx.callAsync({ method: 'GET', url: '/x' });
+        requests[requests.length - 1].error();
+        expect(global.alert.called).to.be.true;
+    });
+
+    it('callAsync blocks directory traversal', function () {
+        const onError = sinon.spy();
+        ctx.callAsync({ method: 'GET', url: '/x/../y', onError });
+        expect(onError.calledWith(undefined, 'directory traversal restricted')).to.be.true;
+        ctx.callAsync({ method: 'GET', url: '/x/../y' }); // no onError → alert
+        expect(global.alert.calledOnce).to.be.true;
+    });
+
+    it('callAsync reports a backend error via onError with the parsed message', function () {
+        const onError = sinon.spy();
+        ctx.callAsync({ method: 'GET', url: '/x', onError });
+        requests[0].respond(500, { 'Content-Type': 'application/json' }, '{"message":"boom"}');
+        expect(onError.calledWith(500, 'boom')).to.be.true;
+    });
+
+    it('callAsync without onError shows the error alert on failure', function () {
+        ctx.callAsync({ method: 'GET', url: '/x' });
+        requests[0].respond(400, { 'Content-Type': 'text/plain' }, 'not json');
+        expect(document.getElementById('action-error').style.display).to.equal('inline-block');
+    });
+
+    it('callAsync onerror routes to onError', function () {
+        const onError = sinon.spy();
+        ctx.callAsync({ method: 'GET', url: '/x', onError });
+        requests[0].error();
+        expect(onError.called).to.be.true;
+    });
+
+    it('getStringIfTextResponse returns text only for text response types', function () {
+        expect(ctx.getStringIfTextResponse({ responseType: 'text', responseText: 'a' })).to.equal('a');
+        expect(ctx.getStringIfTextResponse({ responseType: 'blob', responseText: 'a' })).to.equal(undefined);
+    });
+
+    it('downloadBlob creates a temporary object URL and clicks a link', function () {
+        window.URL.createObjectURL = sinon.stub().returns('blob:x');
+        window.URL.revokeObjectURL = sinon.stub();
+        global.URL = window.URL;
+        const click = sinon.stub(window.HTMLAnchorElement.prototype, 'click');
+        ctx.downloadBlob(new window.Blob(['data']), 'file.txt');
+        expect(window.URL.createObjectURL.calledOnce).to.be.true;
+        expect(click.calledOnce).to.be.true;
+        // Note: the webkitURL fallback and the in-iframe (window.top) download path are
+        // environment-specific and not reproducible in jsdom, so they stay uncovered.
+    });
+
+    it('readAndFillRevisions renders rows and wires a revert button; empty list shows a message', function () {
+        const revertCb = sinon.spy();
+        ctx.readAndFillRevisions({ configurationName: 'Default', revertToRevisionCallback: revertCb });
+        requests[0].respond(200, { 'Content-Type': 'application/json' },
+            JSON.stringify([{ name: '100', baseline: 'b', date: 'd', author: 'a', description: 'x' }]));
+        const rows = document.querySelector('#revisions-table tbody').querySelectorAll('tr');
+        expect(rows.length).to.equal(1);
+        // clicking the revert button fires a second request whose onOk calls the callback
+        document.querySelector('.revert-to-revision-button').dispatchEvent(new window.Event('click'));
+        requests[1].respond(200, { 'Content-Type': 'application/json' }, 'reverted-content');
+        expect(revertCb.calledWith('reverted-content')).to.be.true;
+        // now an empty list
+        ctx.readAndFillRevisions({ configurationName: 'Default' });
+        requests[2].respond(200, { 'Content-Type': 'application/json' }, '[]');
+        expect(document.querySelector('#revisions-table .empty-message')).to.exist;
+    });
+
+    it('readAndFillRevisions shows the revisions-loading error on failure', function () {
+        ctx.readAndFillRevisions({ setting: 'other' });
+        requests[0].respond(500, {}, '');
+        expect(ctx.getElementById('revisions-loading-error').style.display).to.equal('block');
+    });
+});

--- a/app/src/test/js/modules/ExtensionContextTest.js
+++ b/app/src/test/js/modules/ExtensionContextTest.js
@@ -125,6 +125,11 @@ describe('ExtensionContext — DOM-backed helpers', function () {
         delete global.alert;
         delete global.confirm;
         delete global.XMLHttpRequest;
+        // Browser libs some tests stub ad hoc — cleared here so a mid-test assertion failure
+        // can't leak them into later tests.
+        delete global.codeInput;
+        delete global.Prism;
+        delete global.$;
     });
 
     it('reads/writes input, checkbox, selector and toggles visibility', function () {
@@ -228,8 +233,6 @@ describe('ExtensionContext — DOM-backed helpers', function () {
         new ExtensionContext({ initCodeInput: true, propertiesHighlighting: true });
         expect(global.codeInput.registerTemplate.calledOnce).to.be.true;
         expect(global.Prism.languages.properties).to.exist;
-        delete global.codeInput;
-        delete global.Prism;
     });
 
     it('getJQueryElement and querySelector delegate to the root-scoped selectors', function () {

--- a/app/src/test/js/modules/SearchableDropdownTest.js
+++ b/app/src/test/js/modules/SearchableDropdownTest.js
@@ -464,6 +464,18 @@ describe('SearchableDropdown', function () {
             expect(label.htmlFor).to.equal('my-build_sd-trigger');
             dropdown.destroy();
         });
+
+        it('id returns undefined in build mode when the container is absent (defensive fallback)', function () {
+            const container = document.createElement('div');
+            container.id = 'my-build';
+            document.body.appendChild(container);
+            const dropdown = new SearchableDropdown({ selectContainer: container, rememberSelection: false });
+            expect(dropdown.id).to.equal('my-build');
+            dropdown.container = null; // simulate a missing container
+            expect(dropdown.id).to.equal(undefined);
+            dropdown.container = container; // restore so destroy() can clean up
+            dropdown.destroy();
+        });
     });
 
     describe('open/close via pointer + outside click', function () {

--- a/app/src/test/js/modules/dleToolbarStarterTest.js
+++ b/app/src/test/js/modules/dleToolbarStarterTest.js
@@ -1,0 +1,232 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { JSDOM } from 'jsdom';
+
+// dle-toolbar-starter.js is a plain IIFE that, at load time, reads `top` (the observer/order
+// registries) and registers `window.GenericDleToolbarStarter`. So the globals it closes over must
+// exist BEFORE the module is evaluated — hence a dynamic import() in before(), after wiring globals.
+// `top === window` here models the non-iframe case (self === top). requestAnimationFrame is faked so
+// the self-healing re-inject can be driven deterministically instead of waiting on a real frame.
+describe('GenericDleToolbarStarter (dle-toolbar-starter.js)', function () {
+    let dom, window, document, reg, rafCallbacks;
+
+    // Full Polarion DLE toolbar sub-tree the selectors expect. Flags let each test omit a piece
+    // (the toolbar row, the spacer cell, the rich-text area) to hit the early-return branches.
+    function dleHtml({ toolbar = true, spacer = true, richText = true } = {}) {
+        const spacerCell = spacer ? '<td width="100%"></td>' : '';
+        const toolbarRow = toolbar
+            ? `<div class="polarion-rte-ToolbarPanelWrapper">
+                 <table class="polarion-dle-ToolbarPanel"><tbody>
+                   <tr><td class="existing-tool"></td>${spacerCell}</tr>
+                 </tbody></table>
+               </div>`
+            : '';
+        const richTextPanel = richText
+            ? `<div class="polarion-dle-SplitPanel">first</div>
+               <div class="polarion-dle-SplitPanel">
+                 <div class="rta-wrapper"><div class="rta-inner">
+                   <div class="polarion-dle-RichTextArea"></div>
+                 </div></div>
+               </div>`
+            : '';
+        return `<div class="polarion-content-container"><div class="polarion-Container">
+                  <div class="polarion-dle-Container"><div class="polarion-dle-Wrapper">
+                    <div class="polarion-dle-RpcPanel"><div class="polarion-dle-MainDockPanel">
+                      ${toolbarRow}${richTextPanel}
+                    </div></div>
+                  </div></div>
+                </div></div>`;
+    }
+
+    const cfg = (over = {}) => ({ markerId: 'my-btn', alternateHtml: '<button>A</button>', defaultHtml: '<button>D</button>', ...over });
+
+    before(async function () {
+        dom = new JSDOM('<!DOCTYPE html><html lang="en"><head></head><body></body></html>', { url: 'http://localhost/' });
+        window = dom.window;
+        document = window.document;
+        global.window = window;
+        global.top = window;                 // module reads bare `top`; self === top (not in an iframe)
+        global.document = document;
+        global.MutationObserver = window.MutationObserver;
+        rafCallbacks = [];
+        global.requestAnimationFrame = (cb) => rafCallbacks.push(cb);
+        await import('../../../main/resources/js/dle-toolbar-starter.js');
+        reg = window.__genericDleToolbarObservers; // the closed-over registry (same object reference)
+    });
+
+    after(function () {
+        delete global.window;
+        delete global.top;
+        delete global.document;
+        delete global.MutationObserver;
+        delete global.requestAnimationFrame;
+    });
+
+    afterEach(function () {
+        // Clear the closed-over registries by key (never reassign — the module captured the object).
+        Object.keys(reg).forEach((k) => { try { reg[k].disconnect(); } catch { /* node gone */ } delete reg[k]; });
+        const order = window.__genericDleToolbarOrder;
+        if (order) Object.keys(order).forEach((k) => delete order[k]);
+        document.head.innerHTML = '';
+        document.body.innerHTML = '';
+        rafCallbacks.length = 0;
+        sinon.restore();
+    });
+
+    const flushObserver = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+    it('injects the alternate button as a <td> before the spacer cell', function () {
+        document.body.innerHTML = dleHtml();
+        const starter = window.GenericDleToolbarStarter.create(cfg());
+        starter.injectToolbar({ alternate: true });
+
+        const cell = document.getElementById('my-btn');
+        expect(cell).to.exist;
+        expect(cell.tagName).to.equal('TD');
+        expect(cell.innerHTML).to.equal('<button>A</button>');
+        expect(cell.nextElementSibling.getAttribute('width')).to.equal('100%'); // sits before the spacer
+    });
+
+    it('is idempotent — a second inject with the button present is a no-op', function () {
+        document.body.innerHTML = dleHtml();
+        const starter = window.GenericDleToolbarStarter.create(cfg());
+        starter.injectToolbar({ alternate: true });
+        starter.injectToolbar({ alternate: true });
+        expect(document.querySelectorAll('#my-btn').length).to.equal(1);
+    });
+
+    it('does nothing in alternate mode when the toolbar row is not rendered yet', function () {
+        document.body.innerHTML = dleHtml({ toolbar: false });
+        const starter = window.GenericDleToolbarStarter.create(cfg());
+        starter.injectToolbar({ alternate: true });
+        expect(document.getElementById('my-btn')).to.equal(null);
+    });
+
+    it('appends at the end and warns when the spacer cell is missing', function () {
+        document.body.innerHTML = dleHtml({ spacer: false });
+        const warn = sinon.stub(console, 'warn');
+        const starter = window.GenericDleToolbarStarter.create(cfg());
+        starter.injectToolbar({ alternate: true });
+
+        const row = document.querySelector('table.polarion-dle-ToolbarPanel tr');
+        expect(row.lastElementChild.id).to.equal('my-btn'); // appended at the end
+        expect(warn.calledOnce).to.be.true;
+        expect(warn.firstCall.args[0]).to.contain('my-btn');
+    });
+
+    it('keeps a stable order — a lower-order button is inserted before a higher-order one', function () {
+        document.body.innerHTML = dleHtml();
+        window.GenericDleToolbarStarter.create(cfg({ markerId: 'btn-high', order: 10 })).injectToolbar({ alternate: true });
+        window.GenericDleToolbarStarter.create(cfg({ markerId: 'btn-low', order: 0 })).injectToolbar({ alternate: true });
+
+        const ids = [...document.querySelector('table.polarion-dle-ToolbarPanel tr').children].map((c) => c.id);
+        expect(ids.indexOf('btn-low')).to.be.lessThan(ids.indexOf('btn-high')); // low sits before high
+    });
+
+    it('injects the default button as a div above the rich-text area', function () {
+        document.body.innerHTML = dleHtml();
+        const starter = window.GenericDleToolbarStarter.create(cfg());
+        starter.injectToolbar({}); // not alternate → default path
+
+        const box = document.getElementById('my-btn');
+        expect(box.tagName).to.equal('DIV');
+        expect(box.classList.contains('dleToolBarContainer')).to.be.true;
+        expect(box.style.marginRight).to.equal('14px');
+        // prepended into richTextArea.parentNode.parentNode (the .rta-wrapper)
+        expect(box.parentElement.classList.contains('rta-wrapper')).to.be.true;
+    });
+
+    it('does nothing in default mode when the rich-text area is absent', function () {
+        document.body.innerHTML = dleHtml({ richText: false });
+        const starter = window.GenericDleToolbarStarter.create(cfg());
+        starter.injectToolbar({});
+        expect(document.getElementById('my-btn')).to.equal(null);
+    });
+
+    it('re-injects the button when the toolbar re-renders (self-healing observer)', async function () {
+        document.body.innerHTML = dleHtml();
+        const starter = window.GenericDleToolbarStarter.create(cfg());
+        starter.injectToolbar({ alternate: true });
+        expect(document.getElementById('my-btn')).to.exist;
+
+        document.getElementById('my-btn').remove();                      // GWT wipes the button
+        document.querySelector('div.polarion-dle-Container').appendChild(document.createElement('span')); // re-render mutation
+        await flushObserver();
+
+        expect(rafCallbacks.length).to.be.greaterThan(0);                // a coalesced re-inject was queued
+        rafCallbacks.forEach((cb) => cb());
+        expect(document.getElementById('my-btn')).to.exist;              // healed
+    });
+
+    it('the observer stays idle while the button is still present', async function () {
+        document.body.innerHTML = dleHtml();
+        const starter = window.GenericDleToolbarStarter.create(cfg());
+        starter.injectToolbar({ alternate: true });
+
+        document.querySelector('div.polarion-dle-Container').appendChild(document.createElement('span'));
+        await flushObserver();
+        expect(rafCallbacks.length).to.equal(0); // fast-path: button present → nothing scheduled
+    });
+
+    it('falls back to observing document.body when the stable ancestor is absent', async function () {
+        document.body.innerHTML = ''; // no toolbar, no ancestor
+        const starter = window.GenericDleToolbarStarter.create(cfg());
+        starter.injectToolbar({ alternate: true }); // inject early-returns, observer still set up on body
+        expect(reg['my-btn']).to.exist;
+
+        document.body.appendChild(document.createElement('span'));
+        await flushObserver();
+        expect(rafCallbacks.length).to.be.greaterThan(0); // observing body works
+    });
+
+    it('destroy() disconnects the observer and drops it from the registry', function () {
+        document.body.innerHTML = dleHtml();
+        const starter = window.GenericDleToolbarStarter.create(cfg());
+        starter.injectToolbar({ alternate: true });
+        expect(reg['my-btn']).to.exist;
+
+        starter.destroy();
+        expect(reg['my-btn']).to.be.undefined;
+        starter.destroy(); // second destroy with nothing registered is harmless
+    });
+
+    it('re-installs the observer after destroy (observerSetUp resets)', function () {
+        document.body.innerHTML = dleHtml();
+        const starter = window.GenericDleToolbarStarter.create(cfg());
+        starter.injectToolbar({ alternate: true });
+        starter.destroy();
+        starter.injectToolbar({ alternate: true }); // sets a fresh observer up again
+        expect(reg['my-btn']).to.exist;
+    });
+
+    it('disconnects a leftover observer when the same markerId is re-created', function () {
+        document.body.innerHTML = dleHtml();
+        const first = window.GenericDleToolbarStarter.create(cfg());
+        first.injectToolbar({ alternate: true });
+        const firstObserver = reg['my-btn'];
+        const spy = sinon.spy(firstObserver, 'disconnect');
+
+        const second = window.GenericDleToolbarStarter.create(cfg());
+        second.injectToolbar({ alternate: true });
+        expect(spy.calledOnce).to.be.true;           // the previous observer was disconnected
+        expect(reg['my-btn']).to.not.equal(firstObserver); // registry now holds the new one
+    });
+
+    it('injectStyles adds a stylesheet link once and injectScript adds a script once', function () {
+        window.GenericDleToolbarStarter.injectStyles('sbb-css', '/x.css');
+        window.GenericDleToolbarStarter.injectStyles('sbb-css', '/x.css'); // idempotent
+        const link = document.getElementById('sbb-css');
+        expect(link.tagName).to.equal('LINK');
+        expect(link.rel).to.equal('stylesheet');
+        expect(link.href).to.contain('/x.css');
+        expect(document.querySelectorAll('#sbb-css').length).to.equal(1);
+
+        window.GenericDleToolbarStarter.injectScript('sbb-js', '/x.js');
+        window.GenericDleToolbarStarter.injectScript('sbb-js', '/x.js'); // idempotent
+        const script = document.getElementById('sbb-js');
+        expect(script.tagName).to.equal('SCRIPT');
+        expect(script.getAttribute('type')).to.equal('text/javascript'); // default type
+        expect(script.getAttribute('src')).to.equal('/x.js');
+        expect(document.querySelectorAll('#sbb-js').length).to.equal(1);
+    });
+});

--- a/app/src/test/js/modules/searchableSelectTest.js
+++ b/app/src/test/js/modules/searchableSelectTest.js
@@ -63,6 +63,14 @@ describe('createSearchableSelect', function () {
     expect(m.nextElementSibling.querySelector('.sd-trigger-multi')).to.exist; // rendered as multi-select
   });
 
+  it('initSearchableDropdowns tolerates a null singleIds list (multi-select only)', function () {
+    const m = selectWith(['c']); m.id = 'roles'; m.multiple = true;
+    const ctx = { getElementById: (id) => document.getElementById(id) };
+    initSearchableDropdowns(ctx, null, 'roles'); // null single-ids → the `singleIds || []` fallback
+    expect(m.nextElementSibling.classList.contains('searchable-dropdown')).to.be.true;
+    expect(m.nextElementSibling.querySelector('.sd-trigger-multi')).to.exist;
+  });
+
   it('createEditableSelect wraps an <input> as an editable free-text dropdown', function () {
     const input = document.createElement('input');
     input.type = 'text';


### PR DESCRIPTION
### Proposed changes

This pull request adds comprehensive new unit tests to the `ConfigurationsPane`, `CustomSelect`, and `BreadcrumbBridge` modules, significantly improving test coverage for configuration management, custom select UI behavior, and breadcrumb replacement logic. The tests cover a wide range of edge cases, error handling, and UI behaviors, ensuring robustness and reliability for these components.

### Configuration management tests (`ConfigurationsPaneTest.js`)

* Extensive tests were added for validation logic (invalid character detection, duplicate name detection), error handling, and all main configuration CRUD operations: create, update, load, and delete, including backend failure cases and UI state updates. (F93f31dfL139)
* Helper functions and DOM setup for test isolation and coverage of UI behaviors such as enabling/disabling controls, showing/hiding errors and notes, and handling inherited configurations were included. (F93f31dfL139)
* Additional test DOM elements were added for configuration labels to support new tests. (F93f31dfL17)

### Custom select component tests (`CustomSelectTest.js`)

* New tests verify `CustomSelect` behaviors including option existence checks, single and multi-select logic, change event firing, label wiring, outside click handling, and option clearing. (Ff742f82L75)
* Edge cases such as empty selection, fallback UI, and container defaults are covered to ensure correct and accessible UI interactions. (Ff742f82L75)

### Breadcrumb replacement logic tests (`BreadcrumbBridgeTest.js`)

* Tests ensure the breadcrumb replacement element correctly copies the original's flex order and hides itself when navigating away from the app page, improving reliability of UI integration. (F64c9909L131)

These additions provide much more robust regression protection and confidence in the configuration and UI components.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
