### PR TITLE
feat: add shared StylePackageWeights admin component

### DIFF
--- a/app/src/main/resources/css/style-package-weights.css
+++ b/app/src/main/resources/css/style-package-weights.css
@@ -1,0 +1,150 @@
+/*
+ * Style Package Weights list — shared look for the exporter extensions' weights admin page
+ * (see js/modules/StylePackageWeights.js). Flat Polarion 2606 styling built on the --sbb-* control
+ * tokens (control-tokens.css), so it stays in sync with the rest of the UI. Scoped to
+ * .standard-admin-page, where the tokens are declared. Link it from the page:
+ *   <link rel="stylesheet" href="../ui/generic/css/style-package-weights.css?bundle=...">
+ */
+.standard-admin-page .weights-list {
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
+    max-width: 500px;
+    border: 1px solid var(--sbb-control-border);
+    border-radius: 3px;
+    overflow: hidden;
+}
+
+.standard-admin-page .weight-item {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    padding: 7px 10px;
+    background-color: #fff;
+    border-bottom: 1px solid #ededed;
+    cursor: grab;
+    transition: background-color 0.12s ease, box-shadow 0.08s ease;
+}
+
+.standard-admin-page .weight-item:last-child {
+    border-bottom: none;
+}
+
+.standard-admin-page .weight-item:hover {
+    background-color: var(--sbb-hover-tint);
+}
+
+.standard-admin-page .weight-item.dragging {
+    opacity: 0.4;
+}
+
+/* Insertion indicator: an accent line on the edge the dragged item would land on. */
+.standard-admin-page .weight-item.drop-above {
+    box-shadow: inset 0 3px 0 var(--sbb-accent);
+}
+
+.standard-admin-page .weight-item.drop-below {
+    box-shadow: inset 0 -3px 0 var(--sbb-accent);
+}
+
+.standard-admin-page .weight-item.static {
+    background-color: #f7f7f5;
+    color: #9a9a9a;
+    cursor: default;
+}
+
+.standard-admin-page .weight-item .name {
+    flex: 1;
+    min-width: 0;
+    font-weight: 600;
+}
+
+/* Left slot — drag handle (movable rows) or lock marker (read-only global rows). Both occupy the
+   same 14px box so names line up across all rows. */
+.standard-admin-page .weight-item .drag-handle,
+.standard-admin-page .weight-item .lock-marker {
+    flex: 0 0 auto;
+    width: 14px;
+    padding: 2px 0;
+    box-sizing: content-box;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 0;
+}
+
+.standard-admin-page .weight-item .drag-handle {
+    color: #9a9a9a;
+    cursor: grab;
+    border-radius: 3px;
+}
+
+.standard-admin-page .weight-item .drag-handle:hover {
+    color: #555;
+    background-color: var(--sbb-hover-tint);
+}
+
+.standard-admin-page .weight-item .lock-marker {
+    color: #8a8a8a;
+    cursor: help;
+}
+
+.standard-admin-page .weight-item .drag-handle svg,
+.standard-admin-page .weight-item .lock-marker svg {
+    display: block;
+}
+
+.standard-admin-page .weights-list .sbb-number {
+    flex: 0 0 auto;
+    width: 66px;
+}
+
+.standard-admin-page .weight-item.static .weight-input {
+    background-color: #f1f1f1;
+    color: #9a9a9a;
+    pointer-events: none;
+}
+
+/* Up / down reorder buttons — keyboard-accessible alternative to drag. */
+.standard-admin-page .reorder-arrows {
+    flex: 0 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.standard-admin-page .reorder-arrows.placeholder {
+    width: 22px;
+}
+
+.standard-admin-page .reorder-arrows button {
+    width: 22px;
+    height: 13px;
+    padding: 0;
+    margin: 0;
+    border: 1px solid var(--sbb-btn-border);
+    border-radius: 2px;
+    background-color: var(--sbb-btn-control-bg);
+    color: #595959;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 0;
+}
+
+.standard-admin-page .reorder-arrows button:hover:not(:disabled) {
+    background-color: var(--sbb-hover-tint);
+    border-color: var(--sbb-btn-hover-border);
+}
+
+.standard-admin-page .reorder-arrows button:disabled {
+    opacity: 0.35;
+    cursor: default;
+}
+
+.standard-admin-page .reorder-arrows svg {
+    display: block;
+    width: 9px;
+    height: 6px;
+}

--- a/app/src/main/resources/js/modules/StylePackageWeights.js
+++ b/app/src/main/resources/js/modules/StylePackageWeights.js
@@ -1,0 +1,333 @@
+import { enhanceNumericInput } from './NumericSpinner.js';
+
+/**
+ * Reusable "Style Package Weights" admin component, shared by the exporter extensions
+ * (pdf-exporter, docx-exporter, ...). It renders the weighted, reorderable list of style packages
+ * on the Polarion 2606 look (built on the --sbb-* control tokens; see css/style-package-weights.css)
+ * and talks to each extension's own `rest/internal/settings/style-package/weights` endpoint through
+ * the supplied ExtensionContext.
+ *
+ * Higher weight = higher position; the top item is the one pre-selected in the export panel dropdown.
+ * A global-scoped entry shown in a narrower scope is read-only here (it is managed at the global
+ * level) and only acts as a fixed reference point in the ordering.
+ *
+ *   import ExtensionContext from '../../ui/generic/js/modules/ExtensionContext.js';
+ *   import StylePackageWeights from '../../ui/generic/js/modules/StylePackageWeights.js';
+ *   const ctx = new ExtensionContext({ extension: 'pdf-exporter', scopeFieldId: 'scope' });
+ *   new StylePackageWeights({ ctx, listId: 'sortable-list' });
+ */
+export default class StylePackageWeights {
+
+    static ID_PREFIX = 'input.weight.';
+    static GLOBAL_LOCK_TITLE = 'Global scope — defined at the global level and cannot be reordered here';
+
+    static HANDLE_SVG = '<svg width="10" height="16" viewBox="0 0 10 16" fill="currentColor" aria-hidden="true">'
+        + '<circle cx="2" cy="3" r="1.4"/><circle cx="8" cy="3" r="1.4"/><circle cx="2" cy="8" r="1.4"/>'
+        + '<circle cx="8" cy="8" r="1.4"/><circle cx="2" cy="13" r="1.4"/><circle cx="8" cy="13" r="1.4"/></svg>';
+    static LOCK_SVG = '<svg width="13" height="14" viewBox="0 0 14 16" fill="none" stroke="currentColor" stroke-width="1.3" aria-hidden="true">'
+        + '<rect x="2.2" y="7" width="9.6" height="7" rx="1.2" fill="currentColor" stroke="none"/>'
+        + '<path d="M4.3 7V4.8a2.7 2.7 0 0 1 5.4 0V7"/></svg>';
+    static CARET_UP_SVG = '<svg viewBox="0 0 8 5" fill="currentColor" aria-hidden="true"><path d="M4 0l4 5H0z"/></svg>';
+    static CARET_DOWN_SVG = '<svg viewBox="0 0 8 5" fill="currentColor" aria-hidden="true"><path d="M0 0h8L4 5z"/></svg>';
+
+    /**
+     * @param {ExtensionContext} ctx     configured with the owning extension and scope field
+     * @param {string} listId            id of the <ul> that hosts the list
+     * @param {boolean} bindToolbar      wire the standard save/cancel toolbar buttons (default true)
+     * @param {boolean} autoLoad         load the weights immediately (default true)
+     */
+    constructor({ ctx, listId, bindToolbar = true, autoLoad = true }) {
+        this.ctx = ctx;
+        this.list = ctx.getElementById(listId);
+        this.items = [];
+        this.dragIndex = null;
+
+        // This page has no "default" values and no per-configuration revisions.
+        const defaultButton = ctx.getElementById("default-toolbar-button");
+        if (defaultButton) {
+            defaultButton.style.display = "none";
+        }
+        const revisionsButton = ctx.getElementById("revisions-toolbar-button");
+        if (revisionsButton) {
+            revisionsButton.style.display = "none";
+        }
+
+        if (bindToolbar) {
+            ctx.onClick(
+                'save-toolbar-button', () => this.save(),
+                'cancel-toolbar-button', () => this.load()
+            );
+        }
+        if (autoLoad) {
+            this.load();
+        }
+    }
+
+    load() {
+        this.ctx.callAsync({
+            method: 'GET',
+            url: `/polarion/${this.ctx.extension}/rest/internal/settings/style-package/weights?scope=${this.ctx.scope}`,
+            contentType: 'application/json',
+            onOk: (responseText) => this.setData(responseText),
+            onError: () => this.ctx.setLoadingErrorNotificationVisible(true)
+        });
+    }
+
+    save() {
+        const result = this.items
+            .filter(item => !item.static)
+            .map(item => ({ name: item.name, scope: this.ctx.scope, weight: item.weight }));
+
+        this.ctx.callAsync({
+            method: 'POST',
+            url: `/polarion/${this.ctx.extension}/rest/internal/settings/style-package/weights`,
+            contentType: 'application/json',
+            body: JSON.stringify(result),
+            onOk: () => this.ctx.showSaveSuccessAlert(),
+            onError: () => this.ctx.showSaveErrorAlert()
+        });
+    }
+
+    setData(jsonString) {
+        this.items = JSON.parse(jsonString).map(item => {
+            const isStatic = item.scope === "" && this.ctx.scope !== "";
+            return {
+                name: item.name,
+                scope: item.scope,
+                weight: item.weight,
+                originalWeight: item.weight, // server snapshot, kept to preserve weight when it still fits
+                static: isStatic
+            };
+        });
+        this.render();
+    }
+
+    sortItems() {
+        // Higher weight first; ties resolved alphabetically to keep a stable, predictable order.
+        this.items.sort((a, b) => (b.weight - a.weight) || a.name.localeCompare(b.name));
+    }
+
+    render() {
+        this.sortItems();
+        this.list.innerHTML = '';
+
+        this.items.forEach((item, index) => {
+            const li = document.createElement("li");
+            li.classList.add("weight-item");
+            if (item.static) {
+                li.classList.add("static");
+            }
+
+            // Left slot: lock (read-only global) or drag handle.
+            const marker = document.createElement("span");
+            if (item.static) {
+                marker.className = "lock-marker";
+                marker.title = StylePackageWeights.GLOBAL_LOCK_TITLE;
+                marker.innerHTML = StylePackageWeights.LOCK_SVG;
+            } else {
+                marker.className = "drag-handle";
+                marker.title = "Drag to reorder";
+                marker.innerHTML = StylePackageWeights.HANDLE_SVG;
+            }
+            li.appendChild(marker);
+
+            const name = document.createElement("span");
+            name.className = "name";
+            name.textContent = item.name;
+            li.appendChild(name);
+
+            // Weight input, wrapped by the shared 2606 caret spinner.
+            const input = document.createElement("input");
+            input.id = `${StylePackageWeights.ID_PREFIX}${item.name}`;
+            input.type = "number";
+            input.className = "weight-input";
+            input.min = "0";
+            input.max = "100";
+            input.step = "0.1";
+            input.value = item.weight;
+            if (item.static) {
+                input.readOnly = true;
+            } else {
+                input.addEventListener("change", () => this.commitWeight(item, input));
+                input.addEventListener("keydown", (event) => {
+                    if (event.key === "Enter") {
+                        this.commitWeight(item, input);
+                    }
+                });
+            }
+            li.appendChild(input);
+            enhanceNumericInput(input);
+
+            li.appendChild(this.buildArrows(item, index));
+
+            this.wireDrag(li, index, item);
+            this.list.appendChild(li);
+        });
+    }
+
+    buildArrows(item, index) {
+        if (item.static) {
+            const placeholder = document.createElement("span");
+            placeholder.className = "reorder-arrows placeholder";
+            return placeholder;
+        }
+        const box = document.createElement("span");
+        box.className = "reorder-arrows";
+
+        const up = document.createElement("button");
+        up.type = "button";
+        up.title = "Move up";
+        up.innerHTML = StylePackageWeights.CARET_UP_SVG;
+        up.disabled = index === 0;
+        up.addEventListener("click", () => {
+            if (this.placeAt(index, index - 1)) {
+                this.render();
+            }
+        });
+
+        const down = document.createElement("button");
+        down.type = "button";
+        down.title = "Move down";
+        down.innerHTML = StylePackageWeights.CARET_DOWN_SVG;
+        down.disabled = index === this.items.length - 1;
+        down.addEventListener("click", () => {
+            if (this.placeAt(index, index + 2)) {
+                this.render();
+            }
+        });
+
+        box.appendChild(up);
+        box.appendChild(down);
+        return box;
+    }
+
+    // Any row is a valid drop target (including a static global): the drop position is decided by the
+    // top / bottom half of the hovered row, so a package can be placed directly above or below the
+    // read-only global entry. Only non-static rows are draggable.
+    wireDrag(li, index, item) {
+        if (!item.static) {
+            li.setAttribute("draggable", "true");
+            li.addEventListener("dragstart", (event) => {
+                this.dragIndex = index;
+                li.classList.add("dragging");
+                event.dataTransfer.effectAllowed = "move";
+                try {
+                    event.dataTransfer.setData("text/plain", String(index));
+                } catch (ignored) { /* some browsers require a payload */ }
+            });
+            li.addEventListener("dragend", () => {
+                li.classList.remove("dragging");
+                this.clearDropIndicators();
+                this.dragIndex = null;
+            });
+        }
+        li.addEventListener("dragover", (event) => {
+            if (this.dragIndex === null) {
+                return;
+            }
+            event.preventDefault();
+            event.dataTransfer.dropEffect = "move";
+            this.clearDropIndicators();
+            li.classList.add(this.isBottomHalf(event, li) ? "drop-below" : "drop-above");
+        });
+        li.addEventListener("dragleave", () => {
+            li.classList.remove("drop-above", "drop-below");
+        });
+        li.addEventListener("drop", (event) => {
+            if (this.dragIndex === null) {
+                return;
+            }
+            event.preventDefault();
+            const insertIndex = this.isBottomHalf(event, li) ? index + 1 : index;
+            const changed = this.placeAt(this.dragIndex, insertIndex);
+            this.dragIndex = null;
+            this.clearDropIndicators();
+            if (changed) {
+                this.render();
+            }
+        });
+    }
+
+    isBottomHalf(event, element) {
+        const rect = element.getBoundingClientRect();
+        return (event.clientY - rect.top) > rect.height / 2;
+    }
+
+    clearDropIndicators() {
+        this.list.querySelectorAll(".drop-above, .drop-below")
+            .forEach(node => node.classList.remove("drop-above", "drop-below"));
+    }
+
+    // Move the item at fromIndex into the slot at insertIndex (0..length), recomputing its weight to
+    // fit between its new neighbours. Works across a static global (which never moves). Returns true
+    // when something actually changed.
+    placeAt(fromIndex, insertIndex) {
+        if (insertIndex === fromIndex || insertIndex === fromIndex + 1) {
+            return false; // dropped back into its own slot
+        }
+        const moved = this.items[fromIndex];
+        if (!moved || moved.static) {
+            return false;
+        }
+        this.items.splice(fromIndex, 1);
+        if (insertIndex > fromIndex) {
+            insertIndex--;
+        }
+        insertIndex = Math.max(0, Math.min(this.items.length, insertIndex));
+        this.items.splice(insertIndex, 0, moved);
+        moved.weight = this.computeWeightForPosition(insertIndex);
+        this.sortItems();
+        return true;
+    }
+
+    // Weight that keeps the moved item at insertIndex: reuse its original weight when it still fits the
+    // gap between the neighbours, otherwise place it in the middle of the gap (or just past the edge).
+    computeWeightForPosition(insertIndex) {
+        const items = this.items;
+        if (items.length <= 1) {
+            return items[insertIndex].weight;
+        }
+        const initial = items[insertIndex].originalWeight;
+        let value;
+        if (insertIndex === 0) {
+            const next = items[1].weight;
+            value = initial > next ? initial : next + 1;
+        } else if (insertIndex === items.length - 1) {
+            const prev = items[items.length - 2].weight;
+            value = initial < prev ? initial : prev - 1;
+        } else {
+            const prev = items[insertIndex - 1].weight;
+            const next = items[insertIndex + 1].weight;
+            value = (initial > next && initial < prev)
+                ? initial
+                : parseFloat((prev + (next - prev) / 2).toFixed(1));
+        }
+        return Math.max(0, Math.min(100, value));
+    }
+
+    commitWeight(item, input) {
+        StylePackageWeights.adjustWeight(input);
+        item.weight = parseFloat(input.value);
+        this.render();
+    }
+
+    /**
+     * Normalise a manually typed weight: clamp to [0, 100], round to one decimal, fall back to 50 for
+     * anything that does not match the NNN.N shape. Mutates and returns input.value.
+     */
+    static adjustWeight(input) {
+        let value = parseFloat(input.value);
+
+        if (value > 100) {
+            value = 100;
+        }
+        if (value % 1 !== 0) {
+            value = parseFloat(value.toFixed(1));
+        }
+        if (!/^\d{1,3}(\.\d)?$/.test(value)) {
+            value = 50;
+        }
+
+        input.value = value;
+    }
+}

--- a/app/src/main/resources/js/modules/StylePackageWeights.js
+++ b/app/src/main/resources/js/modules/StylePackageWeights.js
@@ -276,8 +276,7 @@ export default class StylePackageWeights {
         insertIndex = Math.max(0, Math.min(this.items.length, insertIndex));
         this.items.splice(insertIndex, 0, moved);
         moved.weight = this.computeWeightForPosition(insertIndex);
-        this.sortItems();
-        return true;
+        return true; // every caller re-renders, and render() re-sorts
     }
 
     // Weight that keeps the moved item at insertIndex: reuse its original weight when it still fits the
@@ -308,6 +307,9 @@ export default class StylePackageWeights {
     commitWeight(item, input) {
         StylePackageWeights.adjustWeight(input);
         item.weight = parseFloat(input.value);
+        // A manually typed weight becomes the new preferred value, so a later reorder keeps it (via
+        // computeWeightForPosition) instead of reverting to the server snapshot.
+        item.originalWeight = item.weight;
         this.render();
     }
 
@@ -320,6 +322,9 @@ export default class StylePackageWeights {
 
         if (value > 100) {
             value = 100;
+        }
+        if (value < 0) {
+            value = 0;
         }
         if (value % 1 !== 0) {
             value = parseFloat(value.toFixed(1));

--- a/app/src/test/js/modules/StylePackageWeightsTest.js
+++ b/app/src/test/js/modules/StylePackageWeightsTest.js
@@ -1,0 +1,243 @@
+import StylePackageWeights from '../../../main/resources/js/modules/StylePackageWeights.js';
+import { expect } from 'chai';
+import { JSDOM } from 'jsdom';
+
+describe('StylePackageWeights', function () {
+    let dom, document, ctx;
+
+    beforeEach(function () {
+        dom = new JSDOM('<!DOCTYPE html><html lang="en"><body><ul id="weights-list"></ul></body></html>');
+        global.window = dom.window;
+        global.document = dom.window.document;
+        global.Event = dom.window.Event;
+        document = dom.window.document;
+        ctx = {
+            extension: 'test-exporter',
+            scope: '',
+            getElementById: (id) => document.getElementById(id)
+        };
+    });
+
+    afterEach(function () {
+        delete global.window;
+        delete global.document;
+        delete global.Event;
+    });
+
+    function component(items = []) {
+        const instance = new StylePackageWeights({ ctx, listId: 'weights-list', bindToolbar: false, autoLoad: false });
+        instance.items = items.map(i => ({
+            name: i.name,
+            scope: i.scope ?? '',
+            weight: i.weight,
+            originalWeight: i.originalWeight ?? i.weight,
+            static: !!i.static
+        }));
+        return instance;
+    }
+
+    function names(instance) {
+        return instance.items.map(i => i.name);
+    }
+    function weightOf(instance, name) {
+        return instance.items.find(i => i.name === name).weight;
+    }
+
+    describe('adjustWeight', function () {
+        it('clamps values above 100 down to 100', function () {
+            const input = { value: '150' };
+            StylePackageWeights.adjustWeight(input);
+            expect(input.value).to.equal(100);
+        });
+
+        it('clamps negative values up to 0 (not the 50 fallback)', function () {
+            const input = { value: '-5' };
+            StylePackageWeights.adjustWeight(input);
+            expect(input.value).to.equal(0);
+        });
+
+        it('rounds to one decimal', function () {
+            const input = { value: '42.37' };
+            StylePackageWeights.adjustWeight(input);
+            expect(input.value).to.equal(42.4);
+        });
+
+        it('falls back to 50 for non-numeric input', function () {
+            const input = { value: 'abc' };
+            StylePackageWeights.adjustWeight(input);
+            expect(input.value).to.equal(50);
+        });
+
+        it('leaves a valid value untouched', function () {
+            const input = { value: '55' };
+            StylePackageWeights.adjustWeight(input);
+            expect(input.value).to.equal(55);
+        });
+    });
+
+    describe('placeAt / computeWeightForPosition', function () {
+        // Sorted list: A 90, B 75, C 60, G 42 (static global), M 20.
+        function sortedList() {
+            return component([
+                { name: 'A', weight: 90 },
+                { name: 'B', weight: 75 },
+                { name: 'C', weight: 60 },
+                { name: 'G', weight: 42, scope: '', static: true },
+                { name: 'M', weight: 20 }
+            ]);
+        }
+
+        it('moves an item up across the static global, recomputing its weight above it', function () {
+            const c = sortedList();
+            expect(c.placeAt(4, 3)).to.equal(true); // M up one rank, past G
+            c.sortItems();
+            expect(names(c)).to.eql(['A', 'B', 'C', 'M', 'G']);
+            expect(weightOf(c, 'M')).to.equal(51); // midpoint of C(60) and G(42)
+            expect(weightOf(c, 'G')).to.equal(42); // static global never changes
+        });
+
+        it('keeps the item weight when it still fits the target gap', function () {
+            const c = component([
+                { name: 'A', weight: 90 },
+                { name: 'B', weight: 50, originalWeight: 50 },
+                { name: 'C', weight: 40 }
+            ]);
+            // Move A (idx 0) between B and C — gap (50, 40); A's original 90 does not fit → midpoint 45.
+            expect(c.placeAt(0, 2)).to.equal(true);
+            c.sortItems();
+            expect(weightOf(c, 'A')).to.equal(45);
+        });
+
+        it('returns false when dropped back into its own slot', function () {
+            const c = sortedList();
+            expect(c.placeAt(1, 1)).to.equal(false);
+            expect(c.placeAt(1, 2)).to.equal(false); // insertIndex === fromIndex + 1
+        });
+
+        it('refuses to move a static global row', function () {
+            const c = sortedList();
+            expect(c.placeAt(3, 0)).to.equal(false);
+            expect(names(c)).to.eql(['A', 'B', 'C', 'G', 'M']);
+        });
+
+        it('places at the very top with a weight above the current maximum', function () {
+            const c = sortedList();
+            expect(c.placeAt(2, 0)).to.equal(true); // C to the top
+            c.sortItems();
+            expect(names(c)[0]).to.equal('C');
+            expect(weightOf(c, 'C')).to.equal(91); // A(90) + 1
+        });
+
+        it('places at the very bottom with a weight below the current minimum', function () {
+            const c = sortedList();
+            expect(c.placeAt(1, 5)).to.equal(true); // B to the bottom
+            c.sortItems();
+            expect(names(c)[names(c).length - 1]).to.equal('B');
+            expect(weightOf(c, 'B')).to.equal(19); // M(20) - 1
+        });
+
+        it('keeps a single remaining item weight unchanged', function () {
+            const c = component([{ name: 'Solo', weight: 33 }]);
+            expect(c.computeWeightForPosition(0)).to.equal(33);
+        });
+    });
+
+    describe('setData / render', function () {
+        it('marks a global entry shown in a narrower scope as a read-only static row', function () {
+            ctx.scope = 'myproject';
+            const c = component();
+            c.setData(JSON.stringify([
+                { name: 'P', scope: 'myproject', weight: 70 },
+                { name: 'GLOB', scope: '', weight: 40 }
+            ]));
+            const rows = [...document.querySelectorAll('#weights-list .weight-item')];
+            expect(rows.length).to.equal(2);
+
+            const globRow = rows.find(r => r.querySelector('.name').textContent === 'GLOB');
+            expect(globRow.classList.contains('static')).to.equal(true);
+            expect(globRow.querySelector('.lock-marker')).to.not.equal(null);
+            expect(globRow.querySelector('.drag-handle')).to.equal(null);
+            expect(globRow.querySelector('input').readOnly).to.equal(true);
+            expect(globRow.getAttribute('draggable')).to.equal(null);
+
+            const projRow = rows.find(r => r.querySelector('.name').textContent === 'P');
+            expect(projRow.querySelector('.drag-handle')).to.not.equal(null);
+            expect(projRow.getAttribute('draggable')).to.equal('true');
+        });
+
+        it('does not mark global entries as static in the global scope', function () {
+            ctx.scope = '';
+            const c = component();
+            c.setData(JSON.stringify([{ name: 'G', scope: '', weight: 40 }]));
+            const row = document.querySelector('#weights-list .weight-item');
+            expect(row.classList.contains('static')).to.equal(false);
+            expect(row.querySelector('.drag-handle')).to.not.equal(null);
+        });
+
+        it('renders rows sorted by weight desc then name and disables the boundary arrows', function () {
+            const c = component();
+            c.setData(JSON.stringify([
+                { name: 'low', scope: '', weight: 10 },
+                { name: 'high', scope: '', weight: 90 },
+                { name: 'mid', scope: '', weight: 50 }
+            ]));
+            const rows = [...document.querySelectorAll('#weights-list .weight-item')];
+            expect(rows.map(r => r.querySelector('.name').textContent)).to.eql(['high', 'mid', 'low']);
+
+            const topArrows = rows[0].querySelectorAll('.reorder-arrows button');
+            expect(topArrows[0].disabled).to.equal(true);  // up disabled at the top
+            expect(topArrows[1].disabled).to.equal(false);
+
+            const bottomArrows = rows[2].querySelectorAll('.reorder-arrows button');
+            expect(bottomArrows[0].disabled).to.equal(false);
+            expect(bottomArrows[1].disabled).to.equal(true); // down disabled at the bottom
+        });
+    });
+
+    describe('load / save', function () {
+        it('GETs the weights for the current scope and renders them on success', function () {
+            ctx.scope = 'proj';
+            let request;
+            ctx.callAsync = (req) => { request = req; };
+            const c = component();
+
+            c.load();
+            expect(request.method).to.equal('GET');
+            expect(request.url).to.contain('/polarion/test-exporter/rest/internal/settings/style-package/weights');
+            expect(request.url).to.contain('scope=proj');
+
+            request.onOk(JSON.stringify([{ name: 'Z', scope: 'proj', weight: 33 }]));
+            expect(c.items.map(i => i.name)).to.eql(['Z']);
+            expect(document.querySelectorAll('#weights-list .weight-item').length).to.equal(1);
+        });
+
+        it('POSTs only the non-static rows with the current scope', function () {
+            ctx.scope = 'proj';
+            let request;
+            ctx.callAsync = (req) => { request = req; };
+            ctx.showSaveSuccessAlert = () => {};
+            const c = component([
+                { name: 'A', scope: 'proj', weight: 80 },
+                { name: 'G', scope: '', weight: 40, static: true }
+            ]);
+
+            c.save();
+            expect(request.method).to.equal('POST');
+            expect(JSON.parse(request.body)).to.eql([{ name: 'A', scope: 'proj', weight: 80 }]);
+
+            request.onOk(); // must not throw
+        });
+    });
+
+    describe('commitWeight', function () {
+        it('syncs originalWeight so a later reorder keeps the typed value', function () {
+            const c = component([{ name: 'X', weight: 80 }]);
+            const input = document.createElement('input');
+            input.type = 'number';
+            input.value = '75';
+            c.commitWeight(c.items[0], input);
+            expect(c.items[0].weight).to.equal(75);
+            expect(c.items[0].originalWeight).to.equal(75);
+        });
+    });
+});


### PR DESCRIPTION
### Proposed changes

Add a reusable "Style Package Weights" component so the exporter extensions (pdf-exporter, docx-exporter, ...) no longer each carry their own duplicated copy.

- js/modules/StylePackageWeights.js: a class instantiated per extension with its ExtensionContext. Renders the weighted, reorderable style package list on the Polarion 2606 look, with native drag-and-drop, keyboard up/down reorder buttons and the shared 2606 numeric spinner. Any row (incl. a read-only global) is a valid drop target so a package can be placed directly above or below the global entry; reordering crosses the static global, which stays put. Weight normalisation (former StylePackageUtils.adjustWeight) is folded in.
- css/style-package-weights.css: the list styling, built on the shared --sbb-* control tokens and linked directly by the page.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
