### PR TITLE
fix: keep injected DLE toolbar buttons in configured order

### DIFF
--- a/app/src/main/resources/js/dle-toolbar-starter.js
+++ b/app/src/main/resources/js/dle-toolbar-starter.js
@@ -91,6 +91,54 @@
     // The "Expand Tools" handle of a collapsed Rich Page toolbar (see autoExpandRichPageTools).
     const EXPAND_TOOLS_SELECTOR = 'div.polarion-rpe-expandTools';
 
+    // Derive a button's left-to-right order from the DOM position of its extension's own inject
+    // script, rather than from config.order.
+    //
+    // Why: several extensions each configure a single-tag injector (…/<ext>/js/dle-toolbar.js or
+    // live-reports.js) in the SAME scriptInjection property, in a deliberate order. Each injector
+    // then ASYNCHRONOUSLY loads its own starter.js, whose stub captures a sequence number when it
+    // finally runs — inside starter.js's onload. Those onloads fire in network-race order, so the
+    // captured config.order does NOT reflect the configured order (the buttons visibly reshuffle
+    // between reloads). Polarion, by contrast, inserts the injector <script> tags into the page in
+    // scriptInjection order and they stay put, so their DOM position IS a stable, deterministic
+    // reflection of the configured order. This runs in the same document as those scripts (the DLE
+    // editor iframe for dleEditor, the top page for richPagePreview), so it can read them directly.
+    //
+    // markerId convention: it starts with the extension's web-context segment (e.g. the button
+    // 'pdf-exporter-toolbar-injected' belongs to '/polarion/pdf-exporter/...'). Falls back to the
+    // caller-supplied order when no matching inject script is found (e.g. deprecated inline config).
+    const INJECT_SCRIPT_RE = /\/js\/(?:dle-toolbar|starter|live-reports)\.js/;
+    const EXT_CONTEXT_RE = /\/polarion\/([^/]+)\/(?:ui\/[^/]+\/)?js\//;
+
+    function domOrder(markerId, fallback) {
+        // Collect the distinct extension web-context segments from the inject scripts, in DOM order
+        // (which Polarion keeps equal to the configured order). The generic engine script itself
+        // (…/js/dle-toolbar-starter.js) is excluded by INJECT_SCRIPT_RE.
+        const seen = {}, contexts = [];
+        for (const script of document.querySelectorAll('head script[src], script[src]')) {
+            const src = script.getAttribute('src') || '';
+            if (!INJECT_SCRIPT_RE.test(src)) {
+                continue;
+            }
+            const match = EXT_CONTEXT_RE.exec(src);
+            const ctx = match && match[1];
+            if (ctx && !seen[ctx]) {
+                seen[ctx] = true;
+                contexts.push(ctx);
+            }
+        }
+        // markerId starts with its extension context; pick the longest matching prefix so a more
+        // specific context wins (e.g. a hypothetical 'pdf-exporter-rp' over 'pdf-exporter').
+        let bestIndex = -1, bestLength = -1;
+        for (let i = 0; i < contexts.length; i++) {
+            if (markerId.indexOf(contexts[i]) === 0 && contexts[i].length > bestLength) {
+                bestIndex = i;
+                bestLength = contexts[i].length;
+            }
+        }
+        return bestIndex >= 0 ? bestIndex : fallback;
+    }
+
     // Registry of live observers keyed by markerId, kept on the top window so it survives this
     // script being re-loaded each time the DLE editor is (re-)opened in Polarion's GWT SPA.
     // Re-using the key lets us disconnect the previous observer instead of accumulating them.
@@ -122,13 +170,14 @@
                 throw new Error(`GenericDleToolbarStarter: unknown target '${config.target}'.`);
             }
 
-            // Stable left-to-right order across re-renders. Each button keeps the order it was
-            // registered with (config.order — the config-execution order); re-injection inserts
-            // before the first already-present button with a *higher* order. Buttons with distinct
-            // orders keep their position regardless of which extension's observer re-fires first;
-            // buttons sharing an order (e.g. callers that omit it → default 0) tie-break by
-            // observer-fire order, so distinct orders are required for full determinism.
-            const myOrder = (typeof config.order === 'number') ? config.order : 0;
+            // Stable left-to-right order across re-renders. Re-injection inserts before the first
+            // already-present button with a *higher* order. The order is derived from the DOM
+            // position of the extension's own inject script (deterministic, = configured order),
+            // falling back to config.order when that can't be resolved (see domOrder). Buttons with
+            // distinct orders keep their position regardless of which extension's observer re-fires
+            // first; buttons sharing an order tie-break by observer-fire order.
+            const fallbackOrder = (typeof config.order === 'number') ? config.order : 0;
+            const myOrder = domOrder(config.markerId, fallbackOrder);
             const orderByMarker = top.__genericDleToolbarOrder || (top.__genericDleToolbarOrder = {});
             orderByMarker[config.markerId] = myOrder;
 

--- a/app/src/main/resources/js/dle-toolbar-starter.js
+++ b/app/src/main/resources/js/dle-toolbar-starter.js
@@ -114,16 +114,16 @@
         // Collect the distinct extension web-context segments from the inject scripts, in DOM order
         // (which Polarion keeps equal to the configured order). The generic engine script itself
         // (…/js/dle-toolbar-starter.js) is excluded by INJECT_SCRIPT_RE.
-        const seen = {}, contexts = [];
-        for (const script of document.querySelectorAll('head script[src], script[src]')) {
-            const src = script.getAttribute('src') || '';
+        const seen = new Set(), contexts = [];
+        for (const script of document.querySelectorAll('script[src]')) {
+            const src = script.getAttribute('src'); // the [src] selector guarantees a string
             if (!INJECT_SCRIPT_RE.test(src)) {
                 continue;
             }
             const match = EXT_CONTEXT_RE.exec(src);
             const ctx = match && match[1];
-            if (ctx && !seen[ctx]) {
-                seen[ctx] = true;
+            if (ctx && !seen.has(ctx)) {
+                seen.add(ctx);
                 contexts.push(ctx);
             }
         }

--- a/app/src/test/js/modules/dleToolbarStarterTest.js
+++ b/app/src/test/js/modules/dleToolbarStarterTest.js
@@ -139,7 +139,48 @@ describe('GenericDleToolbarStarter (dle-toolbar-starter.js)', function () {
         expect(warn.firstCall.args[0]).to.contain('my-btn');
     });
 
-    it('keeps a stable order — a lower-order button is inserted before a higher-order one', function () {
+    // Add the extensions' single-tag inject scripts to <head> in configured order — Polarion keeps
+    // their DOM position equal to the scriptInjection order, and the engine derives the button
+    // order from it (see domOrder).
+    function addInjectScripts(...contexts) {
+        for (const ctx of contexts) {
+            const s = document.createElement('script');
+            s.setAttribute('src', `/polarion/${ctx}/js/dle-toolbar.js?timestamp=1`);
+            document.head.appendChild(s);
+        }
+    }
+
+    it('orders buttons by the DOM position of their inject scripts, ignoring a race-prone config.order', function () {
+        document.body.innerHTML = dleHtml();
+        // Scripts are in configured order pdf, docx, strictdoc...
+        addInjectScripts('pdf-exporter', 'docx-exporter', 'strictdoc-exporter');
+        // ...but the create() calls arrive in onload-race order (reversed) with misleading orders.
+        window.GenericDleToolbarStarter.create(cfg({ markerId: 'strictdoc-exporter-toolbar-injected', order: 1 })).injectToolbar({ alternate: true });
+        window.GenericDleToolbarStarter.create(cfg({ markerId: 'docx-exporter-toolbar-injected', order: 2 })).injectToolbar({ alternate: true });
+        window.GenericDleToolbarStarter.create(cfg({ markerId: 'pdf-exporter-toolbar-injected', order: 3 })).injectToolbar({ alternate: true });
+
+        const ids = [...document.querySelector('table.polarion-dle-ToolbarPanel tr').children].map(c => c.id).filter(Boolean);
+        expect(ids).to.deep.equal(['pdf-exporter-toolbar-injected', 'docx-exporter-toolbar-injected', 'strictdoc-exporter-toolbar-injected']);
+    });
+
+    it('heals to the configured order after a re-render regardless of re-inject timing', function () {
+        document.body.innerHTML = dleHtml();
+        addInjectScripts('pdf-exporter', 'docx-exporter');
+        const pdf = window.GenericDleToolbarStarter.create(cfg({ markerId: 'pdf-exporter-toolbar-injected', order: 5 }));
+        const docx = window.GenericDleToolbarStarter.create(cfg({ markerId: 'docx-exporter-toolbar-injected', order: 0 }));
+        pdf.injectToolbar({ alternate: true });
+        docx.injectToolbar({ alternate: true });
+        // GWT wipes both, then docx re-injects before pdf — order must still be pdf, docx.
+        document.getElementById('pdf-exporter-toolbar-injected').remove();
+        document.getElementById('docx-exporter-toolbar-injected').remove();
+        docx.injectToolbar({ alternate: true });
+        pdf.injectToolbar({ alternate: true });
+
+        const ids = [...document.querySelector('table.polarion-dle-ToolbarPanel tr').children].map(c => c.id).filter(Boolean);
+        expect(ids).to.deep.equal(['pdf-exporter-toolbar-injected', 'docx-exporter-toolbar-injected']);
+    });
+
+    it('falls back to config.order when no inject script matches (deprecated inline config)', function () {
         document.body.innerHTML = dleHtml();
         window.GenericDleToolbarStarter.create(cfg({ markerId: 'btn-high', order: 10 })).injectToolbar({ alternate: true });
         window.GenericDleToolbarStarter.create(cfg({ markerId: 'btn-low', order: 0 })).injectToolbar({ alternate: true });

--- a/app/src/test/js/modules/dleToolbarStarterTest.js
+++ b/app/src/test/js/modules/dleToolbarStarterTest.js
@@ -150,6 +150,14 @@ describe('GenericDleToolbarStarter (dle-toolbar-starter.js)', function () {
         }
     }
 
+    function addScript(src) {
+        const s = document.createElement('script');
+        if (src !== null) {
+            s.setAttribute('src', src);
+        }
+        document.head.appendChild(s);
+    }
+
     it('orders buttons by the DOM position of their inject scripts, ignoring a race-prone config.order', function () {
         document.body.innerHTML = dleHtml();
         // Scripts are in configured order pdf, docx, strictdoc...
@@ -187,6 +195,56 @@ describe('GenericDleToolbarStarter (dle-toolbar-starter.js)', function () {
 
         const ids = [...document.querySelector('table.polarion-dle-ToolbarPanel tr').children].map((c) => c.id);
         expect(ids.indexOf('btn-low')).to.be.lessThan(ids.indexOf('btn-high')); // low sits before high
+    });
+
+    it('ignores non-inject scripts (engine script, empty/foreign src) when deriving the order', function () {
+        document.body.innerHTML = dleHtml();
+        addScript(null);                                                          // src-less <script>
+        addScript('/polarion/pdf-exporter/ui/generic/js/dle-toolbar-starter.js'); // the engine itself
+        addScript('/some/unrelated/app.js');                                      // foreign script
+        addInjectScripts('pdf-exporter', 'docx-exporter');                        // the real injectors
+        window.GenericDleToolbarStarter.create(cfg({ markerId: 'docx-exporter-toolbar-injected', order: 9 })).injectToolbar({ alternate: true });
+        window.GenericDleToolbarStarter.create(cfg({ markerId: 'pdf-exporter-toolbar-injected', order: 9 })).injectToolbar({ alternate: true });
+
+        const ids = [...document.querySelector('table.polarion-dle-ToolbarPanel tr').children].map(c => c.id).filter(Boolean);
+        expect(ids).to.deep.equal(['pdf-exporter-toolbar-injected', 'docx-exporter-toolbar-injected']);
+    });
+
+    it('dedupes multiple inject scripts of the same extension (dle-toolbar.js + starter.js)', function () {
+        document.body.innerHTML = dleHtml();
+        // Each extension ships both a dle-toolbar.js and a starter.js — they must count as one context.
+        addScript('/polarion/pdf-exporter/js/dle-toolbar.js');
+        addScript('/polarion/pdf-exporter/js/starter.js');
+        addScript('/polarion/docx-exporter/js/dle-toolbar.js');
+        addScript('/polarion/docx-exporter/js/starter.js');
+        window.GenericDleToolbarStarter.create(cfg({ markerId: 'docx-exporter-toolbar-injected' })).injectToolbar({ alternate: true });
+        window.GenericDleToolbarStarter.create(cfg({ markerId: 'pdf-exporter-toolbar-injected' })).injectToolbar({ alternate: true });
+
+        const ids = [...document.querySelector('table.polarion-dle-ToolbarPanel tr').children].map(c => c.id).filter(Boolean);
+        expect(ids).to.deep.equal(['pdf-exporter-toolbar-injected', 'docx-exporter-toolbar-injected']);
+    });
+
+    it('is not confused by a context named like an Object prototype key', function () {
+        document.body.innerHTML = dleHtml();
+        // 'constructor' as an extension context must be treated as a normal, distinct segment
+        // (regression guard for using a Set rather than a plain-object seen-map).
+        addInjectScripts('constructor', 'pdf-exporter');
+        window.GenericDleToolbarStarter.create(cfg({ markerId: 'pdf-exporter-toolbar-injected' })).injectToolbar({ alternate: true });
+        window.GenericDleToolbarStarter.create(cfg({ markerId: 'constructor-toolbar-injected' })).injectToolbar({ alternate: true });
+
+        const ids = [...document.querySelector('table.polarion-dle-ToolbarPanel tr').children].map(c => c.id).filter(Boolean);
+        expect(ids).to.deep.equal(['constructor-toolbar-injected', 'pdf-exporter-toolbar-injected']);
+    });
+
+    it('picks the longest matching context prefix for the markerId', function () {
+        document.body.innerHTML = dleHtml();
+        // Two extensions whose contexts both prefix the marker id; the longer, more specific one wins.
+        addInjectScripts('pdf-exporter', 'pdf-exporter-plus');
+        const order = window.GenericDleToolbarStarter
+            .create(cfg({ markerId: 'pdf-exporter-plus-toolbar-injected', order: 99 }));
+        order.injectToolbar({ alternate: true });
+        // 'pdf-exporter-plus' is at DOM index 1 → the button records order 1, not 0 (the shorter match).
+        expect(window.__genericDleToolbarOrder['pdf-exporter-plus-toolbar-injected']).to.equal(1);
     });
 
     it('injects the default button as a div above the rich-text area', function () {
@@ -243,6 +301,20 @@ describe('GenericDleToolbarStarter (dle-toolbar-starter.js)', function () {
         document.body.appendChild(document.createElement('span'));
         await flushObserver();
         expect(rafCallbacks.length).to.be.greaterThan(0); // observing body works
+    });
+
+    it('sets up no observer when neither the stable ancestor nor document.body exist', function () {
+        document.body.innerHTML = '';
+        // Both the ancestor selector and top.document.body resolve to nothing.
+        const realBody = document.body;
+        Object.defineProperty(document, 'body', { configurable: true, get: () => null });
+        try {
+            const starter = window.GenericDleToolbarStarter.create(cfg());
+            starter.injectToolbar({ alternate: true });
+            expect(reg['my-btn']).to.be.undefined; // no anchor → observer not installed
+        } finally {
+            Object.defineProperty(document, 'body', { configurable: true, get: () => realBody });
+        }
     });
 
     it('destroy() disconnects the observer and drops it from the registry', function () {
@@ -421,6 +493,36 @@ describe('GenericDleToolbarStarter (dle-toolbar-starter.js)', function () {
             const observer = window.__genericRpeAutoExpandObserver;
             window.GenericDleToolbarStarter.autoExpandRichPageTools();
             expect(window.__genericRpeAutoExpandObserver).to.equal(observer);
+        });
+
+        it('coalesces mutations across observer callbacks into a single expand check', async function () {
+            document.body.innerHTML = '';
+            window.GenericDleToolbarStarter.autoExpandRichPageTools();
+
+            // Two mutation bursts in separate observer callbacks, before the queued frame runs:
+            // the second callback must early-return on the `scheduled` guard, not queue a 2nd rAF.
+            document.body.appendChild(document.createElement('span'));
+            await flushObserver();                                  // callback 1 → schedules one rAF
+            document.body.appendChild(document.createElement('span'));
+            await flushObserver();                                  // callback 2 → scheduled → returns
+            expect(rafCallbacks.length).to.equal(1);
+        });
+
+        it('defers until the body exists when invoked from a head injection', function () {
+            // Simulate a script running before <body> is parsed: body is momentarily absent.
+            const realBody = document.body;
+            Object.defineProperty(document, 'body', { configurable: true, get: () => null });
+            try {
+                window.GenericDleToolbarStarter.autoExpandRichPageTools();
+            } finally {
+                Object.defineProperty(document, 'body', { configurable: true, get: () => realBody });
+            }
+            // The observer isn't observing yet; it starts on DOMContentLoaded.
+            realBody.innerHTML = rpeHtml({ toolbar: false, expandHandle: true });
+            const clicked = sinon.spy();
+            document.querySelector('.polarion-rpe-expandTools').addEventListener('click', clicked);
+            document.dispatchEvent(new window.Event('DOMContentLoaded'));
+            expect(clicked.calledOnce).to.be.true;
         });
     });
 


### PR DESCRIPTION
### Proposed changes

Closes #591

When several extensions each configure a single-tag DLE toolbar injector (`dle-toolbar.js`) in the same `scriptInjection.dleEditorHead`, their buttons reshuffled between page reloads instead of keeping the configured left-to-right order (e.g. PDF, DOCX, StrictDoc).

**Root cause:** each injector asynchronously loads its own `starter.js`, whose stub captured a sequence number only when it ran inside that `starter.js`'s `onload`. Those onloads fire in network-race order, so the captured `config.order` did not reflect the configured order.

**Fix:** the engine now derives each button's order from the DOM position of its extension's own inject script (`…/<ext>/js/{dle-toolbar,starter,live-reports}.js`). Polarion inserts those `<script>` tags in `scriptInjection` order and keeps their position stable, so it is a deterministic source; `config.order` remains the fallback when no matching inject script is found (deprecated inline config). The engine reads them from its own document (the DLE editor iframe for `dleEditor`, the top page for `richPagePreview`).

**No per-extension change needed** — consumers pick up the fix by bumping the generic version.

Verified at runtime on a local Polarion 2606 with pdf-exporter, docx-exporter and strictdoc-exporter injecting together: 15/15 reloads stable `PDF, DOCX, StrictDoc`, with docx/strictdoc only rebuilt against the new generic (their code untouched), proving the fix needs no consumer code change.

### Checklist

- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation