### PR TITLE
fix: ensure admin action buttons and alerts render with correct tokens

### DIFF
--- a/app/src/main/resources/META-INF/resources/common/jsp/buttons.jsp
+++ b/app/src/main/resources/META-INF/resources/common/jsp/buttons.jsp
@@ -1,6 +1,11 @@
 <%@ page contentType="text/html;charset=UTF-8" %>
 
-<div class="actions-pane hide-on-edit-configuration">
+<%-- sbb-ui carries the --sbb-* design tokens (control-tokens.css) for this fragment. Admin pages
+     include buttons.jsp AFTER the .standard-admin-page wrapper closes, so this action pane is a
+     body-level sibling — without a scope class its buttons (and their .sbb-icon-* glyphs) would read
+     unresolved var(--sbb-*) after #535 dropped the global :root token declarations, rendering
+     unstyled and icon-less. --%>
+<div class="actions-pane hide-on-edit-configuration sbb-ui">
     <div id="revisions-expand-container">
         <table id="revisions-table">
             <thead>

--- a/app/src/main/resources/META-INF/resources/common/jsp/buttons.jsp
+++ b/app/src/main/resources/META-INF/resources/common/jsp/buttons.jsp
@@ -3,8 +3,8 @@
 <%-- sbb-ui carries the --sbb-* design tokens (control-tokens.css) for this fragment. Admin pages
      include buttons.jsp AFTER the .standard-admin-page wrapper closes, so this action pane is a
      body-level sibling — without a scope class its buttons (and their .sbb-icon-* glyphs) would read
-     unresolved var(--sbb-*) after #535 dropped the global :root token declarations, rendering
-     unstyled and icon-less. --%>
+     unresolved var(--sbb-*) now that the tokens are declared only on the scope wrappers (not :root),
+     rendering unstyled and icon-less. --%>
 <div class="actions-pane hide-on-edit-configuration sbb-ui">
     <div id="revisions-expand-container">
         <table id="revisions-table">

--- a/app/src/main/resources/META-INF/resources/common/jsp/configurations.jsp
+++ b/app/src/main/resources/META-INF/resources/common/jsp/configurations.jsp
@@ -2,8 +2,8 @@
     <span id="default-cannot-be-deleted-note">Be aware that "Default" <span class="configuration-label">configuration</span> on global scope can't be deleted or renamed.</span></p>
 <%-- sbb-ui makes this panel self-contained: its .toolbar-button controls and .sbb-icon-* glyphs read
      --sbb-* tokens (control-tokens.css) even if a page ever includes this fragment outside a
-     .standard-admin-page / other scope wrapper. Post-#535 the tokens are no longer on :root, so an
-     unscoped include would render the buttons and their icons unstyled. --%>
+     .standard-admin-page / other scope wrapper. The tokens are declared only on the scope wrappers
+     (not :root), so an unscoped include would render the buttons and their icons unstyled. --%>
 <div class="input-group common-configuration-panel sbb-ui">
     <div id="configurations-pane">
         <label id="configurations-label"><span class="configuration-label-capitalized">Configuration</span>:</label>

--- a/app/src/main/resources/META-INF/resources/common/jsp/configurations.jsp
+++ b/app/src/main/resources/META-INF/resources/common/jsp/configurations.jsp
@@ -1,6 +1,10 @@
 <p>There can be multiple named <span class="configuration-label">configuration</span>s. Please, choose one you would like to modify in dropdown below.
     <span id="default-cannot-be-deleted-note">Be aware that "Default" <span class="configuration-label">configuration</span> on global scope can't be deleted or renamed.</span></p>
-<div class="input-group common-configuration-panel">
+<%-- sbb-ui makes this panel self-contained: its .toolbar-button controls and .sbb-icon-* glyphs read
+     --sbb-* tokens (control-tokens.css) even if a page ever includes this fragment outside a
+     .standard-admin-page / other scope wrapper. Post-#535 the tokens are no longer on :root, so an
+     unscoped include would render the buttons and their icons unstyled. --%>
+<div class="input-group common-configuration-panel sbb-ui">
     <div id="configurations-pane">
         <label id="configurations-label"><span class="configuration-label-capitalized">Configuration</span>:</label>
         <select id="configurations-select"></select>

--- a/app/src/main/resources/META-INF/resources/common/jsp/notifications.jsp
+++ b/app/src/main/resources/META-INF/resources/common/jsp/notifications.jsp
@@ -3,8 +3,9 @@
 <%! String bundleTimestamp = ch.sbb.polarion.extension.generic.util.VersionUtils.getVersion().getBundleBuildTimestampDigitsOnly(); %>
 
 <%-- sbb-ui makes this fragment self-contained: its .alert boxes read --sbb-* tokens (control-tokens.css)
-     even if a page ever includes it outside a .standard-admin-page / other scope wrapper. Post-#535 the
-     tokens are no longer on :root, so an unscoped include would render the alerts unstyled. --%>
+     even if a page ever includes it outside a .standard-admin-page / other scope wrapper. The tokens
+     are declared only on the scope wrappers (not :root), so an unscoped include would render the
+     alerts unstyled. --%>
 <div class="notifications sbb-ui">
     <div id="newer-version-warning" class="alert alert-warning" style="display: none">
         <span>A newer plugin version installed since the data below was persisted which can lead to unexpected behaviour.

--- a/app/src/main/resources/META-INF/resources/common/jsp/notifications.jsp
+++ b/app/src/main/resources/META-INF/resources/common/jsp/notifications.jsp
@@ -2,7 +2,10 @@
 
 <%! String bundleTimestamp = ch.sbb.polarion.extension.generic.util.VersionUtils.getVersion().getBundleBuildTimestampDigitsOnly(); %>
 
-<div class="notifications">
+<%-- sbb-ui makes this fragment self-contained: its .alert boxes read --sbb-* tokens (control-tokens.css)
+     even if a page ever includes it outside a .standard-admin-page / other scope wrapper. Post-#535 the
+     tokens are no longer on :root, so an unscoped include would render the alerts unstyled. --%>
+<div class="notifications sbb-ui">
     <div id="newer-version-warning" class="alert alert-warning" style="display: none">
         <span>A newer plugin version installed since the data below was persisted which can lead to unexpected behaviour.
             Consider checking if persisted data is still compatible and/or relevant to a newer plugin version. <span style="color: #999999">This message will be hidden after the next save.</span>


### PR DESCRIPTION
### Proposed changes

This pull request updates several JSP fragments to ensure that SBB UI design tokens are properly scoped and applied, preventing unstyled components and missing icons when these fragments are included outside of their usual wrapper elements. The main change is the addition of the `sbb-ui` class to key container elements, making the fragments self-contained and robust to changes in global CSS token declarations.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
