### PR TITLE
fix: defer form extension registration until Guice platform is ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,10 +229,12 @@ Bundle-Activator: ch.sbb.polarion.extension.pdf_exporter.ExtensionBundleActivato
   > `GuicePlatform.tryInjectMembers` injects nothing, the singleton is created **empty of all core
   > contributions**, and every Polarion-provided form extension is lost for the whole server
   > lifetime (typical symptom: *"Form extension 'velocity_form' was not found"* on a document/work
-  > item form). To avoid poisoning the registry, `GenericBundleActivator` registers its extensions on
-  > a daemon thread that first waits for the global Guice injector to become available; Polarion then
-  > loads its core extensions first and our extensions are added on top. This is transparent to
-  > subclasses — just implement `getExtensions()`.
+  > item form). To avoid poisoning the registry, `GenericBundleActivator` runs its startup on a daemon
+  > thread that first waits for the global Guice injector to become available; Polarion then loads its
+  > core extensions first and ours are added on top. The `onStart(BundleContext)` hook runs on that
+  > same deferred thread (after the injector is ready, not synchronously during activation), so a
+  > subclass hook may safely touch Polarion's platform. This is transparent to subclasses — just
+  > implement `getExtensions()` and, if needed, override `onStart()`.
 
 * `Export-Package` — if the extension exports packages for use by other bundles:
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,30 @@ Bundle-Name: PDF Exporter Extension for Polarion ALM
 Bundle-Activator: ch.sbb.polarion.extension.pdf_exporter.ExtensionBundleActivator
 ```
 
+  Subclass `GenericBundleActivator` and return your form extensions from `getExtensions()`:
+
+  ```java
+  public class ExtensionBundleActivator extends GenericBundleActivator {
+      @Override
+      protected Map<String, IFormExtension> getExtensions() {
+          return Map.of(MyFormExtension.ID, new MyFormExtension());
+      }
+  }
+  ```
+
+  > **Deferred registration (why it is not done inline in `start()`).**
+  > Polarion's `FormExtensionsRegistry` is a lazily-initialized singleton: on its first
+  > `getInstance()` it injects Polarion's own Guice-bound form extensions (`velocity_form`, `oslc`,
+  > `execute-test`, `linkedResources`, workflow-signatures widget, `gitlab`, …). If that first touch
+  > happens during OSGi bundle activation — before Polarion has built its global Guice injector —
+  > `GuicePlatform.tryInjectMembers` injects nothing, the singleton is created **empty of all core
+  > contributions**, and every Polarion-provided form extension is lost for the whole server
+  > lifetime (typical symptom: *"Form extension 'velocity_form' was not found"* on a document/work
+  > item form). To avoid poisoning the registry, `GenericBundleActivator` registers its extensions on
+  > a daemon thread that first waits for the global Guice injector to become available; Polarion then
+  > loads its core extensions first and our extensions are added on top. This is transparent to
+  > subclasses — just implement `getExtensions()`.
+
 * `Export-Package` — if the extension exports packages for use by other bundles:
 
 ```properties

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/GenericBundleActivator.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/GenericBundleActivator.java
@@ -1,16 +1,17 @@
 package ch.sbb.polarion.extension.generic;
 
+import com.polarion.alm.ui.server.forms.extensions.FormExtensionContribution;
 import com.polarion.alm.ui.server.forms.extensions.IFormExtension;
 import com.polarion.alm.ui.server.forms.extensions.impl.FormExtensionsRegistry;
 import com.polarion.core.util.logging.Logger;
-import com.polarion.platform.guice.internal.GuicePlatform;
+import com.polarion.platform.guice.ipi.GuicePlatform;
+import jakarta.inject.Inject;
 import org.jetbrains.annotations.NotNull;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -28,9 +29,6 @@ public abstract class GenericBundleActivator implements BundleActivator {
     private static final long PLATFORM_WAIT_TIMEOUT_MS = TimeUnit.MINUTES.toMillis(5);
     /** How often to poll for the global Guice injector while waiting. */
     private static final long PLATFORM_POLL_INTERVAL_MS = 200;
-
-    /** {@code GuicePlatform.getGlobalInjector()}, resolved reflectively; {@code null} if unavailable. */
-    private static final Method GET_GLOBAL_INJECTOR = resolveGetGlobalInjector();
 
     protected abstract Map<String, IFormExtension> getExtensions();
 
@@ -85,7 +83,7 @@ public abstract class GenericBundleActivator implements BundleActivator {
     void registerExtensionsWhenReady(@NotNull Map<String, IFormExtension> extensions) {
         if (!awaitGuicePlatform()) {
             logger.warn("Polarion's Guice platform did not become ready within "
-                    + PLATFORM_WAIT_TIMEOUT_MS + " ms; registering form extensions anyway. "
+                    + getPlatformWaitTimeoutMs() + " ms; registering form extensions anyway. "
                     + "Polarion's own form extensions may be unavailable.");
         }
         // Serialize registration across bundles: several activators may cross the readiness barrier
@@ -104,13 +102,13 @@ public abstract class GenericBundleActivator implements BundleActivator {
      * @return {@code true} if the injector became available, {@code false} on timeout
      */
     private boolean awaitGuicePlatform() {
-        long deadline = System.currentTimeMillis() + PLATFORM_WAIT_TIMEOUT_MS;
+        long deadline = System.currentTimeMillis() + getPlatformWaitTimeoutMs();
         while (!isGuicePlatformReady()) {
             if (System.currentTimeMillis() >= deadline) {
                 return false;
             }
             try {
-                Thread.sleep(PLATFORM_POLL_INTERVAL_MS);
+                Thread.sleep(getPlatformPollIntervalMs());
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 return isGuicePlatformReady();
@@ -120,39 +118,31 @@ public abstract class GenericBundleActivator implements BundleActivator {
     }
 
     /**
-     * Probes {@code GuicePlatform.getGlobalInjector()} reflectively — it throws while the platform
-     * is not yet initialized, which is what we treat as "not ready". Reflection is used only to
-     * avoid a compile-time dependency on Guice ({@code com.google.inject.Injector}, the method's
-     * return type), which this framework does not otherwise need. Overridable so tests can drive
-     * readiness without touching the Guice platform.
+     * Probes the global Guice injector the same way {@link FormExtensionsRegistry} does: while the
+     * platform is not yet initialized {@code GuicePlatform.tryInjectMembers} is a no-op, so the
+     * probe's {@code @Inject} field stays {@code null}; once the injector exists the (always-bound)
+     * {@code Set<FormExtensionContribution>} gets injected. Using {@code tryInjectMembers} keeps
+     * this free of any compile-time dependency on Guice. Overridable so tests can drive readiness.
      *
-     * @return {@code true} once the global injector resolves without throwing
+     * @return {@code true} once the global injector injects the probe
      */
     protected boolean isGuicePlatformReady() {
-        if (GET_GLOBAL_INJECTOR == null) {
-            return true; // cannot probe -> fail open, don't block registration forever
-        }
-        try {
-            GET_GLOBAL_INJECTOR.invoke(null);
-            return true;
-        } catch (InvocationTargetException notReadyYet) {
-            return false; // getGlobalInjector() threw -> global injector not built yet
-        } catch (IllegalAccessException e) {
-            logger.error("Unable to probe Guice platform readiness", e);
-            return true; // fail open
-        }
+        ReadinessProbe probe = new ReadinessProbe();
+        GuicePlatform.tryInjectMembers(probe);
+        return probe.contributions != null;
     }
 
-    @SuppressWarnings({"java:S1181", "java:S2139"}) // catch Throwable: a static-init probe must never fail <clinit>
-    private static Method resolveGetGlobalInjector() {
-        try {
-            return GuicePlatform.class.getMethod("getGlobalInjector");
-        } catch (Throwable e) {
-            // NoSuchMethodException, or — e.g. in a unit-test JVM without Guice on the classpath — a
-            // LinkageError while resolving the method's return type (com.google.inject.Injector).
-            // Either way the probe is unavailable and isGuicePlatformReady() fails open.
-            logger.error("Cannot resolve GuicePlatform.getGlobalInjector(); platform-readiness probing disabled", e);
-            return null;
-        }
+    protected long getPlatformWaitTimeoutMs() {
+        return PLATFORM_WAIT_TIMEOUT_MS;
+    }
+
+    protected long getPlatformPollIntervalMs() {
+        return PLATFORM_POLL_INTERVAL_MS;
+    }
+
+    /** Member-injection target used only to detect that the global Guice injector is available. */
+    static final class ReadinessProbe {
+        @Inject
+        Set<FormExtensionContribution> contributions;
     }
 }

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/GenericBundleActivator.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/GenericBundleActivator.java
@@ -13,6 +13,7 @@ import org.osgi.framework.BundleContext;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Simplifies the way of registering form extension(s).
@@ -31,7 +32,7 @@ public abstract class GenericBundleActivator implements BundleActivator {
     private static final long PLATFORM_POLL_INTERVAL_MS = 200;
 
     /** The deferred-registration thread, so {@link #stop(BundleContext)} can cancel a pending wait. */
-    private volatile Thread registrar;
+    private final AtomicReference<Thread> registrar = new AtomicReference<>();
 
     protected abstract Map<String, IFormExtension> getExtensions();
 
@@ -56,7 +57,7 @@ public abstract class GenericBundleActivator implements BundleActivator {
     public void stop(BundleContext context) {
         // Cancel a still-pending deferred registration so a stopped/hot-reloaded bundle does not
         // register stale extensions once (or if) the Guice platform becomes ready.
-        Thread current = registrar;
+        Thread current = registrar.get();
         if (current != null) {
             current.interrupt();
         }
@@ -69,7 +70,7 @@ public abstract class GenericBundleActivator implements BundleActivator {
     protected void runAsync(@NotNull Runnable task) {
         Thread thread = new Thread(task, "generic-form-extension-registrar");
         thread.setDaemon(true);
-        registrar = thread;
+        registrar.set(thread);
         thread.start();
     }
 

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/GenericBundleActivator.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/GenericBundleActivator.java
@@ -18,8 +18,9 @@ import java.util.concurrent.atomic.AtomicReference;
 /**
  * Simplifies the way of registering form extension(s).
  * <p>
- * Registration is performed on a background thread and only once Polarion's global Guice injector
- * is available — see {@link #registerExtensionsWhenReady(Map)} for why this deferral is required.
+ * Both the {@link #onStart(BundleContext)} hook and form-extension registration run on a background
+ * thread, and only once Polarion's global Guice injector is available — see
+ * {@link #startWhenReady(BundleContext)} for why this deferral is required.
  */
 @SuppressWarnings("unused")
 public abstract class GenericBundleActivator implements BundleActivator {
@@ -42,21 +43,17 @@ public abstract class GenericBundleActivator implements BundleActivator {
 
     @Override
     public void start(BundleContext context) {
-        onStart(context);
-        Map<String, IFormExtension> extensions = getExtensions();
-        if (extensions.isEmpty()) {
-            return;
-        }
-        // Do not touch FormExtensionsRegistry on the OSGi activation thread — defer it, see
-        // registerExtensionsWhenReady(). start() must stay non-blocking: the global injector may
-        // still be built later on this very thread, so blocking here could deadlock startup.
-        runAsync(() -> registerExtensionsWhenReady(extensions));
+        // Defer the whole startup — the onStart() hook and form-extension registration — onto a
+        // background thread that first waits for Polarion's global Guice injector, see
+        // startWhenReady(). start() must stay non-blocking: the global injector may still be built
+        // later on this very thread, so blocking here could deadlock startup.
+        runAsync(() -> startWhenReady(context));
     }
 
     @Override
     public void stop(BundleContext context) {
-        // Cancel a still-pending deferred registration so a stopped/hot-reloaded bundle does not
-        // register stale extensions once (or if) the Guice platform becomes ready.
+        // Cancel a still-pending deferred startup so a stopped/hot-reloaded bundle does not run
+        // onStart() or register stale extensions once (or if) the Guice platform becomes ready.
         Thread current = registrar.get();
         if (current != null) {
             current.interrupt();
@@ -64,8 +61,8 @@ public abstract class GenericBundleActivator implements BundleActivator {
     }
 
     /**
-     * Runs the deferred registration task. Spawns a daemon thread by default; overridable so tests
-     * can execute it synchronously.
+     * Runs the deferred startup task. Spawns a daemon thread by default; overridable so tests can
+     * execute it synchronously.
      */
     protected void runAsync(@NotNull Runnable task) {
         Thread thread = new Thread(task, "generic-form-extension-registrar");
@@ -75,8 +72,8 @@ public abstract class GenericBundleActivator implements BundleActivator {
     }
 
     /**
-     * Registers this bundle's form extensions, but only after Polarion's global Guice injector has
-     * been built.
+     * Deferred startup: waits for Polarion's global Guice injector, then runs the subclass
+     * {@link #onStart(BundleContext)} hook and registers this bundle's form extensions.
      * <p>
      * {@link FormExtensionsRegistry} is a lazily-initialized singleton. Its constructor injects
      * Polarion's own (Guice-bound) form extensions — {@code velocity_form}, {@code oslc},
@@ -88,24 +85,35 @@ public abstract class GenericBundleActivator implements BundleActivator {
      * server lifetime (the visible symptom is e.g. "Form extension 'velocity_form' was not found").
      * <p>
      * Waiting for the injector guarantees that the registry first loads Polarion's core extensions;
-     * only then do we add ours on top via {@link FormExtensionsRegistry#registerExtension}. A wait
-     * interrupted via {@link #stop(BundleContext)} aborts registration entirely.
+     * only then do we run {@link #onStart(BundleContext)} and add ours on top. onStart() is deferred
+     * past the barrier too, so that a subclass hook touching {@code FormExtensionsRegistry.getInstance()}
+     * cannot poison the registry either. A wait interrupted via {@link #stop(BundleContext)} aborts
+     * startup entirely.
      */
-    void registerExtensionsWhenReady(@NotNull Map<String, IFormExtension> extensions) {
+    void startWhenReady(@NotNull BundleContext context) {
         try {
             if (!awaitGuicePlatform()) {
                 logger.warn("Polarion's Guice platform did not become ready within "
-                        + getPlatformWaitTimeoutMs() + " ms; registering form extensions anyway. "
+                        + getPlatformWaitTimeoutMs() + " ms; starting anyway. "
                         + "Polarion's own form extensions may be unavailable.");
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            logger.info("Form extension registration cancelled before the Guice platform was ready (bundle stopping)");
+            logger.info("Bundle startup cancelled before the Guice platform was ready (bundle stopping)");
             return;
         }
+        onStart(context);
+        registerExtensions(getExtensions());
+    }
+
+    private void registerExtensions(@NotNull Map<String, IFormExtension> extensions) {
         // Serialize registration across bundles: several activators may cross the readiness barrier
-        // at once, and FormExtensionsRegistry's backing map is not synchronized.
-        synchronized (GenericBundleActivator.class) {
+        // at once, and FormExtensionsRegistry's backing map is not synchronized. Lock on a monitor
+        // shared by every bundle: FormExtensionsRegistry comes from Polarion's shared bundle, so its
+        // Class is the same object in every extension, whereas each bundle loads its own
+        // GenericBundleActivator Class (bundle-private classloaders) — locking on the latter would
+        // NOT serialize across bundles. Referencing the Class does not construct the singleton.
+        synchronized (FormExtensionsRegistry.class) {
             extensions.forEach((key, value) -> {
                 logger.info("Registering form extension: " + key);
                 FormExtensionsRegistry.getInstance().registerExtension(key, value);

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/GenericBundleActivator.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/GenericBundleActivator.java
@@ -121,13 +121,20 @@ public abstract class GenericBundleActivator implements BundleActivator {
      */
     private boolean awaitGuicePlatform() throws InterruptedException {
         long deadline = System.currentTimeMillis() + getPlatformWaitTimeoutMs();
-        while (!isGuicePlatformReady()) {
+        while (true) {
+            // Honour cancellation up front: if the injector is already ready the loop would
+            // otherwise never sleep, so an interrupt set by stop() would go unobserved.
+            if (Thread.interrupted()) {
+                throw new InterruptedException();
+            }
+            if (isGuicePlatformReady()) {
+                return true;
+            }
             if (System.currentTimeMillis() >= deadline) {
                 return false;
             }
             Thread.sleep(getPlatformPollIntervalMs());
         }
-        return true;
     }
 
     /**

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/GenericBundleActivator.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/GenericBundleActivator.java
@@ -30,6 +30,9 @@ public abstract class GenericBundleActivator implements BundleActivator {
     /** How often to poll for the global Guice injector while waiting. */
     private static final long PLATFORM_POLL_INTERVAL_MS = 200;
 
+    /** The deferred-registration thread, so {@link #stop(BundleContext)} can cancel a pending wait. */
+    private volatile Thread registrar;
+
     protected abstract Map<String, IFormExtension> getExtensions();
 
     protected void onStart(BundleContext context) {
@@ -51,7 +54,12 @@ public abstract class GenericBundleActivator implements BundleActivator {
 
     @Override
     public void stop(BundleContext context) {
-        // nothing by default
+        // Cancel a still-pending deferred registration so a stopped/hot-reloaded bundle does not
+        // register stale extensions once (or if) the Guice platform becomes ready.
+        Thread current = registrar;
+        if (current != null) {
+            current.interrupt();
+        }
     }
 
     /**
@@ -59,9 +67,10 @@ public abstract class GenericBundleActivator implements BundleActivator {
      * can execute it synchronously.
      */
     protected void runAsync(@NotNull Runnable task) {
-        Thread registrar = new Thread(task, "generic-form-extension-registrar");
-        registrar.setDaemon(true);
-        registrar.start();
+        Thread thread = new Thread(task, "generic-form-extension-registrar");
+        thread.setDaemon(true);
+        registrar = thread;
+        thread.start();
     }
 
     /**
@@ -78,13 +87,20 @@ public abstract class GenericBundleActivator implements BundleActivator {
      * server lifetime (the visible symptom is e.g. "Form extension 'velocity_form' was not found").
      * <p>
      * Waiting for the injector guarantees that the registry first loads Polarion's core extensions;
-     * only then do we add ours on top via {@link FormExtensionsRegistry#registerExtension}.
+     * only then do we add ours on top via {@link FormExtensionsRegistry#registerExtension}. A wait
+     * interrupted via {@link #stop(BundleContext)} aborts registration entirely.
      */
     void registerExtensionsWhenReady(@NotNull Map<String, IFormExtension> extensions) {
-        if (!awaitGuicePlatform()) {
-            logger.warn("Polarion's Guice platform did not become ready within "
-                    + getPlatformWaitTimeoutMs() + " ms; registering form extensions anyway. "
-                    + "Polarion's own form extensions may be unavailable.");
+        try {
+            if (!awaitGuicePlatform()) {
+                logger.warn("Polarion's Guice platform did not become ready within "
+                        + getPlatformWaitTimeoutMs() + " ms; registering form extensions anyway. "
+                        + "Polarion's own form extensions may be unavailable.");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.info("Form extension registration cancelled before the Guice platform was ready (bundle stopping)");
+            return;
         }
         // Serialize registration across bundles: several activators may cross the readiness barrier
         // at once, and FormExtensionsRegistry's backing map is not synchronized.
@@ -100,19 +116,15 @@ public abstract class GenericBundleActivator implements BundleActivator {
      * Blocks until Polarion's global Guice injector is available or the timeout elapses.
      *
      * @return {@code true} if the injector became available, {@code false} on timeout
+     * @throws InterruptedException if the wait is interrupted (e.g. by {@link #stop(BundleContext)})
      */
-    private boolean awaitGuicePlatform() {
+    private boolean awaitGuicePlatform() throws InterruptedException {
         long deadline = System.currentTimeMillis() + getPlatformWaitTimeoutMs();
         while (!isGuicePlatformReady()) {
             if (System.currentTimeMillis() >= deadline) {
                 return false;
             }
-            try {
-                Thread.sleep(getPlatformPollIntervalMs());
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                return isGuicePlatformReady();
-            }
+            Thread.sleep(getPlatformPollIntervalMs());
         }
         return true;
     }
@@ -142,6 +154,9 @@ public abstract class GenericBundleActivator implements BundleActivator {
 
     /** Member-injection target used only to detect that the global Guice injector is available. */
     static final class ReadinessProbe {
+        // Field (not constructor) injection is required: Guice populates this via tryInjectMembers()
+        // on an already-constructed probe, exactly as Polarion's own FormExtensionsRegistry does.
+        @SuppressWarnings("java:S6813")
         @Inject
         Set<FormExtensionContribution> contributions;
     }

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/GenericBundleActivator.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/GenericBundleActivator.java
@@ -3,18 +3,34 @@ package ch.sbb.polarion.extension.generic;
 import com.polarion.alm.ui.server.forms.extensions.IFormExtension;
 import com.polarion.alm.ui.server.forms.extensions.impl.FormExtensionsRegistry;
 import com.polarion.core.util.logging.Logger;
+import com.polarion.platform.guice.internal.GuicePlatform;
+import org.jetbrains.annotations.NotNull;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Simplifies the way of registering form extension(s).
+ * <p>
+ * Registration is performed on a background thread and only once Polarion's global Guice injector
+ * is available — see {@link #registerExtensionsWhenReady(Map)} for why this deferral is required.
  */
 @SuppressWarnings("unused")
 public abstract class GenericBundleActivator implements BundleActivator {
 
     private static final Logger logger = Logger.getLogger(GenericBundleActivator.class);
+
+    /** How long to wait for Polarion's global Guice injector before registering anyway. */
+    private static final long PLATFORM_WAIT_TIMEOUT_MS = TimeUnit.MINUTES.toMillis(5);
+    /** How often to poll for the global Guice injector while waiting. */
+    private static final long PLATFORM_POLL_INTERVAL_MS = 200;
+
+    /** {@code GuicePlatform.getGlobalInjector()}, resolved reflectively; {@code null} if unavailable. */
+    private static final Method GET_GLOBAL_INJECTOR = resolveGetGlobalInjector();
 
     protected abstract Map<String, IFormExtension> getExtensions();
 
@@ -25,14 +41,118 @@ public abstract class GenericBundleActivator implements BundleActivator {
     @Override
     public void start(BundleContext context) {
         onStart(context);
-        getExtensions().forEach((key, value) -> {
-            logger.info("Registering form extension: " + key);
-            FormExtensionsRegistry.getInstance().registerExtension(key, value);
-        });
+        Map<String, IFormExtension> extensions = getExtensions();
+        if (extensions.isEmpty()) {
+            return;
+        }
+        // Do not touch FormExtensionsRegistry on the OSGi activation thread — defer it, see
+        // registerExtensionsWhenReady(). start() must stay non-blocking: the global injector may
+        // still be built later on this very thread, so blocking here could deadlock startup.
+        runAsync(() -> registerExtensionsWhenReady(extensions));
     }
 
     @Override
     public void stop(BundleContext context) {
         // nothing by default
+    }
+
+    /**
+     * Runs the deferred registration task. Spawns a daemon thread by default; overridable so tests
+     * can execute it synchronously.
+     */
+    protected void runAsync(@NotNull Runnable task) {
+        Thread registrar = new Thread(task, "generic-form-extension-registrar");
+        registrar.setDaemon(true);
+        registrar.start();
+    }
+
+    /**
+     * Registers this bundle's form extensions, but only after Polarion's global Guice injector has
+     * been built.
+     * <p>
+     * {@link FormExtensionsRegistry} is a lazily-initialized singleton. Its constructor injects
+     * Polarion's own (Guice-bound) form extensions — {@code velocity_form}, {@code oslc},
+     * {@code execute-test}, {@code linkedResources}, workflow-signatures widget, {@code gitlab}, …
+     * via {@code GuicePlatform.tryInjectMembers}. If the very first {@code getInstance()} call
+     * happens during OSGi bundle activation, before {@link GuicePlatform} has built the global
+     * injector, {@code tryInjectMembers} silently injects nothing: the singleton is created with an
+     * empty contribution set and every Polarion-provided form extension is lost for the whole
+     * server lifetime (the visible symptom is e.g. "Form extension 'velocity_form' was not found").
+     * <p>
+     * Waiting for the injector guarantees that the registry first loads Polarion's core extensions;
+     * only then do we add ours on top via {@link FormExtensionsRegistry#registerExtension}.
+     */
+    void registerExtensionsWhenReady(@NotNull Map<String, IFormExtension> extensions) {
+        if (!awaitGuicePlatform()) {
+            logger.warn("Polarion's Guice platform did not become ready within "
+                    + PLATFORM_WAIT_TIMEOUT_MS + " ms; registering form extensions anyway. "
+                    + "Polarion's own form extensions may be unavailable.");
+        }
+        // Serialize registration across bundles: several activators may cross the readiness barrier
+        // at once, and FormExtensionsRegistry's backing map is not synchronized.
+        synchronized (GenericBundleActivator.class) {
+            extensions.forEach((key, value) -> {
+                logger.info("Registering form extension: " + key);
+                FormExtensionsRegistry.getInstance().registerExtension(key, value);
+            });
+        }
+    }
+
+    /**
+     * Blocks until Polarion's global Guice injector is available or the timeout elapses.
+     *
+     * @return {@code true} if the injector became available, {@code false} on timeout
+     */
+    private boolean awaitGuicePlatform() {
+        long deadline = System.currentTimeMillis() + PLATFORM_WAIT_TIMEOUT_MS;
+        while (!isGuicePlatformReady()) {
+            if (System.currentTimeMillis() >= deadline) {
+                return false;
+            }
+            try {
+                Thread.sleep(PLATFORM_POLL_INTERVAL_MS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return isGuicePlatformReady();
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Probes {@code GuicePlatform.getGlobalInjector()} reflectively — it throws while the platform
+     * is not yet initialized, which is what we treat as "not ready". Reflection is used only to
+     * avoid a compile-time dependency on Guice ({@code com.google.inject.Injector}, the method's
+     * return type), which this framework does not otherwise need. Overridable so tests can drive
+     * readiness without touching the Guice platform.
+     *
+     * @return {@code true} once the global injector resolves without throwing
+     */
+    protected boolean isGuicePlatformReady() {
+        if (GET_GLOBAL_INJECTOR == null) {
+            return true; // cannot probe -> fail open, don't block registration forever
+        }
+        try {
+            GET_GLOBAL_INJECTOR.invoke(null);
+            return true;
+        } catch (InvocationTargetException notReadyYet) {
+            return false; // getGlobalInjector() threw -> global injector not built yet
+        } catch (IllegalAccessException e) {
+            logger.error("Unable to probe Guice platform readiness", e);
+            return true; // fail open
+        }
+    }
+
+    @SuppressWarnings({"java:S1181", "java:S2139"}) // catch Throwable: a static-init probe must never fail <clinit>
+    private static Method resolveGetGlobalInjector() {
+        try {
+            return GuicePlatform.class.getMethod("getGlobalInjector");
+        } catch (Throwable e) {
+            // NoSuchMethodException, or — e.g. in a unit-test JVM without Guice on the classpath — a
+            // LinkageError while resolving the method's return type (com.google.inject.Injector).
+            // Either way the probe is unavailable and isGuicePlatformReady() fails open.
+            logger.error("Cannot resolve GuicePlatform.getGlobalInjector(); platform-readiness probing disabled", e);
+            return null;
+        }
     }
 }

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/GenericBundleActivatorTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/GenericBundleActivatorTest.java
@@ -10,8 +10,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.osgi.framework.BundleContext;
 
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -42,13 +46,24 @@ class GenericBundleActivatorTest {
     }
 
     @Test
+    void runAsyncExecutesTaskOnDaemonThread() throws InterruptedException {
+        CountDownLatch ran = new CountDownLatch(1);
+        new RealSeamsActivator().runAsync(ran::countDown); // real daemon-thread implementation
+        assertTrue(ran.await(5, TimeUnit.SECONDS), "runAsync should have executed the task");
+    }
+
+    @Test
+    void readinessProbeStartsUninjected() {
+        assertNull(new GenericBundleActivator.ReadinessProbe().contributions);
+    }
+
+    @Test
     void registrationWaitsUntilGuicePlatformReady() {
         try (MockedStatic<FormExtensionsRegistry> extensionsRegistryStatic = mockStatic(FormExtensionsRegistry.class)) {
             extensionsRegistryStatic.when(FormExtensionsRegistry::getInstance).thenReturn(registry);
 
-            // Reports "not ready" for the first two polls, then ready.
             TestBundleActivator activator = new TestBundleActivator(Map.of("only", mock(IFormExtension.class)));
-            activator.readyAfterPolls = 2;
+            activator.readyAfterPolls = 2; // not ready for the first two polls, then ready
 
             activator.registerExtensionsWhenReady(Map.of("only", mock(IFormExtension.class)));
 
@@ -57,11 +72,64 @@ class GenericBundleActivatorTest {
         }
     }
 
+    @Test
+    void restoresInterruptFlagAndRegistersWhenWaitInterrupted() throws InterruptedException {
+        try (MockedStatic<FormExtensionsRegistry> extensionsRegistryStatic = mockStatic(FormExtensionsRegistry.class)) {
+            extensionsRegistryStatic.when(FormExtensionsRegistry::getInstance).thenReturn(registry);
+
+            CountDownLatch polling = new CountDownLatch(1);
+            TestBundleActivator activator = new TestBundleActivator(Map.of()) {
+                @Override
+                protected boolean isGuicePlatformReady() {
+                    polling.countDown();
+                    return false;
+                }
+            };
+            activator.timeoutMs = TimeUnit.MINUTES.toMillis(5);
+            activator.pollMs = TimeUnit.MINUTES.toMillis(5); // long sleep so the wait is interrupted mid-flight
+
+            Thread target = Thread.currentThread();
+            Thread interrupter = new Thread(() -> {
+                try {
+                    polling.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                target.interrupt();
+            });
+            interrupter.setDaemon(true);
+            interrupter.start();
+
+            activator.registerExtensionsWhenReady(Map.of("only", mock(IFormExtension.class)));
+
+            assertTrue(Thread.interrupted(), "interrupt flag should have been restored"); // also clears it
+            verify(registry, times(1)).registerExtension(eq("only"), any());
+        }
+    }
+
+    @Test
+    void registersAnywayWhenPlatformNeverBecomesReady() {
+        try (MockedStatic<FormExtensionsRegistry> extensionsRegistryStatic = mockStatic(FormExtensionsRegistry.class)) {
+            extensionsRegistryStatic.when(FormExtensionsRegistry::getInstance).thenReturn(registry);
+
+            TestBundleActivator activator = new TestBundleActivator(Map.of("only", mock(IFormExtension.class)));
+            activator.readyAfterPolls = Integer.MAX_VALUE; // never ready
+            activator.timeoutMs = 20;
+            activator.pollMs = 5;
+
+            activator.registerExtensionsWhenReady(Map.of("only", mock(IFormExtension.class)));
+
+            verify(registry, times(1)).registerExtension(eq("only"), any()); // registered despite timeout
+        }
+    }
+
     private static class TestBundleActivator extends GenericBundleActivator {
 
         final Map<String, IFormExtension> extensions;
         int readyAfterPolls = 0;
         int readinessPolls = 0;
+        long timeoutMs = TimeUnit.MINUTES.toMillis(5);
+        long pollMs = 1;
 
         public TestBundleActivator(Map<String, IFormExtension> extensions) {
             this.extensions = extensions;
@@ -80,6 +148,16 @@ class GenericBundleActivatorTest {
         @Override
         protected boolean isGuicePlatformReady() {
             return readinessPolls++ >= readyAfterPolls;
+        }
+
+        @Override
+        protected long getPlatformWaitTimeoutMs() {
+            return timeoutMs;
+        }
+
+        @Override
+        protected long getPlatformPollIntervalMs() {
+            return pollMs;
         }
 
         @Override
@@ -103,6 +181,15 @@ class GenericBundleActivatorTest {
         @Override
         protected void runAsync(Runnable task) {
             task.run(); // run synchronously in tests
+        }
+    }
+
+    /** Overrides nothing beyond the abstract method, so the real runAsync/isGuicePlatformReady run. */
+    private static class RealSeamsActivator extends GenericBundleActivator {
+
+        @Override
+        protected Map<String, IFormExtension> getExtensions() {
+            return Map.of();
         }
     }
 }

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/GenericBundleActivatorTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/GenericBundleActivatorTest.java
@@ -114,7 +114,7 @@ class GenericBundleActivatorTest {
         activator.runAsync(() -> {
             started.countDown();
             try {
-                Thread.sleep(TimeUnit.SECONDS.toMillis(10));
+                new CountDownLatch(1).await(); // block until interrupted by stop()
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 interrupted.countDown();

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/GenericBundleActivatorTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/GenericBundleActivatorTest.java
@@ -65,7 +65,7 @@ class GenericBundleActivatorTest {
             TestBundleActivator activator = new TestBundleActivator(Map.of("only", mock(IFormExtension.class)));
             activator.readyAfterPolls = 2; // not ready for the first two polls, then ready
 
-            activator.registerExtensionsWhenReady(Map.of("only", mock(IFormExtension.class)));
+            activator.startWhenReady(mock(BundleContext.class));
 
             assertEquals(3, activator.readinessPolls); // polled until ready (2 misses + 1 hit)
             verify(registry, times(1)).registerExtension(eq("only"), any());
@@ -76,7 +76,7 @@ class GenericBundleActivatorTest {
     void cancelsRegistrationWhenWaitInterrupted() {
         try (MockedStatic<FormExtensionsRegistry> extensionsRegistryStatic = mockStatic(FormExtensionsRegistry.class)) {
             CountDownLatch polling = new CountDownLatch(1);
-            TestBundleActivator activator = new TestBundleActivator(Map.of()) {
+            TestBundleActivator activator = new TestBundleActivator(Map.of("only", mock(IFormExtension.class))) {
                 @Override
                 protected boolean isGuicePlatformReady() {
                     polling.countDown();
@@ -98,7 +98,7 @@ class GenericBundleActivatorTest {
             interrupter.setDaemon(true);
             interrupter.start();
 
-            activator.registerExtensionsWhenReady(Map.of("only", mock(IFormExtension.class)));
+            activator.startWhenReady(mock(BundleContext.class));
 
             assertTrue(Thread.interrupted(), "interrupt flag should have been restored"); // also clears it
             extensionsRegistryStatic.verify(FormExtensionsRegistry::getInstance, never()); // registration aborted
@@ -108,11 +108,11 @@ class GenericBundleActivatorTest {
     @Test
     void cancelsRegistrationWhenAlreadyInterruptedAndPlatformReady() {
         try (MockedStatic<FormExtensionsRegistry> extensionsRegistryStatic = mockStatic(FormExtensionsRegistry.class)) {
-            TestBundleActivator activator = new TestBundleActivator(Map.of());
+            TestBundleActivator activator = new TestBundleActivator(Map.of("only", mock(IFormExtension.class)));
             activator.readyAfterPolls = 0; // platform ready immediately -> no sleep would occur
 
             Thread.currentThread().interrupt(); // interrupt set before the first readiness check
-            activator.registerExtensionsWhenReady(Map.of("only", mock(IFormExtension.class)));
+            activator.startWhenReady(mock(BundleContext.class));
 
             assertTrue(Thread.interrupted(), "interrupt flag should have been restored"); // also clears it
             extensionsRegistryStatic.verify(FormExtensionsRegistry::getInstance, never()); // registration aborted
@@ -150,7 +150,7 @@ class GenericBundleActivatorTest {
             activator.timeoutMs = 20;
             activator.pollMs = 5;
 
-            activator.registerExtensionsWhenReady(Map.of("only", mock(IFormExtension.class)));
+            activator.startWhenReady(mock(BundleContext.class));
 
             verify(registry, times(1)).registerExtension(eq("only"), any()); // registered despite timeout
         }

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/GenericBundleActivatorTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/GenericBundleActivatorTest.java
@@ -11,6 +11,7 @@ import org.osgi.framework.BundleContext;
 
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -26,6 +27,7 @@ class GenericBundleActivatorTest {
             extensionsRegistryStatic.when(FormExtensionsRegistry::getInstance).thenReturn(registry);
 
             BundleContext bundleContext = mock(BundleContext.class);
+
             new SimplestTestBundleActivator().start(bundleContext); // Force call onStart() in GenericBundleActivator
             verify(registry, times(0)).registerExtension(anyString(), any());
 
@@ -39,10 +41,27 @@ class GenericBundleActivatorTest {
         }
     }
 
+    @Test
+    void registrationWaitsUntilGuicePlatformReady() {
+        try (MockedStatic<FormExtensionsRegistry> extensionsRegistryStatic = mockStatic(FormExtensionsRegistry.class)) {
+            extensionsRegistryStatic.when(FormExtensionsRegistry::getInstance).thenReturn(registry);
+
+            // Reports "not ready" for the first two polls, then ready.
+            TestBundleActivator activator = new TestBundleActivator(Map.of("only", mock(IFormExtension.class)));
+            activator.readyAfterPolls = 2;
+
+            activator.registerExtensionsWhenReady(Map.of("only", mock(IFormExtension.class)));
+
+            assertEquals(3, activator.readinessPolls); // polled until ready (2 misses + 1 hit)
+            verify(registry, times(1)).registerExtension(eq("only"), any());
+        }
+    }
 
     private static class TestBundleActivator extends GenericBundleActivator {
 
-        Map<String, IFormExtension> extensions;
+        final Map<String, IFormExtension> extensions;
+        int readyAfterPolls = 0;
+        int readinessPolls = 0;
 
         public TestBundleActivator(Map<String, IFormExtension> extensions) {
             this.extensions = extensions;
@@ -57,6 +76,16 @@ class GenericBundleActivatorTest {
         public void onStart(BundleContext context) {
             context.getProperty("test_property");
         }
+
+        @Override
+        protected boolean isGuicePlatformReady() {
+            return readinessPolls++ >= readyAfterPolls;
+        }
+
+        @Override
+        protected void runAsync(Runnable task) {
+            task.run(); // run synchronously in tests
+        }
     }
 
     private static class SimplestTestBundleActivator extends GenericBundleActivator {
@@ -64,6 +93,16 @@ class GenericBundleActivatorTest {
         @Override
         protected Map<String, IFormExtension> getExtensions() {
             return Map.of();
+        }
+
+        @Override
+        protected boolean isGuicePlatformReady() {
+            return true;
+        }
+
+        @Override
+        protected void runAsync(Runnable task) {
+            task.run(); // run synchronously in tests
         }
     }
 }

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/GenericBundleActivatorTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/GenericBundleActivatorTest.java
@@ -73,10 +73,8 @@ class GenericBundleActivatorTest {
     }
 
     @Test
-    void restoresInterruptFlagAndRegistersWhenWaitInterrupted() throws InterruptedException {
+    void cancelsRegistrationWhenWaitInterrupted() {
         try (MockedStatic<FormExtensionsRegistry> extensionsRegistryStatic = mockStatic(FormExtensionsRegistry.class)) {
-            extensionsRegistryStatic.when(FormExtensionsRegistry::getInstance).thenReturn(registry);
-
             CountDownLatch polling = new CountDownLatch(1);
             TestBundleActivator activator = new TestBundleActivator(Map.of()) {
                 @Override
@@ -103,8 +101,29 @@ class GenericBundleActivatorTest {
             activator.registerExtensionsWhenReady(Map.of("only", mock(IFormExtension.class)));
 
             assertTrue(Thread.interrupted(), "interrupt flag should have been restored"); // also clears it
-            verify(registry, times(1)).registerExtension(eq("only"), any());
+            extensionsRegistryStatic.verify(FormExtensionsRegistry::getInstance, never()); // registration aborted
         }
+    }
+
+    @Test
+    void stopInterruptsPendingRegistrar() throws InterruptedException {
+        RealSeamsActivator activator = new RealSeamsActivator();
+        CountDownLatch started = new CountDownLatch(1);
+        CountDownLatch interrupted = new CountDownLatch(1);
+
+        activator.runAsync(() -> {
+            started.countDown();
+            try {
+                Thread.sleep(TimeUnit.SECONDS.toMillis(10));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                interrupted.countDown();
+            }
+        });
+
+        assertTrue(started.await(5, TimeUnit.SECONDS), "background task should have started");
+        activator.stop(mock(BundleContext.class));
+        assertTrue(interrupted.await(5, TimeUnit.SECONDS), "stop() should interrupt the registrar thread");
     }
 
     @Test

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/GenericBundleActivatorTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/GenericBundleActivatorTest.java
@@ -106,6 +106,20 @@ class GenericBundleActivatorTest {
     }
 
     @Test
+    void cancelsRegistrationWhenAlreadyInterruptedAndPlatformReady() {
+        try (MockedStatic<FormExtensionsRegistry> extensionsRegistryStatic = mockStatic(FormExtensionsRegistry.class)) {
+            TestBundleActivator activator = new TestBundleActivator(Map.of());
+            activator.readyAfterPolls = 0; // platform ready immediately -> no sleep would occur
+
+            Thread.currentThread().interrupt(); // interrupt set before the first readiness check
+            activator.registerExtensionsWhenReady(Map.of("only", mock(IFormExtension.class)));
+
+            assertTrue(Thread.interrupted(), "interrupt flag should have been restored"); // also clears it
+            extensionsRegistryStatic.verify(FormExtensionsRegistry::getInstance, never()); // registration aborted
+        }
+    }
+
+    @Test
     void stopInterruptsPendingRegistrar() throws InterruptedException {
         RealSeamsActivator activator = new RealSeamsActivator();
         CountDownLatch started = new CountDownLatch(1);


### PR DESCRIPTION
### Proposed changes

- Implemented asynchronous registration of form extensions to avoid blocking the OSGi activation thread.
- Added logic to wait for Polarion's global Guice injector to become available before registering extensions, preventing potential loss of core contributions.
- Enhanced test coverage to verify registration behavior during Guice platform readiness.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
