### PR TITLE
fix: update button icon alignment for consistency

### DIFF
--- a/app/src/main/resources/css/common.css
+++ b/app/src/main/resources/css/common.css
@@ -292,11 +292,13 @@ code-input {
 
 /* .toolbar-button now lives in the unified button system (buttons.css); its legacy selector is
    aliased there. .button-image is the button's leading icon (a background-image <span> carrying a
-   .sbb-icon-* class); padding-right gives the icon-to-label gap. float is a no-op inside the flex
-   toolbar-button but is kept for any downstream <img class="button-image"> still laid out inline. */
+   .sbb-icon-* class); padding-right gives the icon-to-label gap. vertical-align: middle centres the
+   icon against the label in a non-flex (inline-block) button and is a no-op inside the flex
+   toolbar-button (align-items handles it there) — do NOT float it, a float would top-align the icon
+   in the inline-block case ("icon rides up"). */
 .button-image {
     padding-right: 5px;
-    float: left;
+    vertical-align: middle;
 }
 
 :not(pre) > code[class*=language-],

--- a/app/src/main/resources/css/control-tokens.css
+++ b/app/src/main/resources/css/control-tokens.css
@@ -182,6 +182,7 @@
     display: inline-block;
     width: 16px;
     height: 16px;
+    vertical-align: middle;
     background: center / contain no-repeat;
 }
 .sbb-icon-save {

--- a/app/src/main/resources/js/modules/ConfigurationsPane.js
+++ b/app/src/main/resources/js/modules/ConfigurationsPane.js
@@ -134,7 +134,8 @@ export default class ConfigurationsPane {
             htmlInput.style.display = "none";
         });
         document.querySelectorAll('#edit-configuration-pane .new-configuration').forEach(htmlInput => {
-            htmlInput.style.display = "inline-block";
+            // Buttons keep the shared flex layout (centres their icon); labels/inputs are inline-block.
+            htmlInput.style.display = htmlInput.tagName === "BUTTON" ? "inline-flex" : "inline-block";
         });
         this.editConfigurationPane.style.display = "block";
         this.setContentAreaEnabled(false);
@@ -145,7 +146,8 @@ export default class ConfigurationsPane {
     editConfiguration() {
         this.configurationsPane.style.display = "none";
         document.querySelectorAll('#edit-configuration-pane .edit-configuration').forEach(htmlInput => {
-            htmlInput.style.display = "inline-block";
+            // Buttons keep the shared flex layout (centres their icon); labels/inputs are inline-block.
+            htmlInput.style.display = htmlInput.tagName === "BUTTON" ? "inline-flex" : "inline-block";
         });
         document.querySelectorAll('#edit-configuration-pane .new-configuration').forEach(htmlInput => {
             htmlInput.style.display = "none";


### PR DESCRIPTION
### Proposed changes

- Adjust vertical alignment of button icons to center them against labels
- Remove float property to prevent misalignment in inline-block buttons

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
