### PR TITLE
fix: X-Polarion-REST-Token token layout changed

### DIFF
--- a/app/src/main/java/ch/sbb/polarion/extension/generic/auth/AbstractAuthValidator.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/auth/AbstractAuthValidator.java
@@ -5,6 +5,7 @@ import org.jetbrains.annotations.NotNull;
 
 public abstract class AbstractAuthValidator implements AuthValidator {
     protected String userId;
+    protected String sessionId;
     protected String secret;
 
     protected ISecurityService securityService;
@@ -12,6 +13,12 @@ public abstract class AbstractAuthValidator implements AuthValidator {
     @Override
     public @NotNull AuthValidator userId(@NotNull String userId) {
         this.userId = userId;
+        return this;
+    }
+
+    @Override
+    public @NotNull AuthValidator sessionId(@NotNull String sessionId) {
+        this.sessionId = sessionId;
         return this;
     }
 

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/auth/AuthValidator.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/auth/AuthValidator.java
@@ -12,6 +12,7 @@ public interface AuthValidator {
     @NotNull Subject validate() throws AuthenticationFailedException;
 
     @NotNull AuthValidator userId(@NotNull String userId);
+    @NotNull AuthValidator sessionId(@NotNull String sessionId);
     @NotNull AuthValidator secret(@NotNull String secret);
 
     @NotNull AuthValidator securityService(@NotNull ISecurityService securityService);

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/auth/XsrfTokenValidator.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/auth/XsrfTokenValidator.java
@@ -40,11 +40,14 @@ public class XsrfTokenValidator extends AbstractAuthValidator {
             return false;
         }
 
+        // Polarion 2606 token layout (see com.polarion.alm.server.xsrf.XsrfTokenServiceImpl):
+        // <salt>$<expiration>$<userId>$<sessionId> - parts[0] (random salt) is ignored.
         String[] parts = token.split("\\$");
-        if (parts.length >= 2) {
-            Instant tokenTimestamp = parseTokenTimestamp(parts[0]);
-            String tokenUser = parts[1];
-            return isTokenValid(userId, tokenUser, tokenTimestamp);
+        if (parts.length >= 4) {
+            Instant tokenTimestamp = parseTokenTimestamp(parts[1]);
+            String tokenUser = parts[2];
+            String tokenSessionId = parts[3];
+            return isTokenValid(userId, tokenUser, tokenTimestamp, tokenSessionId);
         }
 
         return false;
@@ -59,8 +62,11 @@ public class XsrfTokenValidator extends AbstractAuthValidator {
         }
     }
 
-    private boolean isTokenValid(@NotNull String userId, @NotNull String tokenUser, @NotNull Instant tokenTimestamp) {
-        return Objects.equals(userId, tokenUser) && !tokenTimestamp.isBefore(Instant.now());
+    private boolean isTokenValid(@NotNull String userId, @NotNull String tokenUser, @NotNull Instant tokenTimestamp, @NotNull String tokenSessionId) {
+        return Objects.equals(userId, tokenUser)
+                && !tokenTimestamp.isBefore(Instant.now())
+                && !tokenSessionId.isBlank()
+                && Objects.equals(sessionId, tokenSessionId);
     }
 
     private Instant parseTokenTimestamp(@NotNull String timestampPart) {

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/rest/filter/AuthenticationFilter.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/rest/filter/AuthenticationFilter.java
@@ -6,6 +6,7 @@ import ch.sbb.polarion.extension.generic.auth.ValidatorType;
 import com.polarion.platform.core.PlatformContext;
 import com.polarion.platform.security.AuthenticationFailedException;
 import com.polarion.platform.security.ISecurityService;
+import com.polarion.platform.session.PolarionSingleSignOn;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -91,9 +92,20 @@ public class AuthenticationFilter implements ContainerRequestFilter {
 
     private @NotNull AuthValidator createXsrfTokenValidator(@NotNull String xsrfToken) {
         String userId = httpServletRequest.getUserPrincipal().getName();
+        String sessionId = getSessionId(httpServletRequest);
         return ValidatorFactory.getValidator(ValidatorType.XSRF_TOKEN)
                 .userId(userId)
+                .sessionId(sessionId)
                 .secret(xsrfToken)
                 .securityService(securityService);
+    }
+
+    /**
+     * Resolves the current Polarion single-sign-on session id. Extracted as an overridable seam so
+     * that {@link com.polarion.platform.session.PolarionSingleSignOn} (which requires a fully
+     * initialized platform) does not need to be loaded in unit tests.
+     */
+    protected @NotNull String getSessionId(@NotNull HttpServletRequest request) {
+        return PolarionSingleSignOn.getSsoId(request);
     }
 }

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/rest/filter/AuthenticationFilter.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/rest/filter/AuthenticationFilter.java
@@ -92,20 +92,11 @@ public class AuthenticationFilter implements ContainerRequestFilter {
 
     private @NotNull AuthValidator createXsrfTokenValidator(@NotNull String xsrfToken) {
         String userId = httpServletRequest.getUserPrincipal().getName();
-        String sessionId = getSessionId(httpServletRequest);
+        String sessionId = PolarionSingleSignOn.getSsoId(httpServletRequest);
         return ValidatorFactory.getValidator(ValidatorType.XSRF_TOKEN)
                 .userId(userId)
                 .sessionId(sessionId)
                 .secret(xsrfToken)
                 .securityService(securityService);
-    }
-
-    /**
-     * Resolves the current Polarion single-sign-on session id. Extracted as an overridable seam so
-     * that {@link com.polarion.platform.session.PolarionSingleSignOn} (which requires a fully
-     * initialized platform) does not need to be loaded in unit tests.
-     */
-    protected @NotNull String getSessionId(@NotNull HttpServletRequest request) {
-        return PolarionSingleSignOn.getSsoId(request);
     }
 }

--- a/app/src/main/resources/META-INF/resources/common/jsp/about.jsp
+++ b/app/src/main/resources/META-INF/resources/common/jsp/about.jsp
@@ -33,6 +33,7 @@
 <head>
     <title></title>
     <link rel="stylesheet" href="../ui/generic/css/common.css?bundle=<%= version.getBundleBuildTimestampDigitsOnly() %>">
+    <link rel="stylesheet" href="../ui/generic/css/buttons.css?bundle=<%= version.getBundleBuildTimestampDigitsOnly() %>">
     <link rel="stylesheet" href="../ui/generic/css/about.css?bundle=<%= version.getBundleBuildTimestampDigitsOnly() %>">
     <link rel="stylesheet" href="../ui/generic/css/github-markdown-light.css?bundle=<%= version.getBundleBuildTimestampDigitsOnly() %>">
 </head>
@@ -67,6 +68,67 @@
             %>
             </tbody>
         </table>
+
+        <h3>REST API authentication test</h3>
+
+        <p>
+            Sends <code>GET <%= "/polarion/" + context.getExtensionContext() + "/rest/api/version" %></code>
+            with the current session's <code>X-Polarion-REST-Token</code> header, obtained via
+            <code>top.getRestApiToken()</code>. Use it to verify that in-session REST authentication works.
+            The token requires <code>com.siemens.polarion.rest.security.restApiToken.enabled=true</code> in
+            <code>polarion.properties</code>.
+        </p>
+
+        <button type="button" id="rest-auth-test-button" class="sbb-btn sbb-btn--action">Test REST authentication</button>
+        <pre id="rest-auth-test-output" class="rest-auth-test-output" style="display: none;"></pre>
+
+        <script>
+            (function () {
+                var restApiUrl = "<%= "/polarion/" + context.getExtensionContext() + "/rest/api/version" %>";
+                var button = document.getElementById("rest-auth-test-button");
+                var output = document.getElementById("rest-auth-test-output");
+
+                function showResult(text, success) {
+                    output.style.display = "block";
+                    output.textContent = text;
+                    output.classList.remove("success", "failure");
+                    output.classList.add(success ? "success" : "failure");
+                }
+
+                button.addEventListener("click", function () {
+                    var token;
+                    try {
+                        token = top.getRestApiToken();
+                    } catch (e) {
+                        showResult("Unable to obtain a token via top.getRestApiToken(): " + e, false);
+                        return;
+                    }
+                    if (!token) {
+                        showResult("top.getRestApiToken() returned no token. Make sure the REST API token is enabled and you are logged in.", false);
+                        return;
+                    }
+
+                    button.disabled = true;
+                    showResult("Calling " + restApiUrl + " …", true);
+
+                    fetch(restApiUrl, {
+                        method: "GET",
+                        headers: {
+                            "Accept": "application/json",
+                            "X-Polarion-REST-Token": token
+                        }
+                    }).then(function (response) {
+                        return response.text().then(function (body) {
+                            showResult("HTTP " + response.status + " " + response.statusText + "\n\n" + body, response.ok);
+                        });
+                    }).catch(function (e) {
+                        showResult("Request failed: " + e, false);
+                    }).finally(function () {
+                        button.disabled = false;
+                    });
+                });
+            })();
+        </script>
 
         <h3>Extension configuration properties</h3>
 

--- a/app/src/main/resources/META-INF/resources/common/jsp/about.jsp
+++ b/app/src/main/resources/META-INF/resources/common/jsp/about.jsp
@@ -69,66 +69,9 @@
             </tbody>
         </table>
 
-        <h3>REST API authentication test</h3>
-
-        <p>
-            Sends <code>GET <%= "/polarion/" + context.getExtensionContext() + "/rest/api/version" %></code>
-            with the current session's <code>X-Polarion-REST-Token</code> header, obtained via
-            <code>top.getRestApiToken()</code>. Use it to verify that in-session REST authentication works.
-            The token requires <code>com.siemens.polarion.rest.security.restApiToken.enabled=true</code> in
-            <code>polarion.properties</code>.
-        </p>
-
-        <button type="button" id="rest-auth-test-button" class="sbb-btn sbb-btn--action">Test REST authentication</button>
-        <pre id="rest-auth-test-output" class="rest-auth-test-output" style="display: none;"></pre>
-
-        <script>
-            (function () {
-                var restApiUrl = "<%= "/polarion/" + context.getExtensionContext() + "/rest/api/version" %>";
-                var button = document.getElementById("rest-auth-test-button");
-                var output = document.getElementById("rest-auth-test-output");
-
-                function showResult(text, success) {
-                    output.style.display = "block";
-                    output.textContent = text;
-                    output.classList.remove("success", "failure");
-                    output.classList.add(success ? "success" : "failure");
-                }
-
-                button.addEventListener("click", function () {
-                    var token;
-                    try {
-                        token = top.getRestApiToken();
-                    } catch (e) {
-                        showResult("Unable to obtain a token via top.getRestApiToken(): " + e, false);
-                        return;
-                    }
-                    if (!token) {
-                        showResult("top.getRestApiToken() returned no token. Make sure the REST API token is enabled and you are logged in.", false);
-                        return;
-                    }
-
-                    button.disabled = true;
-                    showResult("Calling " + restApiUrl + " …", true);
-
-                    fetch(restApiUrl, {
-                        method: "GET",
-                        headers: {
-                            "Accept": "application/json",
-                            "X-Polarion-REST-Token": token
-                        }
-                    }).then(function (response) {
-                        return response.text().then(function (body) {
-                            showResult("HTTP " + response.status + " " + response.statusText + "\n\n" + body, response.ok);
-                        });
-                    }).catch(function (e) {
-                        showResult("Request failed: " + e, false);
-                    }).finally(function () {
-                        button.disabled = false;
-                    });
-                });
-            })();
-        </script>
+        <% if (CurrentExtensionConfiguration.getInstance().getExtensionConfiguration().isDebug()) { %>
+        <%@ include file="rest-auth-test.jsp" %>
+        <% } %>
 
         <h3>Extension configuration properties</h3>
 

--- a/app/src/main/resources/META-INF/resources/common/jsp/rest-auth-test.jsp
+++ b/app/src/main/resources/META-INF/resources/common/jsp/rest-auth-test.jsp
@@ -55,7 +55,15 @@
                 }
             }).then(function (response) {
                 return response.text().then(function (body) {
-                    showResult("HTTP " + response.status + " " + response.statusText + "\n\n" + body, response.ok);
+                    let formattedBody = body;
+                    try {
+                        formattedBody = JSON.stringify(JSON.parse(body), null, 2);
+                    } catch (ignored) {
+                        // Response is not JSON; show it as-is.
+                    }
+                    const statusText = response.statusText && response.statusText !== String(response.status)
+                        ? " " + response.statusText : "";
+                    showResult("HTTP " + response.status + statusText + "\n\n" + formattedBody, response.ok);
                 });
             }).catch(function (e) {
                 showResult("Request failed: " + e, false);

--- a/app/src/main/resources/META-INF/resources/common/jsp/rest-auth-test.jsp
+++ b/app/src/main/resources/META-INF/resources/common/jsp/rest-auth-test.jsp
@@ -1,0 +1,67 @@
+<%@ page import="ch.sbb.polarion.extension.generic.util.ExtensionInfo" %>
+<%--
+    Fragment (statically included by about.jsp) providing a manual X-Polarion-REST-Token
+    authentication test. Shown only when the extension's debug mode is enabled.
+--%>
+<% String restAuthTestUrl = "/polarion/" + ExtensionInfo.getInstance().getContext().getExtensionContext() + "/rest/api/version"; %>
+
+<h3>REST API authentication test</h3>
+
+<p>
+    Sends <code>GET <%= restAuthTestUrl %></code>
+    with the current session's <code>X-Polarion-REST-Token</code> header, obtained via
+    <code>top.getRestApiToken()</code>. Use it to verify that in-session REST authentication works.
+    The token requires <code>com.siemens.polarion.rest.security.restApiToken.enabled=true</code> in
+    <code>polarion.properties</code>.
+</p>
+
+<button type="button" id="rest-auth-test-button" class="sbb-btn sbb-btn--action">Test REST authentication</button>
+<pre id="rest-auth-test-output" class="rest-auth-test-output" style="display: none;"></pre>
+
+<script>
+    (function () {
+        const restApiUrl = "<%= restAuthTestUrl %>";
+        const button = document.getElementById("rest-auth-test-button");
+        const output = document.getElementById("rest-auth-test-output");
+
+        function showResult(text, success) {
+            output.style.display = "block";
+            output.textContent = text;
+            output.classList.remove("success", "failure");
+            output.classList.add(success ? "success" : "failure");
+        }
+
+        button.addEventListener("click", function () {
+            let token;
+            try {
+                token = top.getRestApiToken();
+            } catch (e) {
+                showResult("Unable to obtain a token via top.getRestApiToken(): " + e, false);
+                return;
+            }
+            if (!token) {
+                showResult("top.getRestApiToken() returned no token. Make sure the REST API token is enabled and you are logged in.", false);
+                return;
+            }
+
+            button.disabled = true;
+            showResult("Calling " + restApiUrl + " …", true);
+
+            fetch(restApiUrl, {
+                method: "GET",
+                headers: {
+                    "Accept": "application/json",
+                    "X-Polarion-REST-Token": token
+                }
+            }).then(function (response) {
+                return response.text().then(function (body) {
+                    showResult("HTTP " + response.status + " " + response.statusText + "\n\n" + body, response.ok);
+                });
+            }).catch(function (e) {
+                showResult("Request failed: " + e, false);
+            }).finally(function () {
+                button.disabled = false;
+            });
+        });
+    })();
+</script>

--- a/app/src/main/resources/css/about.css
+++ b/app/src/main/resources/css/about.css
@@ -58,3 +58,26 @@
     white-space: pre-wrap;
     padding: 6px 10px;
 }
+
+.about-page-text .rest-auth-test-output {
+    margin-top: 10px;
+    padding: 8px 10px;
+    font-family: monospace;
+    font-size: 12px;
+    line-height: 18px;
+    white-space: pre-wrap;
+    word-break: break-word;
+    border-radius: 3px;
+    border: 1px solid #DFE1E6;
+    background-color: #F4F5F7;
+}
+
+.about-page-text .rest-auth-test-output.success {
+    border-color: #B7DFB9;
+    background-color: #EBF7EC;
+}
+
+.about-page-text .rest-auth-test-output.failure {
+    border-color: #F1B0B7;
+    background-color: #FCEBEC;
+}

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/auth/XsrfTokenValidatorTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/auth/XsrfTokenValidatorTest.java
@@ -30,7 +30,12 @@ import static org.mockito.Mockito.when;
 class XsrfTokenValidatorTest {
 
     private static final String USER_ID = "testUser";
+    private static final String SESSION_ID = "testSession";
     private static final String VALIDATOR_INPUT = "dummy-value";
+
+    // Polarion 2606 token layout is <salt>$<expiration>$<userId>$<sessionId>;
+    // the leading salt is random and ignored during validation.
+    private static final String SALT = "cmFuZG9tU2FsdA==";
 
     // Fixed epoch-milli bounds so the tests don't depend on the system clock:
     // Long.MAX_VALUE is always in the future, 0 (Instant.EPOCH) is always in the past.
@@ -54,7 +59,7 @@ class XsrfTokenValidatorTest {
         try (MockedStatic<Configuration> configurationMockedStatic = mockStatic(Configuration.class);
              MockedStatic<PasswordEncryptor> passwordEncryptorMockedStatic = mockStatic(PasswordEncryptor.class)) {
             mockRestApiTokenEnabled(configurationMockedStatic, true);
-            mockDecryptedToken(passwordEncryptorMockedStatic, FAR_FUTURE_TIMESTAMP + "$" + USER_ID);
+            mockDecryptedToken(passwordEncryptorMockedStatic, token(FAR_FUTURE_TIMESTAMP, USER_ID, SESSION_ID));
 
             Subject subject = new Subject();
             when(securityService.getCurrentSubject()).thenReturn(subject);
@@ -69,7 +74,7 @@ class XsrfTokenValidatorTest {
         try (MockedStatic<Configuration> configurationMockedStatic = mockStatic(Configuration.class);
              MockedStatic<PasswordEncryptor> passwordEncryptorMockedStatic = mockStatic(PasswordEncryptor.class)) {
             mockRestApiTokenEnabled(configurationMockedStatic, true);
-            mockDecryptedToken(passwordEncryptorMockedStatic, PAST_TIMESTAMP + "$" + USER_ID);
+            mockDecryptedToken(passwordEncryptorMockedStatic, token(PAST_TIMESTAMP, USER_ID, SESSION_ID));
 
             assertThrows(AuthenticationFailedException.class, createValidator()::validate);
         }
@@ -80,7 +85,7 @@ class XsrfTokenValidatorTest {
         try (MockedStatic<Configuration> configurationMockedStatic = mockStatic(Configuration.class);
              MockedStatic<PasswordEncryptor> passwordEncryptorMockedStatic = mockStatic(PasswordEncryptor.class)) {
             mockRestApiTokenEnabled(configurationMockedStatic, true);
-            mockDecryptedToken(passwordEncryptorMockedStatic, "notANumber$" + USER_ID);
+            mockDecryptedToken(passwordEncryptorMockedStatic, token("notANumber", USER_ID, SESSION_ID));
 
             assertThrows(AuthenticationFailedException.class, createValidator()::validate);
         }
@@ -91,7 +96,58 @@ class XsrfTokenValidatorTest {
         try (MockedStatic<Configuration> configurationMockedStatic = mockStatic(Configuration.class);
              MockedStatic<PasswordEncryptor> passwordEncryptorMockedStatic = mockStatic(PasswordEncryptor.class)) {
             mockRestApiTokenEnabled(configurationMockedStatic, true);
-            mockDecryptedToken(passwordEncryptorMockedStatic, FAR_FUTURE_TIMESTAMP + "$anotherUser");
+            mockDecryptedToken(passwordEncryptorMockedStatic, token(FAR_FUTURE_TIMESTAMP, "anotherUser", SESSION_ID));
+
+            assertThrows(AuthenticationFailedException.class, createValidator()::validate);
+        }
+    }
+
+    @Test
+    void testTokenWithDifferentSessionRejected() {
+        try (MockedStatic<Configuration> configurationMockedStatic = mockStatic(Configuration.class);
+             MockedStatic<PasswordEncryptor> passwordEncryptorMockedStatic = mockStatic(PasswordEncryptor.class)) {
+            mockRestApiTokenEnabled(configurationMockedStatic, true);
+            mockDecryptedToken(passwordEncryptorMockedStatic, token(FAR_FUTURE_TIMESTAMP, USER_ID, "anotherSession"));
+
+            assertThrows(AuthenticationFailedException.class, createValidator()::validate);
+        }
+    }
+
+    @Test
+    void testTokenWithEmptySessionRejected() {
+        try (MockedStatic<Configuration> configurationMockedStatic = mockStatic(Configuration.class);
+             MockedStatic<PasswordEncryptor> passwordEncryptorMockedStatic = mockStatic(PasswordEncryptor.class)) {
+            mockRestApiTokenEnabled(configurationMockedStatic, true);
+            mockDecryptedToken(passwordEncryptorMockedStatic, token(FAR_FUTURE_TIMESTAMP, USER_ID, ""));
+
+            assertThrows(AuthenticationFailedException.class, createValidator()::validate);
+        }
+    }
+
+    @Test
+    void testTokenWithAdditionalTrailingPartsAccepted() throws AuthenticationFailedException {
+        // Forward-compatibility: should Polarion append further fields (as 2606 did over 2512),
+        // validation must keep reading the pinned indices salt$expiration$userId$sessionId.
+        try (MockedStatic<Configuration> configurationMockedStatic = mockStatic(Configuration.class);
+             MockedStatic<PasswordEncryptor> passwordEncryptorMockedStatic = mockStatic(PasswordEncryptor.class)) {
+            mockRestApiTokenEnabled(configurationMockedStatic, true);
+            mockDecryptedToken(passwordEncryptorMockedStatic, token(FAR_FUTURE_TIMESTAMP, USER_ID, SESSION_ID) + "$hypotheticalFutureField");
+
+            Subject subject = new Subject();
+            when(securityService.getCurrentSubject()).thenReturn(subject);
+            when(securityService.getSubjectUser(subject)).thenReturn(USER_ID);
+
+            assertSame(subject, createValidator().validate());
+        }
+    }
+
+    @Test
+    void testTokenWithTooFewPartsRejected() {
+        try (MockedStatic<Configuration> configurationMockedStatic = mockStatic(Configuration.class);
+             MockedStatic<PasswordEncryptor> passwordEncryptorMockedStatic = mockStatic(PasswordEncryptor.class)) {
+            mockRestApiTokenEnabled(configurationMockedStatic, true);
+            // Pre-2606 layout (<expiration>$<userId>) no longer has enough parts.
+            mockDecryptedToken(passwordEncryptorMockedStatic, FAR_FUTURE_TIMESTAMP + "$" + USER_ID);
 
             assertThrows(AuthenticationFailedException.class, createValidator()::validate);
         }
@@ -124,7 +180,7 @@ class XsrfTokenValidatorTest {
         try (MockedStatic<Configuration> configurationMockedStatic = mockStatic(Configuration.class);
              MockedStatic<PasswordEncryptor> passwordEncryptorMockedStatic = mockStatic(PasswordEncryptor.class)) {
             mockRestApiTokenEnabled(configurationMockedStatic, true);
-            mockDecryptedToken(passwordEncryptorMockedStatic, FAR_FUTURE_TIMESTAMP + "$" + USER_ID);
+            mockDecryptedToken(passwordEncryptorMockedStatic, token(FAR_FUTURE_TIMESTAMP, USER_ID, SESSION_ID));
 
             Subject subject = new Subject();
             when(securityService.getCurrentSubject()).thenReturn(subject);
@@ -145,9 +201,13 @@ class XsrfTokenValidatorTest {
         verify(requestContext).setProperty(LogoutFilter.XSRF_SKIP_LOGOUT, Boolean.TRUE);
     }
 
+    private String token(String expiration, String userId, String sessionId) {
+        return SALT + "$" + expiration + "$" + userId + "$" + sessionId;
+    }
+
     private XsrfTokenValidator createValidator() {
         XsrfTokenValidator validator = new XsrfTokenValidator();
-        validator.userId(USER_ID).secret(VALIDATOR_INPUT).securityService(securityService);
+        validator.userId(USER_ID).sessionId(SESSION_ID).secret(VALIDATOR_INPUT).securityService(securityService);
         return validator;
     }
 

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/rest/filter/AuthenticationFilterTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/rest/filter/AuthenticationFilterTest.java
@@ -3,6 +3,7 @@ package ch.sbb.polarion.extension.generic.rest.filter;
 import ch.sbb.polarion.extension.generic.auth.AuthValidator;
 import ch.sbb.polarion.extension.generic.auth.ValidatorFactory;
 import ch.sbb.polarion.extension.generic.auth.ValidatorType;
+import ch.sbb.polarion.extension.generic.test_extensions.PlatformContextMockExtension;
 import com.polarion.core.config.Configuration;
 import com.polarion.core.config.IConfiguration;
 import com.polarion.platform.security.AuthenticationFailedException;
@@ -28,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({MockitoExtension.class, PlatformContextMockExtension.class})
 class AuthenticationFilterTest {
 
     @Mock
@@ -126,7 +127,7 @@ class AuthenticationFilterTest {
         try (MockedStatic<ValidatorFactory> validatorFactoryMockedStatic = mockStatic(ValidatorFactory.class)) {
             when(ValidatorFactory.getValidator(ValidatorType.XSRF_TOKEN)).thenReturn(xsrfValidator);
 
-            AuthenticationFilter filter = xsrfTestFilter();
+            AuthenticationFilter filter = new AuthenticationFilter(securityService, httpServletRequest);
             filter.filter(requestContext);
             verify(requestContext, times(1)).setProperty(eq("user_subject"), any(Subject.class));
         }
@@ -147,7 +148,7 @@ class AuthenticationFilterTest {
                     .getUserPrincipal()
                     .getName()).thenReturn("user");
 
-            AuthenticationFilter filter = xsrfTestFilter();
+            AuthenticationFilter filter = new AuthenticationFilter(securityService, httpServletRequest);
 
             assertThatThrownBy(() -> filter.filter(requestContext))
                     .isInstanceOf(NotAuthorizedException.class)
@@ -169,7 +170,7 @@ class AuthenticationFilterTest {
                     .getUserPrincipal()
                     .getName()).thenReturn("user");
 
-            AuthenticationFilter filter = xsrfTestFilter();
+            AuthenticationFilter filter = new AuthenticationFilter(securityService, httpServletRequest);
 
             assertThatThrownBy(() -> filter.filter(requestContext))
                     .isInstanceOf(NotAuthorizedException.class)
@@ -191,25 +192,11 @@ class AuthenticationFilterTest {
                     .getUserPrincipal()
                     .getName()).thenReturn("different_user");
 
-            AuthenticationFilter filter = xsrfTestFilter();
+            AuthenticationFilter filter = new AuthenticationFilter(securityService, httpServletRequest);
 
             assertThatThrownBy(() -> filter.filter(requestContext))
                     .isInstanceOf(NotAuthorizedException.class)
                     .hasMessageContaining("Invalid XSRF token");
         }
-    }
-
-    /**
-     * Builds a filter whose session-id lookup is stubbed, so the real
-     * {@link com.polarion.platform.session.PolarionSingleSignOn} (which requires an initialized
-     * platform) is never loaded during unit tests.
-     */
-    private AuthenticationFilter xsrfTestFilter() {
-        return new AuthenticationFilter(securityService, httpServletRequest) {
-            @Override
-            protected String getSessionId(HttpServletRequest request) {
-                return "session";
-            }
-        };
     }
 }

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/rest/filter/AuthenticationFilterTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/rest/filter/AuthenticationFilterTest.java
@@ -119,13 +119,14 @@ class AuthenticationFilterTest {
         AuthValidator xsrfValidator = mock(AuthValidator.class);
         when(xsrfValidator.validate()).thenReturn(new Subject());
         when(xsrfValidator.userId(anyString())).thenReturn(xsrfValidator);
+        when(xsrfValidator.sessionId(anyString())).thenReturn(xsrfValidator);
         when(xsrfValidator.secret(anyString())).thenReturn(xsrfValidator);
         when(xsrfValidator.securityService(securityService)).thenReturn(xsrfValidator);
         doCallRealMethod().when(xsrfValidator).updateRequestContext(any(), any());
         try (MockedStatic<ValidatorFactory> validatorFactoryMockedStatic = mockStatic(ValidatorFactory.class)) {
             when(ValidatorFactory.getValidator(ValidatorType.XSRF_TOKEN)).thenReturn(xsrfValidator);
 
-            AuthenticationFilter filter = new AuthenticationFilter(securityService, httpServletRequest);
+            AuthenticationFilter filter = xsrfTestFilter();
             filter.filter(requestContext);
             verify(requestContext, times(1)).setProperty(eq("user_subject"), any(Subject.class));
         }
@@ -146,7 +147,7 @@ class AuthenticationFilterTest {
                     .getUserPrincipal()
                     .getName()).thenReturn("user");
 
-            AuthenticationFilter filter = new AuthenticationFilter(securityService, httpServletRequest);
+            AuthenticationFilter filter = xsrfTestFilter();
 
             assertThatThrownBy(() -> filter.filter(requestContext))
                     .isInstanceOf(NotAuthorizedException.class)
@@ -168,7 +169,7 @@ class AuthenticationFilterTest {
                     .getUserPrincipal()
                     .getName()).thenReturn("user");
 
-            AuthenticationFilter filter = new AuthenticationFilter(securityService, httpServletRequest);
+            AuthenticationFilter filter = xsrfTestFilter();
 
             assertThatThrownBy(() -> filter.filter(requestContext))
                     .isInstanceOf(NotAuthorizedException.class)
@@ -190,11 +191,25 @@ class AuthenticationFilterTest {
                     .getUserPrincipal()
                     .getName()).thenReturn("different_user");
 
-            AuthenticationFilter filter = new AuthenticationFilter(securityService, httpServletRequest);
+            AuthenticationFilter filter = xsrfTestFilter();
 
             assertThatThrownBy(() -> filter.filter(requestContext))
                     .isInstanceOf(NotAuthorizedException.class)
                     .hasMessageContaining("Invalid XSRF token");
         }
+    }
+
+    /**
+     * Builds a filter whose session-id lookup is stubbed, so the real
+     * {@link com.polarion.platform.session.PolarionSingleSignOn} (which requires an initialized
+     * platform) is never loaded during unit tests.
+     */
+    private AuthenticationFilter xsrfTestFilter() {
+        return new AuthenticationFilter(securityService, httpServletRequest) {
+            @Override
+            protected String getSessionId(HttpServletRequest request) {
+                return "session";
+            }
+        };
     }
 }

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/test_extensions/PlatformContextMockExtension.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/test_extensions/PlatformContextMockExtension.java
@@ -3,6 +3,8 @@ package ch.sbb.polarion.extension.generic.test_extensions;
 import com.polarion.alm.projects.IProjectService;
 import com.polarion.alm.tracker.ITestManagementService;
 import com.polarion.alm.tracker.ITrackerService;
+import com.polarion.core.config.Configuration;
+import com.polarion.core.config.IConfiguration;
 import com.polarion.platform.IPlatformService;
 import com.polarion.platform.core.IPlatform;
 import com.polarion.platform.core.PlatformContext;
@@ -12,6 +14,7 @@ import com.polarion.platform.security.ISecurityService;
 import com.polarion.platform.security.accesstoken.IUserAccessTokenService;
 import com.polarion.platform.security.auth.UserAuthenticationProvider;
 import com.polarion.platform.service.repository.IRepositoryService;
+import com.polarion.platform.session.PolarionSingleSignOn;
 import com.polarion.portal.internal.server.navigation.TestManagementServiceAccessor;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
@@ -70,6 +73,29 @@ public class PlatformContextMockExtension implements BeforeEachCallback, AfterEa
         testManagementServiceAccessorMockedConstruction = mockConstruction(TestManagementServiceAccessor.class, (testManagementServiceAccessor, mockedContructionContext) -> {
             lenient().when(testManagementServiceAccessor.getTestingService()).thenReturn(testManagementService);
         });
+
+        initSingleSignOn();
+    }
+
+    /**
+     * Ensures {@link PolarionSingleSignOn} is initialized so that code resolving the current session id
+     * (e.g. XSRF token authentication via {@code PolarionSingleSignOn.getSsoId(request)}) works without
+     * a running platform. On a mock request {@code getSsoId} simply returns {@code ""}.
+     * <p>
+     * The class's static initializer builds a {@code HostHeaderValidator} that reads
+     * {@code Configuration.getInstance().tomcat()...}, so a {@link Configuration} must be available
+     * while the class is initialized; a deep-stub one is provided for that moment only. The class is
+     * loaded (not mocked with {@code mockStatic}) on purpose: one of its methods references
+     * {@code org.apache.catalina.connector.Request}, which is absent from the unit-test classpath and
+     * would make Byte Buddy instrumentation fail.
+     */
+    private void initSingleSignOn() {
+        try (MockedStatic<Configuration> configurationMockedStatic = mockStatic(Configuration.class)) {
+            configurationMockedStatic.when(Configuration::getInstance).thenReturn(mock(IConfiguration.class, Answers.RETURNS_DEEP_STUBS));
+            Class.forName(PolarionSingleSignOn.class.getName(), true, PolarionSingleSignOn.class.getClassLoader());
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Unable to initialize " + PolarionSingleSignOn.class.getName(), e);
+        }
     }
 
     @Override


### PR DESCRIPTION
### Proposed changes

This pull request introduces improved session validation for XSRF (REST API) token authentication, updates related interfaces and tests, and adds a debug-only manual authentication test to the about page. The main focus is to ensure that the session ID from the token matches the current session, increasing security and aligning with Polarion 2606 token format. It also enhances developer experience with better testing and debug tools.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
