### PR TITLE
feat: move shared DLE toolbar CSS into generic, fix button symmetry

### DIFF
--- a/app/src/main/resources/css/dle-toolbar.css
+++ b/app/src/main/resources/css/dle-toolbar.css
@@ -1,0 +1,76 @@
+/*
+ * Shared styling for buttons injected into Polarion's native document (DLE) and Rich Page toolbars
+ * by the self-healing engine (dle-toolbar-starter.js). Previously each exporter extension shipped
+ * its own private copy of these rules; because the class names are global, those copies overrode
+ * each other in the same page. This is the single source of truth — the engine injects it, so every
+ * consumer inherits identical (and fixable-in-one-place) toolbar-button styling.
+ */
+
+.dleToolBarContainer {
+    width: fit-content;
+    height: 45px;
+    background-color: #f5f5f5;
+    z-index: 1;
+    position: absolute;
+    right: 0;
+    border-bottom: 1px solid #DEDEDE;
+    border-right: 1px solid #DEDEDE;
+    border-left: 1px solid #DEDEDE;
+    padding-left: 8px;
+    padding-right: 3px;
+    vertical-align: middle;
+    display: flex;
+}
+
+.dleToolBarTable {
+    align-self: center;
+    border-spacing: 0;
+}
+
+.dleToolBarRow {
+    display: table-row;
+    vertical-align: middle;
+}
+
+.dleToolBarTableCell {
+    padding: 0;
+}
+
+.dleToolBarButton {
+    cursor: pointer;
+    opacity: .6;
+}
+
+.dleToolBarButton:hover {
+    opacity: 1;
+}
+
+.dleToolBarSingleButton {
+    border: 1px solid #DEDEDE;
+    padding: 5px;
+    border-radius: 2px;
+}
+
+/* Only the default (above-the-editor) button needs a right margin. In the alternate toolbar-row
+   layout the button sits between two padded separators, so an extra right margin would make it
+   asymmetric (closer to the left separator than the right one). */
+.dleToolBarContainer .dleToolBarSingleButton {
+    margin-right: 5px;
+}
+
+.dleToolBarLeftButton {
+    border: 1px solid #DEDEDE;
+    padding: 5px;
+    border-top-left-radius: 2px;
+    border-bottom-left-radius: 2px;
+}
+
+.dleToolBarRightButton {
+    border-width: 1px 1px 1px 0px;
+    border-style: solid;
+    border-color: #DEDEDE;
+    padding: 5px;
+    border-top-right-radius: 2px;
+    border-bottom-right-radius: 2px;
+    margin-right: 5px;
+}

--- a/app/src/main/resources/css/dle-toolbar.css
+++ b/app/src/main/resources/css/dle-toolbar.css
@@ -51,13 +51,6 @@
     border-radius: 2px;
 }
 
-/* Only the default (above-the-editor) button needs a right margin. In the alternate toolbar-row
-   layout the button sits between two padded separators, so an extra right margin would make it
-   asymmetric (closer to the left separator than the right one). */
-.dleToolBarContainer .dleToolBarSingleButton {
-    margin-right: 5px;
-}
-
 .dleToolBarLeftButton {
     border: 1px solid #DEDEDE;
     padding: 5px;
@@ -72,5 +65,13 @@
     padding: 5px;
     border-top-right-radius: 2px;
     border-bottom-right-radius: 2px;
+}
+
+/* Only the default (above-the-editor) button needs a right margin (both the single button and the
+   right half of a left/right split pair). In the alternate toolbar-row layout the button sits
+   between two padded separators, so an extra right margin would make it asymmetric — closer to the
+   left separator than the right one. */
+.dleToolBarContainer .dleToolBarSingleButton,
+.dleToolBarContainer .dleToolBarRightButton {
     margin-right: 5px;
 }

--- a/app/src/main/resources/js/dle-toolbar-starter.js
+++ b/app/src/main/resources/js/dle-toolbar-starter.js
@@ -35,11 +35,13 @@
     }
 
     // Inject the shared toolbar-button stylesheet that ships next to this script
-    // (…/ui/generic/css/dle-toolbar.css). Deriving the href from this script's own URL keeps the
-    // /polarion/<ext>/ context out of the code; idempotent via the fixed id, so loading the engine
-    // from several extensions injects it once.
-    function injectOwnStyles() {
-        const selfSrc = (document.currentScript && document.currentScript.src) || '';
+    // (…/ui/generic/css/dle-toolbar.css). The engine URL is taken from `scriptUrl` when given,
+    // otherwise from this script's own URL — available only while the script is executing
+    // (document.currentScript), which is the on-load self-inject path. A later caller (or a test)
+    // that no longer has currentScript passes the URL explicitly. Deriving the href keeps the
+    // /polarion/<ext>/ context out of the code; idempotent via the fixed id.
+    function injectOwnStyles(scriptUrl) {
+        const selfSrc = scriptUrl || (document.currentScript && document.currentScript.src) || '';
         const href = selfSrc.replace(/js\/dle-toolbar-starter\.js.*$/, 'css/dle-toolbar.css');
         if (href && href !== selfSrc) {
             injectStyles('generic-dle-toolbar-styles', href);

--- a/app/src/main/resources/js/dle-toolbar-starter.js
+++ b/app/src/main/resources/js/dle-toolbar-starter.js
@@ -34,6 +34,18 @@
         }
     }
 
+    // Inject the shared toolbar-button stylesheet that ships next to this script
+    // (…/ui/generic/css/dle-toolbar.css). Deriving the href from this script's own URL keeps the
+    // /polarion/<ext>/ context out of the code; idempotent via the fixed id, so loading the engine
+    // from several extensions injects it once.
+    function injectOwnStyles() {
+        const selfSrc = (document.currentScript && document.currentScript.src) || '';
+        const href = selfSrc.replace(/js\/dle-toolbar-starter\.js.*$/, 'css/dle-toolbar.css');
+        if (href && href !== selfSrc) {
+            injectStyles('generic-dle-toolbar-styles', href);
+        }
+    }
+
     function injectScript(id, src, type = "text/javascript") {
         if (!top.document.getElementById(id)) {
             const script = top.document.createElement("script");
@@ -147,6 +159,7 @@
     window.GenericDleToolbarStarter = {
         injectStyles: injectStyles,
         injectScript: injectScript,
+        injectOwnStyles: injectOwnStyles,
 
         /**
          * @param config {{ markerId: string, alternateHtml: string, defaultHtml: string, target: string|undefined, order: number|undefined }}
@@ -329,4 +342,8 @@
             }
         }
     };
+
+    // Ship the shared toolbar-button styles the moment the engine loads (currentScript is still
+    // available here), so consumers don't each carry their own copy of the CSS.
+    injectOwnStyles();
 })();

--- a/app/src/test/js/modules/dleToolbarStarterTest.js
+++ b/app/src/test/js/modules/dleToolbarStarterTest.js
@@ -526,6 +526,26 @@ describe('GenericDleToolbarStarter (dle-toolbar-starter.js)', function () {
         });
     });
 
+    it('injectOwnStyles injects the shared toolbar stylesheet derived from its own script URL', function () {
+        const fakeScript = { src: 'http://x/polarion/pdf-exporter/ui/generic/js/dle-toolbar-starter.js?timestamp=1' };
+        Object.defineProperty(document, 'currentScript', { configurable: true, get: () => fakeScript });
+        try {
+            window.GenericDleToolbarStarter.injectOwnStyles();
+        } finally {
+            Object.defineProperty(document, 'currentScript', { configurable: true, get: () => null });
+        }
+        const link = document.getElementById('generic-dle-toolbar-styles');
+        expect(link).to.exist;
+        expect(link.tagName).to.equal('LINK');
+        expect(link.href).to.contain('/polarion/pdf-exporter/ui/generic/css/dle-toolbar.css');
+    });
+
+    it('injectOwnStyles is a no-op when the script URL cannot be resolved', function () {
+        Object.defineProperty(document, 'currentScript', { configurable: true, get: () => null });
+        window.GenericDleToolbarStarter.injectOwnStyles();
+        expect(document.getElementById('generic-dle-toolbar-styles')).to.equal(null);
+    });
+
     it('injectStyles adds a stylesheet link once and injectScript adds a script once', function () {
         window.GenericDleToolbarStarter.injectStyles('sbb-css', '/x.css');
         window.GenericDleToolbarStarter.injectStyles('sbb-css', '/x.css'); // idempotent

--- a/app/src/test/js/modules/dleToolbarStarterTest.js
+++ b/app/src/test/js/modules/dleToolbarStarterTest.js
@@ -526,24 +526,40 @@ describe('GenericDleToolbarStarter (dle-toolbar-starter.js)', function () {
         });
     });
 
-    it('injectOwnStyles injects the shared toolbar stylesheet derived from its own script URL', function () {
-        const fakeScript = { src: 'http://x/polarion/pdf-exporter/ui/generic/js/dle-toolbar-starter.js?timestamp=1' };
-        Object.defineProperty(document, 'currentScript', { configurable: true, get: () => fakeScript });
-        try {
-            window.GenericDleToolbarStarter.injectOwnStyles();
-        } finally {
-            Object.defineProperty(document, 'currentScript', { configurable: true, get: () => null });
-        }
+    it('injectOwnStyles injects the shared toolbar stylesheet derived from the given script URL', function () {
+        window.GenericDleToolbarStarter.injectOwnStyles('http://x/polarion/pdf-exporter/ui/generic/js/dle-toolbar-starter.js?timestamp=1');
         const link = document.getElementById('generic-dle-toolbar-styles');
         expect(link).to.exist;
         expect(link.tagName).to.equal('LINK');
         expect(link.href).to.contain('/polarion/pdf-exporter/ui/generic/css/dle-toolbar.css');
     });
 
-    it('injectOwnStyles is a no-op when the script URL cannot be resolved', function () {
-        Object.defineProperty(document, 'currentScript', { configurable: true, get: () => null });
+    it('injectOwnStyles is a no-op when no script URL is given and currentScript is unavailable', function () {
+        // In this ESM test document.currentScript is null, and no explicit URL is passed.
         window.GenericDleToolbarStarter.injectOwnStyles();
         expect(document.getElementById('generic-dle-toolbar-styles')).to.equal(null);
+    });
+
+    it('injectOwnStyles falls back to document.currentScript on the on-load path', function () {
+        // The on-load self-inject path (no explicit URL) reads document.currentScript. Mock it and
+        // restore the original property descriptor so no state leaks into other tests.
+        const original = Object.getOwnPropertyDescriptor(document, 'currentScript');
+        Object.defineProperty(document, 'currentScript', {
+            configurable: true,
+            get: () => ({ src: 'http://x/polarion/docx-exporter/ui/generic/js/dle-toolbar-starter.js?timestamp=1' })
+        });
+        try {
+            window.GenericDleToolbarStarter.injectOwnStyles();
+        } finally {
+            if (original) {
+                Object.defineProperty(document, 'currentScript', original);
+            } else {
+                delete document.currentScript;
+            }
+        }
+        const link = document.getElementById('generic-dle-toolbar-styles');
+        expect(link).to.exist;
+        expect(link.href).to.contain('/polarion/docx-exporter/ui/generic/css/dle-toolbar.css');
     });
 
     it('injectStyles adds a stylesheet link once and injectScript adds a script once', function () {


### PR DESCRIPTION
### Proposed changes

Closes #593

The `.dleToolBar*` toolbar-button styles were duplicated in every exporter's CSS. Because the class names are global, those copies overrode each other in the same page — a fix in one extension was undone by another extension's still-old copy (e.g. an alternate button kept its `margin-right` from a sibling extension, so it sat closer to its left separator than its right one).

This moves the shared rules into generic (`css/dle-toolbar.css`) and has the toolbar engine inject them from its own URL on load (idempotent — loading the engine from several extensions injects the stylesheet once). The right margin that only the default above-the-editor button needs is scoped to `.dleToolBarContainer`, so alternate toolbar-row buttons are symmetric between their separators.

**No per-extension change is required to get the fix** — consumers inherit the CSS by bumping the generic version; they can then drop their now-dead private `.dleToolBar*` copy in a follow-up.

`injectOwnStyles` is also exposed on the public API for testability/reuse (alongside `injectStyles`/`injectScript`).

Verified at runtime on a local Polarion 2606 with pdf/docx/strictdoc injecting together: all three live-doc buttons are symmetric (equal 8px gaps to both separators, `margin-right: 0`), with docx/strictdoc only rebuilt against the new generic (their private CSS copies removed, no other change). Engine JS coverage is 100%.

### Checklist

- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation