### PR TITLE
feat: add icons to chips of selected options in multiselection dropdown

### DIFF
--- a/app/src/main/resources/css/searchable-dropdown.css
+++ b/app/src/main/resources/css/searchable-dropdown.css
@@ -83,7 +83,7 @@
     width: 100%;
     min-height: var(--sbb-control-height);
     box-sizing: border-box;
-    padding: 1px 2rem 1px 3px;
+    padding: 4px 2rem 4px 4px;
     border: 1px solid var(--sbb-control-border);
     border-radius: var(--sbb-control-radius);
     background-color: var(--sbb-control-bg);
@@ -117,6 +117,15 @@
     font-size: 12px;
     font-weight: 600;
     line-height: 17px;
+}
+
+/* Per-option icon inside a multi-select chip. Smaller than the popup/trigger icon (16px) to
+   fit the compact chip line-height. */
+.searchable-dropdown .sd-chip-icon {
+    flex: none;
+    width: 12px;
+    height: 12px;
+    object-fit: contain;
 }
 
 .searchable-dropdown .sd-chip-label {
@@ -319,6 +328,7 @@
    radius that turn the icon's own background into a neat little tile — matching the entity/project
    icon tiles the React pickers use. */
 .searchable-dropdown .sd-trigger-icon.has-icon-bg,
+.searchable-dropdown .sd-chip-icon.has-icon-bg,
 .sd-portal .option .option-icon.has-icon-bg {
     padding: 2px;
     border-radius: 2px;

--- a/app/src/main/resources/js/modules/SearchableDropdown.js
+++ b/app/src/main/resources/js/modules/SearchableDropdown.js
@@ -957,6 +957,18 @@ export default class SearchableDropdown {
             const chip = document.createElement('span');
             chip.className = 'sd-chip';
 
+            // Mirror the option's icon (and optional coloured tile) onto the chip, rendered
+            // smaller than the popup/trigger icon (see .sd-chip-icon). Reuses _applyIconBg so the
+            // tile handling matches the options list and single-select trigger.
+            if (item.icon) {
+                const icon = document.createElement('img');
+                icon.className = 'sd-chip-icon';
+                icon.src = item.icon;
+                icon.alt = '';
+                this._applyIconBg(icon, item.iconBg);
+                chip.appendChild(icon);
+            }
+
             const label = document.createElement('span');
             label.className = 'sd-chip-label';
             label.textContent = item.label;

--- a/app/src/test/js/modules/SearchableDropdownTest.js
+++ b/app/src/test/js/modules/SearchableDropdownTest.js
@@ -891,6 +891,49 @@ describe('SearchableDropdown', function () {
             expect(dropdown.getSelectedText()).to.deep.equal(['A', 'C']);
             dropdown.destroy();
         });
+
+        it('renders the option icon inside a selected chip', function () {
+            const dropdown = new SearchableDropdown({
+                selectContainer: document.getElementById('build-container'),
+                multiselect: true,
+                rememberSelection: false
+            });
+            dropdown.addOption('a', 'A', '/i/a.svg');
+            dropdown.selectValue('a');
+            const icon = dropdown.trigger.querySelector('.sd-chip img.sd-chip-icon');
+            expect(icon).to.exist;
+            expect(icon.getAttribute('src')).to.equal('/i/a.svg');
+            dropdown.destroy();
+        });
+
+        it('applies the icon-bg tile on a chip icon', function () {
+            const dropdown = new SearchableDropdown({
+                selectContainer: document.getElementById('build-container'),
+                multiselect: true,
+                rememberSelection: false
+            });
+            dropdown.addOption('a', 'A', '/i/a.svg', '#1a3a5c');
+            dropdown.selectValue('a');
+            const icon = dropdown.trigger.querySelector('.sd-chip img.sd-chip-icon');
+            expect(icon.classList.contains('has-icon-bg')).to.be.true;
+            expect(icon.style.backgroundColor).to.not.equal('');
+            dropdown.destroy();
+        });
+
+        it('renders no chip icon when the option has no icon', function () {
+            const dropdown = new SearchableDropdown({
+                selectContainer: document.getElementById('build-container'),
+                multiselect: true,
+                rememberSelection: false
+            });
+            dropdown.addOption('a', 'A');
+            dropdown.selectValue('a');
+            const chip = dropdown.trigger.querySelector('.sd-chip');
+            expect(chip).to.exist;
+            expect(chip.querySelector('img.sd-chip-icon')).to.be.null;
+            expect(chip.querySelector('.sd-chip-label').textContent).to.equal('A');
+            dropdown.destroy();
+        });
     });
 
     describe('clearable button mousedown', function () {


### PR DESCRIPTION
### Proposed changes

Add icons to chips of selected options in multiselection dropdown.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
