### PR TITLE
refactor: remove global :root token declarations for scoped UI

### DIFF
--- a/app/src/main/resources/css/common.css
+++ b/app/src/main/resources/css/common.css
@@ -51,7 +51,6 @@
  * override a token downstream if a page needs a different shade.
  */
 :root {
-    --polarion-accent: var(--sbb-accent); /* links / accent — derives from the brand accent token */
     --polarion-heading-text: #000028;    /* admin / section heading text */
     --polarion-heading-bg: #F3F3F0;      /* section-header bar + h1 underline */
     --polarion-table-header-bg: #E8E8E3; /* repo-browser header fill */
@@ -59,6 +58,18 @@
     --polarion-table-cell-border: #DDDDDD; /* data-cell column separator */
     --polarion-table-row-alt: #F3F3F0;   /* zebra odd-row (repo-browser #F3F3F0/white) */
     --polarion-table-row-hover: #EBF7F8; /* row hover light-teal */
+}
+
+/* --polarion-accent is the one palette entry derived from a --sbb-* token. Since #535 --sbb-accent
+   lives only on the shared UI scopes (control-tokens.css), and var() substitutes at the element that
+   declares the property, derive --polarion-accent on those same scopes — NOT :root, where --sbb-accent
+   is absent and the substitution would be invalid. common.css is admin-only, so every consuming <a>
+   sits under .standard-admin-page. */
+.modal__container,
+.standard-admin-page,
+.form-wrapper,
+.sbb-ui {
+    --polarion-accent: var(--sbb-accent); /* links / accent — derives from the brand accent token */
 }
 
 a, td, div, li, ul, input, button, option {

--- a/app/src/main/resources/css/control-tokens.css
+++ b/app/src/main/resources/css/control-tokens.css
@@ -20,15 +20,15 @@
  * (the React SPAs link it directly and must render even when /polarion/* 404s). Edit the .svg, never
  * a base64 blob; the source here shows only placeholders.
  */
-/* Tokens are declared on the shared UI scopes (not only :root) so that on a page where several
-   extensions load their OWN bundled generic at DIFFERENT versions (the Polarion document page), each
-   extension's controls read the tokens from the closest scoped ancestor — its own bundle's copy —
-   instead of whichever extension's :root declaration happened to load last. Custom properties
-   inherit downward, so a `.sbb-ui` (or existing .modal__container / .standard-admin-page /
-   .form-wrapper) wrapper shadows any foreign :root value for its subtree.
-   :root is kept for backward-compat during rollout (consumers not yet carrying a scope class); it
-   can be dropped once every consumer wraps its UI roots in .sbb-ui. */
-:root,
+/* Tokens are declared on the shared UI scopes (NOT :root) so that on a page where several extensions
+   load their OWN bundled generic at DIFFERENT versions (the Polarion document page), each extension's
+   controls read the tokens from the closest scoped ancestor — its own bundle's copy — instead of
+   whichever extension's declaration happened to load last. Custom properties inherit downward, so a
+   `.sbb-ui` (or .modal__container / .standard-admin-page / .form-wrapper) wrapper shadows any foreign
+   value for its subtree.
+   :root was dropped in #535 once every consumer surface carried a scope wrapper — do NOT reintroduce
+   it: a :root declaration is global and re-enables cross-version clobbering for any control that
+   sits outside a wrapper. New consumers must tag their UI root with one of the scope classes. */
 .modal__container,
 .standard-admin-page,
 .form-wrapper,

--- a/app/src/main/resources/css/tabs.css
+++ b/app/src/main/resources/css/tabs.css
@@ -6,14 +6,14 @@
  * Two activation mechanisms are supported so consumers don't all need JS:
  *   1. JS-driven — add class="active" to the active <li class="tab">. Use this for a DYNAMIC tab
  *      count (the active state is not tied to a fixed selector).
- *   2. Pure-CSS radio-driven — inside a .tabbed wrapper the tab <input type="radio">s come first,
- *      then .tabs, then the <div class="tab-content"> panels; the Nth checked radio activates the Nth
- *      .tab and reveals the Nth .tab-content. The mappings use :nth-child(N of <selector>), which
- *      counts ONLY the matching elements (the radios / the .tab items / the .tab-content panels), so
- *      unrelated siblings — a hidden field, a toolbar or a description <div> — do NOT shift the
- *      indices. Only the order matters: radios → .tabs → panels. Limited to the tab count spelled out
- *      in the lists below (currently 4). (:nth-child(of S) needs the same modern engine as the :has()
- *      rules in this file.)
+ *   2. Pure-CSS radio-driven — inside a .tabbed wrapper, put the tab <input type="radio">s (and NO
+ *      other inputs) BEFORE .tabs, and keep the <div class="tab-content"> panels as the ONLY <div>s
+ *      at that level. The Nth checked radio activates the Nth .tab and reveals the Nth .tab-content.
+ *      Both mappings use :nth-of-type, which counts every sibling of the same tag (all <input>s / all
+ *      <div>s), NOT just the tab controls — so a stray input before .tabs, or a stray div before or
+ *      between the panels, shifts the indices and breaks the pairing. Keep those out (extra inputs
+ *      AFTER .tabs are fine, e.g. hidden fields), or use the JS-driven variant. Limited to the tab
+ *      count spelled out in the :nth-of-type lists below (currently 4).
  *
  * Markup:
  *   <div class="tabbed">                     (only needed for the radio-driven variant)
@@ -85,10 +85,10 @@
    baseline so the active tab reads as one surface with the panel. Applied by BOTH mechanisms
    (JS .active + radio :nth-of-type). */
 .tab.active > label,
-.tabbed [type="radio"]:nth-child(1 of [type="radio"]):checked ~ .tabs .tab:nth-child(1 of .tab) > label,
-.tabbed [type="radio"]:nth-child(2 of [type="radio"]):checked ~ .tabs .tab:nth-child(2 of .tab) > label,
-.tabbed [type="radio"]:nth-child(3 of [type="radio"]):checked ~ .tabs .tab:nth-child(3 of .tab) > label,
-.tabbed [type="radio"]:nth-child(4 of [type="radio"]):checked ~ .tabs .tab:nth-child(4 of .tab) > label {
+.tabbed [type="radio"]:nth-of-type(1):checked ~ .tabs .tab:nth-of-type(1) > label,
+.tabbed [type="radio"]:nth-of-type(2):checked ~ .tabs .tab:nth-of-type(2) > label,
+.tabbed [type="radio"]:nth-of-type(3):checked ~ .tabs .tab:nth-of-type(3) > label,
+.tabbed [type="radio"]:nth-of-type(4):checked ~ .tabs .tab:nth-of-type(4) > label {
     margin-bottom: -1px;
     border: 1px solid var(--sbb-control-border);
     border-top: 2px solid var(--sbb-accent); /* brand accent marks the active tab */
@@ -101,10 +101,10 @@
 
 /* Disabled tab (radio-driven). pointer-events:none so it takes no hover effects (no shadow-lift, no
    text darkening) and is not clickable. */
-.tabbed [type="radio"]:nth-child(1 of [type="radio"]):disabled ~ .tabs .tab:nth-child(1 of .tab) > label,
-.tabbed [type="radio"]:nth-child(2 of [type="radio"]):disabled ~ .tabs .tab:nth-child(2 of .tab) > label,
-.tabbed [type="radio"]:nth-child(3 of [type="radio"]):disabled ~ .tabs .tab:nth-child(3 of .tab) > label,
-.tabbed [type="radio"]:nth-child(4 of [type="radio"]):disabled ~ .tabs .tab:nth-child(4 of .tab) > label {
+.tabbed [type="radio"]:nth-of-type(1):disabled ~ .tabs .tab:nth-of-type(1) > label,
+.tabbed [type="radio"]:nth-of-type(2):disabled ~ .tabs .tab:nth-of-type(2) > label,
+.tabbed [type="radio"]:nth-of-type(3):disabled ~ .tabs .tab:nth-of-type(3) > label,
+.tabbed [type="radio"]:nth-of-type(4):disabled ~ .tabs .tab:nth-of-type(4) > label {
     color: var(--sbb-btn-dlg-disabled-fg);
     cursor: default;
     pointer-events: none;
@@ -113,10 +113,10 @@
 /* Keyboard focus ring. JS-driven: the focusable radio is inside the tab. Radio-driven: the focused
    radio is a sibling before .tabs, so mirror the ring onto its tab via the nth-of-type map. */
 .tab:has([type="radio"]:focus-visible) > label,
-.tabbed [type="radio"]:nth-child(1 of [type="radio"]):focus-visible ~ .tabs .tab:nth-child(1 of .tab) > label,
-.tabbed [type="radio"]:nth-child(2 of [type="radio"]):focus-visible ~ .tabs .tab:nth-child(2 of .tab) > label,
-.tabbed [type="radio"]:nth-child(3 of [type="radio"]):focus-visible ~ .tabs .tab:nth-child(3 of .tab) > label,
-.tabbed [type="radio"]:nth-child(4 of [type="radio"]):focus-visible ~ .tabs .tab:nth-child(4 of .tab) > label {
+.tabbed [type="radio"]:nth-of-type(1):focus-visible ~ .tabs .tab:nth-of-type(1) > label,
+.tabbed [type="radio"]:nth-of-type(2):focus-visible ~ .tabs .tab:nth-of-type(2) > label,
+.tabbed [type="radio"]:nth-of-type(3):focus-visible ~ .tabs .tab:nth-of-type(3) > label,
+.tabbed [type="radio"]:nth-of-type(4):focus-visible ~ .tabs .tab:nth-of-type(4) > label {
     box-shadow: var(--sbb-btn-focus-ring);
 }
 
@@ -127,10 +127,10 @@
     transition: opacity 0.4s;
 }
 
-.tabbed [type="radio"]:nth-child(1 of [type="radio"]):checked ~ .tab-content:nth-child(1 of .tab-content),
-.tabbed [type="radio"]:nth-child(2 of [type="radio"]):checked ~ .tab-content:nth-child(2 of .tab-content),
-.tabbed [type="radio"]:nth-child(3 of [type="radio"]):checked ~ .tab-content:nth-child(3 of .tab-content),
-.tabbed [type="radio"]:nth-child(4 of [type="radio"]):checked ~ .tab-content:nth-child(4 of .tab-content) {
+.tabbed [type="radio"]:nth-of-type(1):checked ~ .tab-content:nth-of-type(1),
+.tabbed [type="radio"]:nth-of-type(2):checked ~ .tab-content:nth-of-type(2),
+.tabbed [type="radio"]:nth-of-type(3):checked ~ .tab-content:nth-of-type(3),
+.tabbed [type="radio"]:nth-of-type(4):checked ~ .tab-content:nth-of-type(4) {
     display: block;
     opacity: 1;
 }

--- a/app/src/main/resources/css/tabs.css
+++ b/app/src/main/resources/css/tabs.css
@@ -6,14 +6,14 @@
  * Two activation mechanisms are supported so consumers don't all need JS:
  *   1. JS-driven — add class="active" to the active <li class="tab">. Use this for a DYNAMIC tab
  *      count (the active state is not tied to a fixed selector).
- *   2. Pure-CSS radio-driven — inside a .tabbed wrapper, put the tab <input type="radio">s (and NO
- *      other inputs) BEFORE .tabs, and keep the <div class="tab-content"> panels as the ONLY <div>s
- *      at that level. The Nth checked radio activates the Nth .tab and reveals the Nth .tab-content.
- *      Both mappings use :nth-of-type, which counts every sibling of the same tag (all <input>s / all
- *      <div>s), NOT just the tab controls — so a stray input before .tabs, or a stray div before or
- *      between the panels, shifts the indices and breaks the pairing. Keep those out (extra inputs
- *      AFTER .tabs are fine, e.g. hidden fields), or use the JS-driven variant. Limited to the tab
- *      count spelled out in the :nth-of-type lists below (currently 4).
+ *   2. Pure-CSS radio-driven — inside a .tabbed wrapper the tab <input type="radio">s come first,
+ *      then .tabs, then the <div class="tab-content"> panels; the Nth checked radio activates the Nth
+ *      .tab and reveals the Nth .tab-content. The mappings use :nth-child(N of <selector>), which
+ *      counts ONLY the matching elements (the radios / the .tab items / the .tab-content panels), so
+ *      unrelated siblings — a hidden field, a toolbar or a description <div> — do NOT shift the
+ *      indices. Only the order matters: radios → .tabs → panels. Limited to the tab count spelled out
+ *      in the lists below (currently 4). (:nth-child(of S) needs the same modern engine as the :has()
+ *      rules in this file.)
  *
  * Markup:
  *   <div class="tabbed">                     (only needed for the radio-driven variant)
@@ -85,10 +85,10 @@
    baseline so the active tab reads as one surface with the panel. Applied by BOTH mechanisms
    (JS .active + radio :nth-of-type). */
 .tab.active > label,
-.tabbed [type="radio"]:nth-of-type(1):checked ~ .tabs .tab:nth-of-type(1) > label,
-.tabbed [type="radio"]:nth-of-type(2):checked ~ .tabs .tab:nth-of-type(2) > label,
-.tabbed [type="radio"]:nth-of-type(3):checked ~ .tabs .tab:nth-of-type(3) > label,
-.tabbed [type="radio"]:nth-of-type(4):checked ~ .tabs .tab:nth-of-type(4) > label {
+.tabbed [type="radio"]:nth-child(1 of [type="radio"]):checked ~ .tabs .tab:nth-child(1 of .tab) > label,
+.tabbed [type="radio"]:nth-child(2 of [type="radio"]):checked ~ .tabs .tab:nth-child(2 of .tab) > label,
+.tabbed [type="radio"]:nth-child(3 of [type="radio"]):checked ~ .tabs .tab:nth-child(3 of .tab) > label,
+.tabbed [type="radio"]:nth-child(4 of [type="radio"]):checked ~ .tabs .tab:nth-child(4 of .tab) > label {
     margin-bottom: -1px;
     border: 1px solid var(--sbb-control-border);
     border-top: 2px solid var(--sbb-accent); /* brand accent marks the active tab */
@@ -101,10 +101,10 @@
 
 /* Disabled tab (radio-driven). pointer-events:none so it takes no hover effects (no shadow-lift, no
    text darkening) and is not clickable. */
-.tabbed [type="radio"]:nth-of-type(1):disabled ~ .tabs .tab:nth-of-type(1) > label,
-.tabbed [type="radio"]:nth-of-type(2):disabled ~ .tabs .tab:nth-of-type(2) > label,
-.tabbed [type="radio"]:nth-of-type(3):disabled ~ .tabs .tab:nth-of-type(3) > label,
-.tabbed [type="radio"]:nth-of-type(4):disabled ~ .tabs .tab:nth-of-type(4) > label {
+.tabbed [type="radio"]:nth-child(1 of [type="radio"]):disabled ~ .tabs .tab:nth-child(1 of .tab) > label,
+.tabbed [type="radio"]:nth-child(2 of [type="radio"]):disabled ~ .tabs .tab:nth-child(2 of .tab) > label,
+.tabbed [type="radio"]:nth-child(3 of [type="radio"]):disabled ~ .tabs .tab:nth-child(3 of .tab) > label,
+.tabbed [type="radio"]:nth-child(4 of [type="radio"]):disabled ~ .tabs .tab:nth-child(4 of .tab) > label {
     color: var(--sbb-btn-dlg-disabled-fg);
     cursor: default;
     pointer-events: none;
@@ -113,10 +113,10 @@
 /* Keyboard focus ring. JS-driven: the focusable radio is inside the tab. Radio-driven: the focused
    radio is a sibling before .tabs, so mirror the ring onto its tab via the nth-of-type map. */
 .tab:has([type="radio"]:focus-visible) > label,
-.tabbed [type="radio"]:nth-of-type(1):focus-visible ~ .tabs .tab:nth-of-type(1) > label,
-.tabbed [type="radio"]:nth-of-type(2):focus-visible ~ .tabs .tab:nth-of-type(2) > label,
-.tabbed [type="radio"]:nth-of-type(3):focus-visible ~ .tabs .tab:nth-of-type(3) > label,
-.tabbed [type="radio"]:nth-of-type(4):focus-visible ~ .tabs .tab:nth-of-type(4) > label {
+.tabbed [type="radio"]:nth-child(1 of [type="radio"]):focus-visible ~ .tabs .tab:nth-child(1 of .tab) > label,
+.tabbed [type="radio"]:nth-child(2 of [type="radio"]):focus-visible ~ .tabs .tab:nth-child(2 of .tab) > label,
+.tabbed [type="radio"]:nth-child(3 of [type="radio"]):focus-visible ~ .tabs .tab:nth-child(3 of .tab) > label,
+.tabbed [type="radio"]:nth-child(4 of [type="radio"]):focus-visible ~ .tabs .tab:nth-child(4 of .tab) > label {
     box-shadow: var(--sbb-btn-focus-ring);
 }
 
@@ -127,10 +127,10 @@
     transition: opacity 0.4s;
 }
 
-.tabbed [type="radio"]:nth-of-type(1):checked ~ .tab-content:nth-of-type(1),
-.tabbed [type="radio"]:nth-of-type(2):checked ~ .tab-content:nth-of-type(2),
-.tabbed [type="radio"]:nth-of-type(3):checked ~ .tab-content:nth-of-type(3),
-.tabbed [type="radio"]:nth-of-type(4):checked ~ .tab-content:nth-of-type(4) {
+.tabbed [type="radio"]:nth-child(1 of [type="radio"]):checked ~ .tab-content:nth-child(1 of .tab-content),
+.tabbed [type="radio"]:nth-child(2 of [type="radio"]):checked ~ .tab-content:nth-child(2 of .tab-content),
+.tabbed [type="radio"]:nth-child(3 of [type="radio"]):checked ~ .tab-content:nth-child(3 of .tab-content),
+.tabbed [type="radio"]:nth-child(4 of [type="radio"]):checked ~ .tab-content:nth-child(4 of .tab-content) {
     display: block;
     opacity: 1;
 }

--- a/app/src/test/js/css/controlTokensScopeTest.js
+++ b/app/src/test/js/css/controlTokensScopeTest.js
@@ -6,18 +6,26 @@ const css = readFileSync('src/main/resources/css/control-tokens.css', 'utf8');
 
 describe('control-tokens.css token scoping', function () {
 
-    it('declares the --sbb-* tokens on the shared UI scopes, not only :root', function () {
+    it('declares the --sbb-* tokens on the shared UI scopes only (no :root)', function () {
         // The token block must open on every scope wrapper so that on a page where several extensions
         // load their own bundled generic at different versions, each extension's controls read the
-        // tokens from the closest scoped ancestor (its own bundle) rather than a foreign :root that
-        // happened to load last. Regressing this to `:root {` alone reintroduces the clobbering.
+        // tokens from the closest scoped ancestor (its own bundle) rather than a foreign declaration
+        // that happened to load last.
         expect(css).to.match(
-            /:root,\s*\.modal__container,\s*\.standard-admin-page,\s*\.form-wrapper,\s*\.sbb-ui\s*\{/
+            /\.modal__container,\s*\.standard-admin-page,\s*\.form-wrapper,\s*\.sbb-ui\s*\{/
         );
     });
 
+    it('does NOT declare the tokens on :root (issue #535 — a global :root re-enables clobbering)', function () {
+        // Guard against reintroducing `:root,` (or a bare `:root {`) on the token block: a :root
+        // declaration is global, so any control outside a scope wrapper would again read whichever
+        // extension's tokens loaded last on the shared document page.
+        expect(css).to.not.match(/:root\s*,\s*\.modal__container/);
+        expect(css).to.not.match(/:root\s*\{[\s\S]*?--sbb-/);
+    });
+
     it('actually defines tokens inside that scoped block', function () {
-        const idx = css.search(/:root,\s*\.modal__container,[\s\S]*?\.sbb-ui\s*\{/);
+        const idx = css.search(/\.modal__container,\s*\.standard-admin-page,[\s\S]*?\.sbb-ui\s*\{/);
         expect(idx, 'scoped token block').to.be.greaterThan(-1);
         // A representative token appears right after the scope selector opens the block.
         expect(css.slice(idx)).to.contain('--sbb-control-height');


### PR DESCRIPTION
### Proposed changes

- Migrate --polarion-accent token to specific UI scope classes
- Ensure tokens are only declared within .modal__container, .standard-admin-page, .form-wrapper, and .sbb-ui to prevent cross-version clobbering
- Update tests to validate the absence of :root declarations

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
