### PR TITLE
fix: extract alert styles into injectable alerts.css

### DIFF
--- a/app/src/main/resources/css/alerts.css
+++ b/app/src/main/resources/css/alerts.css
@@ -1,0 +1,84 @@
+/*
+ * Shared alert styles — coloured status text, notification boxes, and the warning/error triangle
+ * icons. Split out of common.css so surfaces that assemble their CSS from the individually injected
+ * control sheets (exporter export dialogs via starter.js / ensureSharedStyles.js, the Bulk PDF Export
+ * widget's inlined CSS) can render alerts correctly without pulling the whole common.css.
+ *
+ * common.css @imports this, so admin pages and everything already on common.css are unchanged.
+ *
+ * Tokens: the ::before icons consume --sbb-warning-icon / --sbb-error-icon from control-tokens.css.
+ * Every injection path guarantees control-tokens.css alongside this sheet (ensureSharedStyles lists it
+ * first; common.css @imports it first; standalone pages link it explicitly).
+ */
+
+/* Inline text alerts — coloured status text (no box). Two entry points, unified here so consumers
+   don't re-declare them: .action-alerts (admin action results) and .validation-alerts (form
+   validation in the exporter popups). Not bold. */
+.action-alerts .alert,
+.validation-alerts .alert {
+    font-size: 12px;
+}
+
+.action-alerts .alert {
+    padding-left: 20px;
+}
+
+.action-alerts .alert-error,
+.validation-alerts .alert-error {
+    color: red;
+}
+
+.action-alerts .alert-success,
+.validation-alerts .alert-success {
+    color: green;
+}
+
+.notifications .alert {
+    margin-bottom: 10px;
+    font-size: 12px;
+    padding: 8px 16px 5px;
+    border-radius: 3px;
+    width: calc(100% - 32px);
+}
+
+/* Alert triangle icon via ::before, so JS-populated alerts (exporter popups set textContent) get it
+   too. Floated left → the message text wraps beside it. Warning may be standalone (interceptor);
+   error only appears inside .notifications (exporter popups / the generic notifications block).
+   The --sbb-*-icon tokens come from control-tokens.css, which is guaranteed alongside this sheet. */
+.alert-warning::before,
+.notifications .alert-error::before {
+    content: "";
+    display: inline-block;
+    /* vertical-align:middle centers the box on the x-height, which leaves a taller icon sitting
+       ~0.1em below the optical center of the capital-height text; nudge it up to compensate. */
+    vertical-align: middle;
+    position: relative;
+    top: -0.1em;
+    width: 18px;
+    height: 18px;
+    margin-right: 6px;
+    background: center / contain no-repeat;
+}
+
+.alert-warning::before {
+    background-image: var(--sbb-warning-icon);
+}
+
+.notifications .alert-error::before {
+    background-image: var(--sbb-error-icon);
+}
+
+.notifications .alert-error {
+    background-color: #f8d7da;
+    border: 1px solid #b3626a;
+}
+
+.notifications .alert-warning {
+    background-color: #fff7cd;
+    border: 1px solid #ffc328;
+}
+
+.notifications .alert-success {
+    background-color: #d1e7dd;
+    border: 1px solid #75b598;
+}

--- a/app/src/main/resources/css/common.css
+++ b/app/src/main/resources/css/common.css
@@ -5,6 +5,7 @@
 @import url("searchable-dropdown.css");
 @import url("tables.css");
 @import url("buttons.css");
+@import url("alerts.css");
 
 @font-face {
     font-family: "Selawik";
@@ -209,77 +210,9 @@ code-input {
     padding-right: 1%;
 }
 
-/* Inline text alerts — coloured status text (no box). Two entry points, unified here so consumers
-   don't re-declare them: .action-alerts (admin action results) and .validation-alerts (form
-   validation in the exporter popups). Not bold. */
-.action-alerts .alert,
-.validation-alerts .alert {
-    font-size: 12px;
-}
-
-.action-alerts .alert {
-    padding-left: 20px;
-}
-
-.action-alerts .alert-error,
-.validation-alerts .alert-error {
-    color: red;
-}
-
-.action-alerts .alert-success,
-.validation-alerts .alert-success {
-    color: green;
-}
-
-.notifications .alert {
-    margin-bottom: 10px;
-    font-size: 12px;
-    padding: 8px 16px 5px;
-    border-radius: 3px;
-    width: calc(100% - 32px);
-}
-
-/* Alert triangle icon via ::before, so JS-populated alerts (exporter popups set textContent) get it
-   too. Floated left → the message text wraps beside it. Warning may be standalone (interceptor);
-   error only appears inside .notifications (exporter popups / the generic notifications block).
-   The --sbb-*-icon tokens come from control-tokens.css, which common.css @imports at its top. */
-.alert-warning::before,
-.notifications .alert-error::before {
-    content: "";
-    display: inline-block;
-    /* vertical-align:middle centers the box on the x-height, which leaves a taller icon sitting
-       ~0.1em below the optical center of the capital-height text; nudge it up to compensate. */
-    vertical-align: middle;
-    position: relative;
-    top: -0.1em;
-    width: 18px;
-    height: 18px;
-    margin-right: 6px;
-    background: center / contain no-repeat;
-}
-
-.alert-warning::before {
-    background-image: var(--sbb-warning-icon);
-}
-
-.notifications .alert-error::before {
-    background-image: var(--sbb-error-icon);
-}
-
-.notifications .alert-error {
-    background-color: #f8d7da;
-    border: 1px solid #b3626a;
-}
-
-.notifications .alert-warning {
-    background-color: #fff7cd;
-    border: 1px solid #ffc328;
-}
-
-.notifications .alert-success {
-    background-color: #d1e7dd;
-    border: 1px solid #75b598;
-}
+/* Alert styles (inline text alerts, notification boxes, warning/error triangle icons) live in the
+   @imported alerts.css so they can be injected on their own into surfaces that don't load common.css
+   (exporter export dialogs, the Bulk PDF Export widget). See alerts.css. */
 
 .actions-pane {
     background: #f5f5f5;

--- a/app/src/main/resources/js/modules/ensureSharedStyles.js
+++ b/app/src/main/resources/js/modules/ensureSharedStyles.js
@@ -22,6 +22,8 @@ const STYLES = [
     ['generic-inputs-styles', 'inputs.css'],
     ['generic-searchable-dropdown-styles', 'searchable-dropdown.css'],
     ['generic-buttons-styles', 'buttons.css'],
+    // alerts.css consumes the --sbb-*-icon tokens defined by control-tokens.css (first entry).
+    ['generic-alerts-styles', 'alerts.css'],
 ];
 
 export default function ensureSharedStyles() {

--- a/app/src/test/js/modules/ensureSharedStylesTest.js
+++ b/app/src/test/js/modules/ensureSharedStylesTest.js
@@ -12,6 +12,7 @@ describe('ensureSharedStyles', function () {
         'generic-inputs-styles',
         'generic-searchable-dropdown-styles',
         'generic-buttons-styles',
+        'generic-alerts-styles',
     ];
     const SD_ID = 'generic-searchable-dropdown-styles';
 


### PR DESCRIPTION
### Proposed changes

Move alert styles from common.css to alerts.css to allow for individual injection into surfaces that do not load common.css. This change ensures that alerts can be rendered correctly in exporter export dialogs and the Bulk PDF Export widget without loading unnecessary styles.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
