### PR TITLE
feat: add rich page toolbar target to DLE engine

### DIFF
--- a/app/src/main/resources/js/dle-toolbar-starter.js
+++ b/app/src/main/resources/js/dle-toolbar-starter.js
@@ -44,11 +44,23 @@
         }
     }
 
+    // GWT shows/hides widgets with inline styles; a widget is effectively hidden when it or any
+    // ancestor carries inline display:none / visibility:hidden (e.g. a stale Rich Page panel kept
+    // in the DOM during an SPA transition).
+    function isInlineVisible(el) {
+        for (let node = el; node && node.style; node = node.parentElement) {
+            if (node.style.display === 'none' || node.style.visibility === 'hidden') {
+                return false;
+            }
+        }
+        return true;
+    }
+
     // Polarion toolbar DOM per supported target — same for all extensions.
     //   rowSelector          the toolbar <tr> buttons are injected into (alternate/row mode);
+    //   findRow              alternative to rowSelector: resolves the row with target-specific
+    //                        logic (used when a plain selector cannot express the constraints);
     //   richTextAreaSelector (dleEditor only) anchor for the default above-the-editor mode;
-    //   guardSelector        when set, injection only happens while this selector matches — used
-    //                        to keep the Rich Page button out of the page's edit mode;
     //   stableAncestorSelector  ancestor that survives the toolbar re-render — observer anchor.
     const TARGETS = {
         dleEditor: {
@@ -57,9 +69,21 @@
             stableAncestorSelector: 'div.polarion-content-container div.polarion-Container div.polarion-dle-Container'
         },
         richPagePreview: {
-            rowSelector: 'div.polarion-rpe-MainPanel table.polarion-dle-ToolbarPanel tr',
             // Only the preview (view) mode of a Rich Page — never the page's edit-mode toolbar.
-            guardSelector: 'div.polarion-rpe-MainPanel div.polarion-rpe-view',
+            // The view marker and the toolbar row are resolved within the SAME visible panel, so a
+            // stale panel kept in the DOM during an SPA transition can neither satisfy the guard
+            // for another panel's toolbar nor receive the button itself.
+            findRow: function (doc) {
+                for (const panel of doc.querySelectorAll('div.polarion-rpe-MainPanel')) {
+                    if (isInlineVisible(panel) && panel.querySelector('div.polarion-rpe-view')) {
+                        const row = panel.querySelector('table.polarion-dle-ToolbarPanel tr');
+                        if (row) {
+                            return row;
+                        }
+                    }
+                }
+                return null;
+            },
             stableAncestorSelector: 'div.polarion-content-container'
         }
     };
@@ -83,7 +107,8 @@
          *   defaultHtml   markup injected above the rich-text area otherwise ('dleEditor' target only).
          *   target        which Polarion toolbar to inject into: 'dleEditor' (default) or
          *                 'richPagePreview'. The 'richPagePreview' target always injects into the
-         *                 toolbar row (alternateHtml), regardless of the alternate flag.
+         *                 toolbar row (alternateHtml), regardless of the alternate flag, and only
+         *                 while the page is in view (preview) mode.
          *
          *   SECURITY: alternateHtml / defaultHtml are written via innerHTML into the top Polarion
          *   frame, so they MUST be static, trusted markup. Never interpolate user-controlled data
@@ -112,13 +137,12 @@
                 if (top.document.getElementById(config.markerId)) {
                     return; // already present
                 }
-                if (target.guardSelector && !top.document.querySelector(target.guardSelector)) {
-                    return; // guarded off (e.g. Rich Page is in edit mode)
-                }
                 if ((params && params.alternate) || !target.richTextAreaSelector) {
-                    const toolbarParent = top.document.querySelector(target.rowSelector);
+                    const toolbarParent = target.findRow
+                        ? target.findRow(top.document)
+                        : top.document.querySelector(target.rowSelector);
                     if (!toolbarParent) {
-                        return; // toolbar not rendered (yet)
+                        return; // toolbar not rendered (yet), or guarded off (e.g. edit mode)
                     }
                     const toolbarContainer = top.document.createElement('td');
                     toolbarContainer.id = config.markerId;
@@ -223,10 +247,12 @@
                 return;
             }
             function expand() {
-                const handle = top.document.querySelector(EXPAND_TOOLS_SELECTOR);
-                // GWT hides widgets with inline display:none — don't click an invisible handle.
-                if (handle && handle.style.display !== 'none') {
-                    handle.click();
+                // Several handles can coexist during an SPA transition (a stale, inline-hidden
+                // Rich Page panel next to the active one) — click only the visible one.
+                for (const handle of top.document.querySelectorAll(EXPAND_TOOLS_SELECTOR)) {
+                    if (isInlineVisible(handle)) {
+                        handle.click();
+                    }
                 }
             }
             let scheduled = false;
@@ -242,8 +268,16 @@
                 });
             });
             top.__genericRpeAutoExpandObserver = observer;
-            observer.observe(top.document.body, { childList: true, subtree: true });
-            expand();
+            // A head-injected script can run before <body> exists — defer until it does.
+            function start() {
+                observer.observe(top.document.body, { childList: true, subtree: true });
+                expand();
+            }
+            if (top.document.body) {
+                start();
+            } else {
+                top.document.addEventListener('DOMContentLoaded', start, { once: true });
+            }
         }
     };
 })();

--- a/app/src/main/resources/js/dle-toolbar-starter.js
+++ b/app/src/main/resources/js/dle-toolbar-starter.js
@@ -1,13 +1,20 @@
 /*
- * Universal self-healing DLE-toolbar button injector — single source for all extensions
- * that inject a button into Polarion's document (DLE) editor toolbar via
- * `scriptInjection.dleEditorHead`.
+ * Universal self-healing Polarion-toolbar button injector — single source for all extensions
+ * that inject a button into a native Polarion toolbar via `scriptInjection.*` configuration.
+ *
+ * Supported toolbars (the `target` config, see TARGETS below):
+ *   - 'dleEditor' (default)      the document (DLE) editor toolbar, configured via
+ *                                `scriptInjection.dleEditorHead`;
+ *   - 'richPagePreview'          the Rich Page / Live Report toolbar in view mode (the one behind
+ *                                the "Expand Tools" handle), configured via `scriptInjection.mainHead`.
  *
  * Polarion (GWT) re-renders the toolbar sub-tree on actions like Save, which wipes out a
  * one-time injected element. This engine injects idempotently and re-injects via a
- * MutationObserver whenever the toolbar is re-rendered and the button disappears.
+ * MutationObserver whenever the toolbar is re-rendered and the button disappears. The Rich Page
+ * toolbar additionally does not exist in the DOM at all until the user expands it — the same
+ * observer picks it up the moment it is rendered.
  *
- * The DLE toolbar selectors below are Polarion's own DOM and identical for every extension.
+ * The toolbar selectors below are Polarion's own DOM and identical for every extension.
  * Extension-specific parts (button HTML, marker id) come in via create(config).
  *
  * Usage (thin extension starter.js loads this, then):
@@ -37,11 +44,28 @@
         }
     }
 
-    // Polarion DLE toolbar DOM — same for all extensions.
-    const ALTERNATE_TOOLBAR_SELECTOR = 'div.polarion-content-container div.polarion-Container div.polarion-dle-Container > div.polarion-dle-Wrapper > div.polarion-dle-RpcPanel > div.polarion-dle-MainDockPanel div.polarion-rte-ToolbarPanelWrapper table.polarion-dle-ToolbarPanel tr';
-    const RICH_TEXT_AREA_SELECTOR = 'div.polarion-content-container div.polarion-Container div.polarion-dle-Container>div.polarion-dle-Wrapper>div.polarion-dle-RpcPanel>div.polarion-dle-MainDockPanel div.polarion-dle-SplitPanel:last-child .polarion-dle-RichTextArea';
-    // Stable ancestor that survives the toolbar re-render — observed for re-injection.
-    const STABLE_ANCESTOR_SELECTOR = 'div.polarion-content-container div.polarion-Container div.polarion-dle-Container';
+    // Polarion toolbar DOM per supported target — same for all extensions.
+    //   rowSelector          the toolbar <tr> buttons are injected into (alternate/row mode);
+    //   richTextAreaSelector (dleEditor only) anchor for the default above-the-editor mode;
+    //   guardSelector        when set, injection only happens while this selector matches — used
+    //                        to keep the Rich Page button out of the page's edit mode;
+    //   stableAncestorSelector  ancestor that survives the toolbar re-render — observer anchor.
+    const TARGETS = {
+        dleEditor: {
+            rowSelector: 'div.polarion-content-container div.polarion-Container div.polarion-dle-Container > div.polarion-dle-Wrapper > div.polarion-dle-RpcPanel > div.polarion-dle-MainDockPanel div.polarion-rte-ToolbarPanelWrapper table.polarion-dle-ToolbarPanel tr',
+            richTextAreaSelector: 'div.polarion-content-container div.polarion-Container div.polarion-dle-Container>div.polarion-dle-Wrapper>div.polarion-dle-RpcPanel>div.polarion-dle-MainDockPanel div.polarion-dle-SplitPanel:last-child .polarion-dle-RichTextArea',
+            stableAncestorSelector: 'div.polarion-content-container div.polarion-Container div.polarion-dle-Container'
+        },
+        richPagePreview: {
+            rowSelector: 'div.polarion-rpe-MainPanel table.polarion-dle-ToolbarPanel tr',
+            // Only the preview (view) mode of a Rich Page — never the page's edit-mode toolbar.
+            guardSelector: 'div.polarion-rpe-MainPanel div.polarion-rpe-view',
+            stableAncestorSelector: 'div.polarion-content-container'
+        }
+    };
+
+    // The "Expand Tools" handle of a collapsed Rich Page toolbar (see autoExpandRichPageTools).
+    const EXPAND_TOOLS_SELECTOR = 'div.polarion-rpe-expandTools';
 
     // Registry of live observers keyed by markerId, kept on the top window so it survives this
     // script being re-loaded each time the DLE editor is (re-)opened in Polarion's GWT SPA.
@@ -53,10 +77,13 @@
         injectScript: injectScript,
 
         /**
-         * @param config {{ markerId: string, alternateHtml: string, defaultHtml: string }}
+         * @param config {{ markerId: string, alternateHtml: string, defaultHtml: string, target: string|undefined, order: number|undefined }}
          *   markerId      unique id set on the injected element; also the idempotency/dedup key.
          *   alternateHtml markup injected into the toolbar row when injectToolbar({alternate: true}).
-         *   defaultHtml   markup injected above the rich-text area otherwise.
+         *   defaultHtml   markup injected above the rich-text area otherwise ('dleEditor' target only).
+         *   target        which Polarion toolbar to inject into: 'dleEditor' (default) or
+         *                 'richPagePreview'. The 'richPagePreview' target always injects into the
+         *                 toolbar row (alternateHtml), regardless of the alternate flag.
          *
          *   SECURITY: alternateHtml / defaultHtml are written via innerHTML into the top Polarion
          *   frame, so they MUST be static, trusted markup. Never interpolate user-controlled data
@@ -65,6 +92,11 @@
          * @returns {{ injectToolbar: function, destroy: function }}
          */
         create: function (config) {
+            const target = TARGETS[config.target || 'dleEditor'];
+            if (!target) {
+                throw new Error(`GenericDleToolbarStarter: unknown target '${config.target}'.`);
+            }
+
             // Stable left-to-right order across re-renders. Each button keeps the order it was
             // registered with (config.order — the config-execution order); re-injection inserts
             // before the first already-present button with a *higher* order. Buttons with distinct
@@ -80,13 +112,19 @@
                 if (top.document.getElementById(config.markerId)) {
                     return; // already present
                 }
-                if (params && params.alternate) {
-                    const toolbarParent = top.document.querySelector(ALTERNATE_TOOLBAR_SELECTOR);
+                if (target.guardSelector && !top.document.querySelector(target.guardSelector)) {
+                    return; // guarded off (e.g. Rich Page is in edit mode)
+                }
+                if ((params && params.alternate) || !target.richTextAreaSelector) {
+                    const toolbarParent = top.document.querySelector(target.rowSelector);
                     if (!toolbarParent) {
                         return; // toolbar not rendered (yet)
                     }
                     const toolbarContainer = top.document.createElement('td');
                     toolbarContainer.id = config.markerId;
+                    // Polarion's own toolbar cells carry vertical-align: middle inline — match them
+                    // so injected buttons line up with the native ones.
+                    toolbarContainer.style.verticalAlign = 'middle';
                     toolbarContainer.innerHTML = config.alternateHtml;
                     const spacer = toolbarParent.querySelector('td[width="100%"]');
                     if (!spacer) {
@@ -106,7 +144,7 @@
                     }
                     toolbarParent.insertBefore(toolbarContainer, reference);
                 } else {
-                    const documentFrame = top.document.querySelector(RICH_TEXT_AREA_SELECTOR);
+                    const documentFrame = top.document.querySelector(target.richTextAreaSelector);
                     if (!documentFrame) {
                         return;
                     }
@@ -132,7 +170,7 @@
                     if (observerSetUp) {
                         return;
                     }
-                    const anchor = top.document.querySelector(STABLE_ANCESTOR_SELECTOR) || top.document.body;
+                    const anchor = top.document.querySelector(target.stableAncestorSelector) || top.document.body;
                     if (!anchor) {
                         return;
                     }
@@ -168,6 +206,44 @@
                     observerSetUp = false;
                 }
             };
+        },
+
+        /**
+         * Keep the Rich Page (Live Report) tools toolbar always expanded. Polarion renders it
+         * collapsed behind an "Expand Tools" handle on every page open and does not persist the
+         * expanded state, so this clicks the handle whenever it (re-)appears — on the initial page
+         * load and on SPA navigation between pages.
+         *
+         * Idempotent across callers: a single shared observer per top window (several extensions
+         * calling this results in one observer). There is no opposite-direction fighting to worry
+         * about — Polarion offers no collapse control once the toolbar is expanded.
+         */
+        autoExpandRichPageTools: function () {
+            if (top.__genericRpeAutoExpandObserver) {
+                return;
+            }
+            function expand() {
+                const handle = top.document.querySelector(EXPAND_TOOLS_SELECTOR);
+                // GWT hides widgets with inline display:none — don't click an invisible handle.
+                if (handle && handle.style.display !== 'none') {
+                    handle.click();
+                }
+            }
+            let scheduled = false;
+            const observer = new MutationObserver(function () {
+                if (scheduled) {
+                    return;
+                }
+                scheduled = true;
+                // Coalesce the burst of mutations during a page render into a single check.
+                requestAnimationFrame(function () {
+                    scheduled = false;
+                    expand();
+                });
+            });
+            top.__genericRpeAutoExpandObserver = observer;
+            observer.observe(top.document.body, { childList: true, subtree: true });
+            expand();
         }
     };
 })();

--- a/app/src/test/js/modules/dleToolbarStarterTest.js
+++ b/app/src/test/js/modules/dleToolbarStarterTest.js
@@ -268,6 +268,28 @@ describe('GenericDleToolbarStarter (dle-toolbar-starter.js)', function () {
             expect(document.getElementById('my-btn')).to.equal(null);
         });
 
+        it('ignores a stale view panel and does not inject into another panel in edit mode', function () {
+            // SPA transition: a stale (hidden) panel still carrying the view marker coexists with
+            // the active panel that is in edit mode — nothing may be injected.
+            document.body.innerHTML =
+                `<div class="polarion-content-container">
+                   <div class="polarion-rpe-MainPanel" style="display: none;">
+                     <div class="polarion-rpe-view"></div>
+                   </div>
+                   <div class="polarion-rpe-MainPanel">
+                     <div class="polarion-rte-ToolbarPanelWrapper">
+                       <table class="polarion-dle-ToolbarPanel"><tbody>
+                         <tr><td class="existing-tool"></td><td width="100%"></td></tr>
+                       </tbody></table>
+                     </div>
+                     <div class="polarion-rpe-edit"></div>
+                   </div>
+                 </div>`;
+            const starter = window.GenericDleToolbarStarter.create(cfg({ target: 'richPagePreview' }));
+            starter.injectToolbar();
+            expect(document.getElementById('my-btn')).to.equal(null);
+        });
+
         it('injects via the observer once the toolbar gets expanded', async function () {
             document.body.innerHTML = rpeHtml({ toolbar: false, expandHandle: true });
             const starter = window.GenericDleToolbarStarter.create(cfg({ target: 'richPagePreview' }));
@@ -320,6 +342,36 @@ describe('GenericDleToolbarStarter (dle-toolbar-starter.js)', function () {
             expect(rafCallbacks.length).to.be.greaterThan(0);
             rafCallbacks.forEach((cb) => cb());
             expect(clicked.calledOnce).to.be.true;
+        });
+
+        it('ignores a handle hidden by an inline-hidden ancestor (stale SPA panel)', function () {
+            document.body.innerHTML =
+                `<div class="polarion-rpe-MainPanel" style="display: none;">
+                   <div class="polarion-rpe-expandTools"><span>Expand Tools</span></div>
+                 </div>`;
+            const clicked = sinon.spy();
+            document.querySelector('.polarion-rpe-expandTools').addEventListener('click', clicked);
+
+            window.GenericDleToolbarStarter.autoExpandRichPageTools();
+            expect(clicked.called).to.be.false;
+        });
+
+        it('clicks the visible handle even when a stale hidden one comes first in the DOM', function () {
+            document.body.innerHTML =
+                `<div class="polarion-rpe-MainPanel" style="display: none;">
+                   <div class="polarion-rpe-expandTools"><span>Expand Tools</span></div>
+                 </div>
+                 <div class="polarion-rpe-MainPanel">
+                   <div class="polarion-rpe-expandTools"><span>Expand Tools</span></div>
+                 </div>`;
+            const handles = document.querySelectorAll('.polarion-rpe-expandTools');
+            const staleClicked = sinon.spy(), activeClicked = sinon.spy();
+            handles[0].addEventListener('click', staleClicked);
+            handles[1].addEventListener('click', activeClicked);
+
+            window.GenericDleToolbarStarter.autoExpandRichPageTools();
+            expect(staleClicked.called).to.be.false;
+            expect(activeClicked.calledOnce).to.be.true;
         });
 
         it('is idempotent — repeated calls keep a single shared observer', function () {

--- a/app/src/test/js/modules/dleToolbarStarterTest.js
+++ b/app/src/test/js/modules/dleToolbarStarterTest.js
@@ -38,6 +38,26 @@ describe('GenericDleToolbarStarter (dle-toolbar-starter.js)', function () {
                 </div></div>`;
     }
 
+    // Rich Page (Live Report) sub-tree: the preview toolbar row plus the view/edit content marker
+    // and, optionally, the collapsed-state "Expand Tools" handle.
+    function rpeHtml({ toolbar = true, view = true, spacer = true, expandHandle = false, handleHidden = false } = {}) {
+        const spacerCell = spacer ? '<td width="100%"></td>' : '';
+        const toolbarRow = toolbar
+            ? `<div class="polarion-rte-ToolbarPanelWrapper">
+                 <table class="polarion-dle-ToolbarPanel"><tbody>
+                   <tr><td class="existing-tool"></td>${spacerCell}</tr>
+                 </tbody></table>
+               </div>`
+            : '';
+        const content = view ? '<div class="polarion-rpe-view"></div>' : '<div class="polarion-rpe-edit"></div>';
+        const handle = expandHandle
+            ? `<div class="polarion-rpe-expandTools"${handleHidden ? ' style="display: none;"' : ''}><span>Expand Tools</span></div>`
+            : '';
+        return `<div class="polarion-content-container">
+                  <div class="polarion-rpe-MainPanel">${toolbarRow}${content}${handle}</div>
+                </div>`;
+    }
+
     const cfg = (over = {}) => ({ markerId: 'my-btn', alternateHtml: '<button>A</button>', defaultHtml: '<button>D</button>', ...over });
 
     before(async function () {
@@ -67,6 +87,11 @@ describe('GenericDleToolbarStarter (dle-toolbar-starter.js)', function () {
         Object.keys(reg).forEach((k) => { try { reg[k].disconnect(); } catch { /* node gone */ } delete reg[k]; });
         const order = window.__genericDleToolbarOrder;
         if (order) Object.keys(order).forEach((k) => delete order[k]);
+        // Release the shared auto-expand observer so each test starts from a clean slate.
+        if (window.__genericRpeAutoExpandObserver) {
+            window.__genericRpeAutoExpandObserver.disconnect();
+            delete window.__genericRpeAutoExpandObserver;
+        }
         document.head.innerHTML = '';
         document.body.innerHTML = '';
         rafCallbacks.length = 0;
@@ -210,6 +235,100 @@ describe('GenericDleToolbarStarter (dle-toolbar-starter.js)', function () {
         second.injectToolbar({ alternate: true });
         expect(spy.calledOnce).to.be.true;           // the previous observer was disconnected
         expect(reg['my-btn']).to.not.equal(firstObserver); // registry now holds the new one
+    });
+
+    it("throws on an unknown target", function () {
+        expect(() => window.GenericDleToolbarStarter.create(cfg({ target: 'nope' }))).to.throw("unknown target 'nope'");
+    });
+
+    describe("richPagePreview target", function () {
+        it('injects the button into the Rich Page toolbar row before the spacer cell', function () {
+            document.body.innerHTML = rpeHtml();
+            const starter = window.GenericDleToolbarStarter.create(cfg({ target: 'richPagePreview' }));
+            starter.injectToolbar(); // no alternate flag — row injection is implied for this target
+
+            const cell = document.getElementById('my-btn');
+            expect(cell).to.exist;
+            expect(cell.tagName).to.equal('TD');
+            expect(cell.innerHTML).to.equal('<button>A</button>');
+            expect(cell.nextElementSibling.getAttribute('width')).to.equal('100%'); // sits before the spacer
+        });
+
+        it('does not inject while the Rich Page is in edit mode (guard selector)', function () {
+            document.body.innerHTML = rpeHtml({ view: false });
+            const starter = window.GenericDleToolbarStarter.create(cfg({ target: 'richPagePreview' }));
+            starter.injectToolbar();
+            expect(document.getElementById('my-btn')).to.equal(null);
+        });
+
+        it('does nothing while the toolbar is still collapsed (row absent)', function () {
+            document.body.innerHTML = rpeHtml({ toolbar: false, expandHandle: true });
+            const starter = window.GenericDleToolbarStarter.create(cfg({ target: 'richPagePreview' }));
+            starter.injectToolbar();
+            expect(document.getElementById('my-btn')).to.equal(null);
+        });
+
+        it('injects via the observer once the toolbar gets expanded', async function () {
+            document.body.innerHTML = rpeHtml({ toolbar: false, expandHandle: true });
+            const starter = window.GenericDleToolbarStarter.create(cfg({ target: 'richPagePreview' }));
+            starter.injectToolbar(); // nothing yet — row absent, but the observer is armed
+
+            // "Expand Tools" clicked: GWT replaces the handle with the toolbar
+            const panel = document.querySelector('.polarion-rpe-MainPanel');
+            panel.querySelector('.polarion-rpe-expandTools').remove();
+            panel.insertAdjacentHTML('afterbegin',
+                `<div class="polarion-rte-ToolbarPanelWrapper">
+                   <table class="polarion-dle-ToolbarPanel"><tbody>
+                     <tr><td class="existing-tool"></td><td width="100%"></td></tr>
+                   </tbody></table>
+                 </div>`);
+            await flushObserver();
+            expect(rafCallbacks.length).to.be.greaterThan(0);
+            rafCallbacks.forEach((cb) => cb());
+            expect(document.getElementById('my-btn')).to.exist;
+        });
+    });
+
+    describe('autoExpandRichPageTools', function () {
+        it('clicks a visible "Expand Tools" handle on the initial call', function () {
+            document.body.innerHTML = rpeHtml({ toolbar: false, expandHandle: true });
+            const handle = document.querySelector('.polarion-rpe-expandTools');
+            const clicked = sinon.spy();
+            handle.addEventListener('click', clicked);
+
+            window.GenericDleToolbarStarter.autoExpandRichPageTools();
+            expect(clicked.calledOnce).to.be.true;
+        });
+
+        it('ignores a handle hidden by GWT (inline display:none)', function () {
+            document.body.innerHTML = rpeHtml({ toolbar: false, expandHandle: true, handleHidden: true });
+            const clicked = sinon.spy();
+            document.querySelector('.polarion-rpe-expandTools').addEventListener('click', clicked);
+
+            window.GenericDleToolbarStarter.autoExpandRichPageTools();
+            expect(clicked.called).to.be.false;
+        });
+
+        it('clicks the handle when it appears later (SPA navigation)', async function () {
+            document.body.innerHTML = '';
+            window.GenericDleToolbarStarter.autoExpandRichPageTools();
+
+            document.body.innerHTML = rpeHtml({ toolbar: false, expandHandle: true });
+            const clicked = sinon.spy();
+            document.querySelector('.polarion-rpe-expandTools').addEventListener('click', clicked);
+            await flushObserver();
+            expect(rafCallbacks.length).to.be.greaterThan(0);
+            rafCallbacks.forEach((cb) => cb());
+            expect(clicked.calledOnce).to.be.true;
+        });
+
+        it('is idempotent — repeated calls keep a single shared observer', function () {
+            document.body.innerHTML = '';
+            window.GenericDleToolbarStarter.autoExpandRichPageTools();
+            const observer = window.__genericRpeAutoExpandObserver;
+            window.GenericDleToolbarStarter.autoExpandRichPageTools();
+            expect(window.__genericRpeAutoExpandObserver).to.equal(observer);
+        });
     });
 
     it('injectStyles adds a stylesheet link once and injectScript adds a script once', function () {


### PR DESCRIPTION
### Proposed changes

Closes #582

Extend the self-healing toolbar injector with an optional 'target' config: 'dleEditor' (default, unchanged behavior) or 'richPagePreview' for the Live Report / Rich Page toolbar hidden behind the Expand Tools handle. The rich page target injects into the toolbar row only in view mode and reuses the same idempotency, ordering and re-injection logic.

Also add autoExpandRichPageTools(): an idempotent shared observer that keeps the rich page toolbar always expanded by clicking the Expand Tools handle whenever it appears, since Polarion does not persist the expanded state across page opens.

Injected row cells now carry vertical-align: middle to line up with Polarion's native toolbar cells.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation

