### PR TITLE
feat: support disabling injected toolbar buttons (permission-gated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -801,7 +801,11 @@ of writing the injection logic in every extension. The engine knows the toolbar 
 user clicks *Save* — so the button does not disappear (a one-time injection otherwise would).
 
 The engine is served to each extension at `/polarion/<extension>/ui/generic/js/dle-toolbar-starter.js`
-and exposes `window.GenericDleToolbarStarter.create({ markerId, alternateHtml, defaultHtml, order })`.
+and exposes `window.GenericDleToolbarStarter.create({ markerId, alternateHtml, defaultHtml, target,
+order, permissionCheckUrl, permissionCheck })`, which returns `{ injectToolbar, setDisabled, destroy }`.
+The same engine also drives the **Live Report** (Rich Page) toolbar — pass `target: 'richPagePreview'`
+(see below); everything here, including disabling, works for both toolbars. It also injects the shared
+toolbar-button stylesheet (`css/dle-toolbar.css`) itself, so you don't ship those `.dleToolBar*` rules.
 
 Add a thin `starter.js` to your extension's webapp that supplies only the extension-specific parts
 (button markup, a unique `markerId`, any css/js the button needs) and bootstraps the engine:
@@ -876,3 +880,52 @@ To change the order, reorder the `injectToolbar` lines in `dleEditorHead`. Note 
 **distinct** `order` values: buttons that share the same `order` (including any caller that omits it — it
 defaults to `0`) tie-break by observer-fire order, i.e. non-deterministically, exactly as before this
 mechanism existed.
+
+#### Disabling the button (permission-gated actions)
+
+When the button's action isn't always available — e.g. the user isn't permitted to export — inject it
+**disabled** instead of clickable. The disabled state is kept by the engine and re-applied on every
+self-healing re-injection (so it survives toolbar re-renders), and the click is blocked via a
+`pointer-events: none` class regardless of the `onclick` baked into your button markup. This works the
+same for the Live Doc (`dleEditor`) and Live Report (`richPagePreview`) toolbars.
+
+There are two ways to use it.
+
+**1. Let the engine run a global permission check.** Pass either a URL or a function to `create(...)`:
+
+```js
+// The engine GETs the URL and expects JSON { "permitted": boolean }.
+// permitted !== true, a non-OK HTTP status, or an error → the button stays disabled (fail-closed).
+generic.create({
+    markerId: 'my-extension-toolbar-injected',
+    alternateHtml: ALTERNATE_TOOLBAR_HTML,
+    defaultHtml: TOOLBAR_HTML,
+    permissionCheckUrl: '/polarion/my-extension/rest/internal/permissions/export'
+}).injectToolbar({ alternate: true });
+
+// ...or run the check yourself (custom headers, your own REST wrapper, extra context):
+generic.create({
+    markerId: 'my-extension-toolbar-injected',
+    alternateHtml: ALTERNATE_TOOLBAR_HTML,
+    defaultHtml: TOOLBAR_HTML,
+    permissionCheck: () => ctx.callAsync({ method: 'GET', url: '…' }).then(r => r.response.permitted)
+}).injectToolbar({ alternate: true });
+```
+
+While the check is pending the button is shown **disabled**, so it never flickers enabled→disabled;
+it becomes clickable only once the check confirms access. `permissionCheck` (a function returning
+`boolean | Promise<boolean>`) takes precedence over `permissionCheckUrl` if both are given. If neither
+is configured the button is enabled, as before.
+
+**2. Toggle it yourself.** `create(...)` returns a `setDisabled(bool)` method, and `injectToolbar`
+accepts a `disabled` flag — use these if you resolve the permission on your own schedule:
+
+```js
+const starter = generic.create({ markerId: '…', alternateHtml: ALTERNATE_TOOLBAR_HTML, defaultHtml: TOOLBAR_HTML });
+starter.injectToolbar({ alternate: true, disabled: true });   // start disabled
+myPermissionCheck().then(allowed => starter.setDisabled(!allowed));   // enable/disable later
+```
+
+The backend endpoint (or whatever decides *whether* the action is permitted) is owned by your
+extension; the engine only renders and preserves the disabled look. The disabled styling lives in the
+shared `css/dle-toolbar.css` as `.dleToolBarDisabled`.

--- a/README.md
+++ b/README.md
@@ -891,16 +891,20 @@ same for the Live Doc (`dleEditor`) and Live Report (`richPagePreview`) toolbars
 
 There are two ways to use it.
 
-**1. Let the engine run a global permission check.** Pass either a URL or a function to `create(...)`:
+**1. Let the engine run a permission check.** Pass either a URL or a function to `create(...)`. The
+engine treats the result as a plain boolean; **any context the check needs (project, document, …) is
+the extension's to supply** — the engine doesn't parse the page or know about projects. The extension
+knows the context (e.g. from its own `ExportContext`) and bakes it into the URL or the function:
 
 ```js
 // The engine GETs the URL and expects JSON { "permitted": boolean }.
 // permitted !== true, a non-OK HTTP status, or an error → the button stays disabled (fail-closed).
+// Build the URL with whatever the check is scoped to — here a project-level permission:
 window.GenericDleToolbarStarter.create({
     markerId: 'my-extension-toolbar-injected',
     alternateHtml: ALTERNATE_TOOLBAR_HTML,
     defaultHtml: TOOLBAR_HTML,
-    permissionCheckUrl: '/polarion/my-extension/rest/internal/permissions/export'
+    permissionCheckUrl: `/polarion/my-extension/rest/internal/permissions/export?projectId=${ctx.getProjectId()}`
 }).injectToolbar({ alternate: true });
 
 // ...or run the check yourself (custom headers, your own REST wrapper, extra context):
@@ -908,7 +912,10 @@ window.GenericDleToolbarStarter.create({
     markerId: 'my-extension-toolbar-injected',
     alternateHtml: ALTERNATE_TOOLBAR_HTML,
     defaultHtml: TOOLBAR_HTML,
-    permissionCheck: () => ctx.callAsync({ method: 'GET', url: '…' }).then(r => r.response.permitted)
+    permissionCheck: () => ctx.callAsync({
+        method: 'GET',
+        url: `/polarion/my-extension/rest/internal/permissions/export?projectId=${ctx.getProjectId()}`
+    }).then(r => r.response.permitted)
 }).injectToolbar({ alternate: true });
 ```
 

--- a/README.md
+++ b/README.md
@@ -896,7 +896,7 @@ There are two ways to use it.
 ```js
 // The engine GETs the URL and expects JSON { "permitted": boolean }.
 // permitted !== true, a non-OK HTTP status, or an error → the button stays disabled (fail-closed).
-generic.create({
+window.GenericDleToolbarStarter.create({
     markerId: 'my-extension-toolbar-injected',
     alternateHtml: ALTERNATE_TOOLBAR_HTML,
     defaultHtml: TOOLBAR_HTML,
@@ -904,7 +904,7 @@ generic.create({
 }).injectToolbar({ alternate: true });
 
 // ...or run the check yourself (custom headers, your own REST wrapper, extra context):
-generic.create({
+window.GenericDleToolbarStarter.create({
     markerId: 'my-extension-toolbar-injected',
     alternateHtml: ALTERNATE_TOOLBAR_HTML,
     defaultHtml: TOOLBAR_HTML,
@@ -921,7 +921,7 @@ is configured the button is enabled, as before.
 accepts a `disabled` flag — use these if you resolve the permission on your own schedule:
 
 ```js
-const starter = generic.create({ markerId: '…', alternateHtml: ALTERNATE_TOOLBAR_HTML, defaultHtml: TOOLBAR_HTML });
+const starter = window.GenericDleToolbarStarter.create({ markerId: '…', alternateHtml: ALTERNATE_TOOLBAR_HTML, defaultHtml: TOOLBAR_HTML });
 starter.injectToolbar({ alternate: true, disabled: true });   // start disabled
 myPermissionCheck().then(allowed => starter.setDisabled(!allowed));   // enable/disable later
 ```

--- a/app/src/main/resources/css/dle-toolbar.css
+++ b/app/src/main/resources/css/dle-toolbar.css
@@ -75,3 +75,12 @@
 .dleToolBarContainer .dleToolBarRightButton {
     margin-right: 5px;
 }
+
+/* Disabled state (e.g. when the user is not permitted to export). The engine adds this class to
+   the injected container; pointer-events: none blocks the click regardless of the onclick baked
+   into the button markup, and the faded look matches Polarion's own disabled toolbar buttons. */
+.dleToolBarDisabled {
+    opacity: .4;
+    pointer-events: none;
+    cursor: default;
+}

--- a/app/src/main/resources/js/dle-toolbar-starter.js
+++ b/app/src/main/resources/js/dle-toolbar-starter.js
@@ -164,20 +164,33 @@
         injectOwnStyles: injectOwnStyles,
 
         /**
-         * @param config {{ markerId: string, alternateHtml: string, defaultHtml: string, target: string|undefined, order: number|undefined }}
+         * @param config {{ markerId: string, alternateHtml: string, defaultHtml: string, target: string|undefined, order: number|undefined, permissionCheckUrl: string|undefined, permissionCheck: function|undefined }}
          *   markerId      unique id set on the injected element; also the idempotency/dedup key.
          *   alternateHtml markup injected into the toolbar row when injectToolbar({alternate: true}).
          *   defaultHtml   markup injected above the rich-text area otherwise ('dleEditor' target only).
          *   target        which Polarion toolbar to inject into: 'dleEditor' (default) or
-         *                 'richPagePreview'. The 'richPagePreview' target always injects into the
-         *                 toolbar row (alternateHtml), regardless of the alternate flag, and only
-         *                 while the page is in view (preview) mode.
+         *                 'richPagePreview' (works for the Live Report toolbar too). The
+         *                 'richPagePreview' target always injects into the toolbar row
+         *                 (alternateHtml), regardless of the alternate flag, and only while the page
+         *                 is in view (preview) mode.
+         *   permissionCheckUrl  optional: a URL the engine GETs to decide if the button is enabled.
+         *                 Expected JSON response { permitted: boolean }; permitted !== true (or a
+         *                 non-OK status / error) disables the button (fail-closed). Works for both
+         *                 targets (Live Doc and Live Report).
+         *   permissionCheck     optional: a function returning boolean|Promise<boolean>, used
+         *                 instead of permissionCheckUrl when given (e.g. to run the extension's own
+         *                 REST wrapper). While either check is pending the button is shown disabled.
          *
          *   SECURITY: alternateHtml / defaultHtml are written via innerHTML into the top Polarion
          *   frame, so they MUST be static, trusted markup. Never interpolate user-controlled data
          *   (document fields, work-item attributes, ...) into them without sanitizing it first.
          *
-         * @returns {{ injectToolbar: function, destroy: function }}
+         * @returns {{ injectToolbar: function, setDisabled: function, destroy: function }}
+         *   injectToolbar(params)  params.alternate → row injection; params.disabled → inject
+         *                          disabled. The latest params are re-used by the self-healing
+         *                          re-inject, so the disabled state survives toolbar re-renders.
+         *   setDisabled(bool)      toggle the disabled state on the live button and for future
+         *                          re-injects (call it when an async permission result arrives).
          */
         create: function (config) {
             const target = TARGETS[config.target || 'dleEditor'];
@@ -195,6 +208,37 @@
             const myOrder = domOrder(config.markerId, fallbackOrder);
             const orderByMarker = top.__genericDleToolbarOrder || (top.__genericDleToolbarOrder = {});
             orderByMarker[config.markerId] = myOrder;
+
+            // Toggle the disabled look/behavior on an injected container: the dleToolBarDisabled
+            // class (pointer-events: none) blocks the click regardless of the onclick baked into the
+            // button markup. Applied on every (re-)inject and by setDisabled() on the live element.
+            function applyDisabled(container, disabled) {
+                if (!container) {
+                    return;
+                }
+                if (disabled) {
+                    container.classList.add('dleToolBarDisabled');
+                    container.setAttribute('aria-disabled', 'true');
+                } else {
+                    container.classList.remove('dleToolBarDisabled');
+                    container.removeAttribute('aria-disabled');
+                }
+            }
+
+            // Optional engine-driven global permission check: permissionCheck (a function returning
+            // boolean|Promise<boolean>) takes precedence over permissionCheckUrl (GET → JSON
+            // { permitted: boolean }). Resolves to whether the button is permitted (enabled).
+            const hasPermissionCheck = !!(config.permissionCheck || config.permissionCheckUrl);
+            let permissionCheckStarted = false;
+
+            function runPermissionCheck() {
+                if (config.permissionCheck) {
+                    return Promise.resolve().then(config.permissionCheck);
+                }
+                return fetch(config.permissionCheckUrl, { credentials: 'same-origin' })
+                    .then(response => response.ok ? response.json() : { permitted: false })
+                    .then(data => !!(data && data.permitted));
+            }
 
             // Idempotent: only inject if the toolbar exists and our button isn't already there.
             function inject(params) {
@@ -214,6 +258,7 @@
                     // so injected buttons line up with the native ones.
                     toolbarContainer.style.verticalAlign = 'middle';
                     toolbarContainer.innerHTML = config.alternateHtml;
+                    applyDisabled(toolbarContainer, params && params.disabled);
                     const spacer = toolbarParent.querySelector('td[width="100%"]');
                     if (!spacer) {
                         // Polarion DOM changed (e.g. after an upgrade) — fall back to appending at the
@@ -241,6 +286,7 @@
                     toolbarContainer.classList.add("dleToolBarContainer");
                     toolbarContainer.style.marginRight = "14px";
                     toolbarContainer.innerHTML = config.defaultHtml;
+                    applyDisabled(toolbarContainer, params && params.disabled);
                     documentFrame.parentNode.parentNode.prepend(toolbarContainer);
                 }
             }
@@ -249,10 +295,30 @@
             // The observer re-injects with the params of the latest injectToolbar() call.
             let lastParams;
 
+            // Toggle the button's disabled state on the live element and for future (re-)injects.
+            function setDisabled(disabled) {
+                lastParams = Object.assign({}, lastParams, { disabled: disabled });
+                applyDisabled(top.document.getElementById(config.markerId), disabled);
+            }
+
             return {
                 injectToolbar: function (params) {
+                    // When a permission check is configured, inject disabled first (no
+                    // enabled→disabled flicker) and resolve the real state asynchronously.
+                    if (hasPermissionCheck && !permissionCheckStarted) {
+                        params = Object.assign({}, params, { disabled: true });
+                    }
                     lastParams = params;
                     inject(params);
+
+                    // Kick off the global permission check once; on error keep it disabled
+                    // (fail-closed — a check that can't confirm access denies it).
+                    if (hasPermissionCheck && !permissionCheckStarted) {
+                        permissionCheckStarted = true;
+                        runPermissionCheck()
+                            .then(permitted => setDisabled(!permitted))
+                            .catch(() => setDisabled(true));
+                    }
 
                     // Set up the self-healing observer once per starter instance.
                     if (observerSetUp) {
@@ -284,6 +350,8 @@
                     observerRegistry[config.markerId] = observer;
                     observer.observe(anchor, { childList: true, subtree: true });
                 },
+
+                setDisabled: setDisabled,
 
                 // Stop self-healing and release the observer (for callers that have a teardown hook).
                 destroy: function () {

--- a/app/src/main/resources/js/dle-toolbar-starter.js
+++ b/app/src/main/resources/js/dle-toolbar-starter.js
@@ -58,6 +58,57 @@
         }
     }
 
+    // Capture-phase click swallower for the disabled state: pointer-events: none already blocks the
+    // mouse; this additionally stops a keyboard- or script-triggered click from reaching the
+    // button's baked-in onclick. Module-level (stateless) so a single shared reference add/removes
+    // consistently on ANY element — including a stale panel's button kept across an SPA navigation,
+    // whose listener a later enable must be able to clear regardless of which starter instance runs.
+    function blockClick(event) {
+        event.stopPropagation();
+        event.preventDefault();
+    }
+
+    // Toggle the disabled look/behavior on an injected container and its inner interactive elements:
+    // the dleToolBarDisabled class fades it and blocks the mouse (pointer-events: none, an inherited
+    // property, so it reaches descendants too); the capture-phase blocker covers keyboard/scripted
+    // clicks; aria-disabled + tabindex=-1 on inner [role=button]/button/a announce the disabled state
+    // to assistive tech and drop it from the tab order. So the click is stopped regardless of the
+    // onclick baked into the button markup.
+    function applyDisabled(container, disabled) {
+        if (!container) {
+            return;
+        }
+        container.removeEventListener('click', blockClick, true);
+        const interactive = container.querySelectorAll('[role="button"], button, a');
+        if (disabled) {
+            container.classList.add('dleToolBarDisabled');
+            container.setAttribute('aria-disabled', 'true');
+            container.addEventListener('click', blockClick, true);
+            interactive.forEach(el => {
+                el.setAttribute('aria-disabled', 'true');
+                if (!el.hasAttribute('data-generic-prev-tabindex')) {
+                    el.setAttribute('data-generic-prev-tabindex', el.getAttribute('tabindex') || '');
+                }
+                el.setAttribute('tabindex', '-1');
+            });
+        } else {
+            container.classList.remove('dleToolBarDisabled');
+            container.removeAttribute('aria-disabled');
+            interactive.forEach(el => {
+                el.removeAttribute('aria-disabled');
+                if (el.hasAttribute('data-generic-prev-tabindex')) {
+                    const prev = el.getAttribute('data-generic-prev-tabindex');
+                    el.removeAttribute('data-generic-prev-tabindex');
+                    if (prev === '') {
+                        el.removeAttribute('tabindex');
+                    } else {
+                        el.setAttribute('tabindex', prev);
+                    }
+                }
+            });
+        }
+    }
+
     // GWT shows/hides widgets with inline styles; a widget is effectively hidden when it or any
     // ancestor carries inline display:none / visibility:hidden (e.g. a stale Rich Page panel kept
     // in the DOM during an SPA transition).
@@ -209,34 +260,6 @@
             const orderByMarker = top.__genericDleToolbarOrder || (top.__genericDleToolbarOrder = {});
             orderByMarker[config.markerId] = myOrder;
 
-            // Capture-phase click swallower for the disabled state: pointer-events: none already
-            // blocks the mouse, and this additionally stops a keyboard- or script-triggered click
-            // from reaching the button's baked-in onclick. Stable reference so it can be removed.
-            function blockClick(event) {
-                event.stopPropagation();
-                event.preventDefault();
-            }
-
-            // Toggle the disabled look/behavior on an injected container: the dleToolBarDisabled
-            // class fades it and blocks the mouse (pointer-events: none), aria-disabled announces it,
-            // and the capture-phase blocker covers keyboard/programmatic clicks — so the click is
-            // stopped regardless of the onclick baked into the button markup. Applied on every
-            // (re-)inject and by setDisabled() on the live element.
-            function applyDisabled(container, disabled) {
-                if (!container) {
-                    return;
-                }
-                container.removeEventListener('click', blockClick, true);
-                if (disabled) {
-                    container.classList.add('dleToolBarDisabled');
-                    container.setAttribute('aria-disabled', 'true');
-                    container.addEventListener('click', blockClick, true);
-                } else {
-                    container.classList.remove('dleToolBarDisabled');
-                    container.removeAttribute('aria-disabled');
-                }
-            }
-
             // Optional engine-driven global permission check: permissionCheck (a function returning
             // boolean|Promise<boolean>) takes precedence over permissionCheckUrl (GET → JSON
             // { permitted: boolean }). Resolves to whether the button is permitted (enabled).
@@ -377,6 +400,9 @@
                         observerRegistry[config.markerId].disconnect();
                         delete observerRegistry[config.markerId];
                     }
+                    // Clear the disabled state (and its capture-phase click blocker) from our
+                    // element so a torn-down button left in the DOM doesn't keep swallowing clicks.
+                    applyDisabled(top.document.getElementById(config.markerId), false);
                     observerSetUp = false;
                 }
             };

--- a/app/src/main/resources/js/dle-toolbar-starter.js
+++ b/app/src/main/resources/js/dle-toolbar-starter.js
@@ -69,11 +69,12 @@
     }
 
     // Toggle the disabled look/behavior on an injected container and its inner interactive elements:
-    // the dleToolBarDisabled class fades it and blocks the mouse (pointer-events: none, an inherited
-    // property, so it reaches descendants too); the capture-phase blocker covers keyboard/scripted
-    // clicks; aria-disabled + tabindex=-1 on inner [role=button]/button/a announce the disabled state
-    // to assistive tech and drop it from the tab order. So the click is stopped regardless of the
-    // onclick baked into the button markup.
+    // the dleToolBarDisabled class fades it and makes the container non-hit-testable to the mouse
+    // (pointer-events: none), so a mouse click can't reach the button; the capture-phase blocker
+    // covers keyboard- and script-triggered clicks (which bypass pointer-events); aria-disabled +
+    // tabindex=-1 on inner [role=button]/button/a announce the disabled state to assistive tech and
+    // drop it from the tab order. So the click is stopped regardless of the onclick baked into the
+    // button markup.
     function applyDisabled(container, disabled) {
         if (!container) {
             return;
@@ -330,6 +331,7 @@
             }
 
             let observerSetUp = false;
+            let destroyed = false;
             // The observer re-injects with the params of the latest injectToolbar() call.
             let lastParams;
 
@@ -357,8 +359,8 @@
                     if (hasPermissionCheck && !permissionCheckStarted) {
                         permissionCheckStarted = true;
                         runPermissionCheck()
-                            .then(permitted => setDisabled(!permitted))
-                            .catch(() => setDisabled(true));
+                            .then(permitted => { if (!destroyed) setDisabled(!permitted); })
+                            .catch(() => { if (!destroyed) setDisabled(true); });
                     }
 
                     // Set up the self-healing observer once per starter instance.
@@ -384,7 +386,7 @@
                         });
                     });
                     // Disconnect any observer left over from a previous editor open for this markerId
-                    // so observers don't accumulate across the SPA's editor open/close cycles.
+                    // so observers don't accumulate across editor open/close cycles.
                     if (observerRegistry[config.markerId]) {
                         observerRegistry[config.markerId].disconnect();
                     }
@@ -396,6 +398,9 @@
 
                 // Stop self-healing and release the observer (for callers that have a teardown hook).
                 destroy: function () {
+                    // Mark destroyed so a still-pending permission check doesn't apply its result
+                    // (setDisabled) after teardown.
+                    destroyed = true;
                     if (observerRegistry[config.markerId]) {
                         observerRegistry[config.markerId].disconnect();
                         delete observerRegistry[config.markerId];

--- a/app/src/main/resources/js/dle-toolbar-starter.js
+++ b/app/src/main/resources/js/dle-toolbar-starter.js
@@ -86,27 +86,39 @@
             container.setAttribute('aria-disabled', 'true');
             container.addEventListener('click', blockClick, true);
             interactive.forEach(el => {
-                el.setAttribute('aria-disabled', 'true');
+                // Remember the element's own aria-disabled / tabindex (if any) so re-enabling
+                // restores the markup's values instead of clobbering them.
+                if (!el.hasAttribute('data-generic-prev-aria-disabled')) {
+                    el.setAttribute('data-generic-prev-aria-disabled', el.getAttribute('aria-disabled') || '');
+                }
                 if (!el.hasAttribute('data-generic-prev-tabindex')) {
                     el.setAttribute('data-generic-prev-tabindex', el.getAttribute('tabindex') || '');
                 }
+                el.setAttribute('aria-disabled', 'true');
                 el.setAttribute('tabindex', '-1');
             });
         } else {
             container.classList.remove('dleToolBarDisabled');
             container.removeAttribute('aria-disabled');
             interactive.forEach(el => {
-                el.removeAttribute('aria-disabled');
-                if (el.hasAttribute('data-generic-prev-tabindex')) {
-                    const prev = el.getAttribute('data-generic-prev-tabindex');
-                    el.removeAttribute('data-generic-prev-tabindex');
-                    if (prev === '') {
-                        el.removeAttribute('tabindex');
-                    } else {
-                        el.setAttribute('tabindex', prev);
-                    }
-                }
+                restoreAttr(el, 'aria-disabled', 'data-generic-prev-aria-disabled');
+                restoreAttr(el, 'tabindex', 'data-generic-prev-tabindex');
             });
+        }
+    }
+
+    // Restore an attribute the engine overrode from its saved-original data attribute: put back the
+    // original value, or remove the attribute if it had none originally. No-op if nothing was saved.
+    function restoreAttr(el, attr, savedAttr) {
+        if (!el.hasAttribute(savedAttr)) {
+            return;
+        }
+        const prev = el.getAttribute(savedAttr);
+        el.removeAttribute(savedAttr);
+        if (prev === '') {
+            el.removeAttribute(attr);
+        } else {
+            el.setAttribute(attr, prev);
         }
     }
 

--- a/app/src/main/resources/js/dle-toolbar-starter.js
+++ b/app/src/main/resources/js/dle-toolbar-starter.js
@@ -335,8 +335,20 @@
             // The observer re-injects with the params of the latest injectToolbar() call.
             let lastParams;
 
+            // Claim ownership of this markerId. If a newer starter is created for the same markerId
+            // (e.g. two create() calls in one context), the older one becomes "superseded" and its
+            // async callbacks (a late permission result) must not touch the shared button — the newer
+            // owner is the source of truth. Prevents a stale instance from overwriting current state.
+            const instanceToken = {};
+            const ownerRegistry = top.__genericDleToolbarOwners || (top.__genericDleToolbarOwners = {});
+            ownerRegistry[config.markerId] = instanceToken;
+            const isCurrentOwner = () => ownerRegistry[config.markerId] === instanceToken;
+
             // Toggle the button's disabled state on the live element and for future (re-)injects.
             function setDisabled(disabled) {
+                if (!isCurrentOwner()) {
+                    return; // a newer starter instance owns this markerId — don't fight it
+                }
                 lastParams = Object.assign({}, lastParams, { disabled: disabled });
                 applyDisabled(top.document.getElementById(config.markerId), disabled);
             }

--- a/app/src/main/resources/js/dle-toolbar-starter.js
+++ b/app/src/main/resources/js/dle-toolbar-starter.js
@@ -209,16 +209,28 @@
             const orderByMarker = top.__genericDleToolbarOrder || (top.__genericDleToolbarOrder = {});
             orderByMarker[config.markerId] = myOrder;
 
+            // Capture-phase click swallower for the disabled state: pointer-events: none already
+            // blocks the mouse, and this additionally stops a keyboard- or script-triggered click
+            // from reaching the button's baked-in onclick. Stable reference so it can be removed.
+            function blockClick(event) {
+                event.stopPropagation();
+                event.preventDefault();
+            }
+
             // Toggle the disabled look/behavior on an injected container: the dleToolBarDisabled
-            // class (pointer-events: none) blocks the click regardless of the onclick baked into the
-            // button markup. Applied on every (re-)inject and by setDisabled() on the live element.
+            // class fades it and blocks the mouse (pointer-events: none), aria-disabled announces it,
+            // and the capture-phase blocker covers keyboard/programmatic clicks — so the click is
+            // stopped regardless of the onclick baked into the button markup. Applied on every
+            // (re-)inject and by setDisabled() on the live element.
             function applyDisabled(container, disabled) {
                 if (!container) {
                     return;
                 }
+                container.removeEventListener('click', blockClick, true);
                 if (disabled) {
                     container.classList.add('dleToolBarDisabled');
                     container.setAttribute('aria-disabled', 'true');
+                    container.addEventListener('click', blockClick, true);
                 } else {
                     container.classList.remove('dleToolBarDisabled');
                     container.removeAttribute('aria-disabled');
@@ -235,7 +247,10 @@
                 if (config.permissionCheck) {
                     return Promise.resolve().then(config.permissionCheck);
                 }
-                return fetch(config.permissionCheckUrl, { credentials: 'same-origin' })
+                // Wrap fetch in a promise so even a synchronous throw (e.g. fetch unavailable) turns
+                // into a rejection handled by the caller's .catch → fail-closed.
+                return Promise.resolve()
+                    .then(() => fetch(config.permissionCheckUrl, { credentials: 'same-origin' }))
                     .then(response => response.ok ? response.json() : { permitted: false })
                     .then(data => !!(data && data.permitted));
             }
@@ -308,8 +323,11 @@
                     if (hasPermissionCheck && !permissionCheckStarted) {
                         params = Object.assign({}, params, { disabled: true });
                     }
-                    lastParams = params;
-                    inject(params);
+                    // Merge onto the previous params (don't replace) so a disabled state set via
+                    // setDisabled() or the pending permission check isn't dropped by a later
+                    // injectToolbar() that omits `disabled`. Self-heal re-injects with the merged set.
+                    lastParams = Object.assign({}, lastParams, params);
+                    inject(lastParams);
 
                     // Kick off the global permission check once; on error keep it disabled
                     // (fail-closed — a check that can't confirm access denies it).

--- a/app/src/test/js/modules/dleToolbarStarterTest.js
+++ b/app/src/test/js/modules/dleToolbarStarterTest.js
@@ -267,6 +267,142 @@ describe('GenericDleToolbarStarter (dle-toolbar-starter.js)', function () {
         expect(document.getElementById('my-btn')).to.equal(null);
     });
 
+    describe('disabled state & permission check', function () {
+        const isDisabled = () => {
+            const el = document.getElementById('my-btn');
+            return el.classList.contains('dleToolBarDisabled') && el.getAttribute('aria-disabled') === 'true';
+        };
+        // Let the pending permission promise(s) settle before asserting.
+        const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+        it('injects disabled when injectToolbar({disabled: true})', function () {
+            document.body.innerHTML = dleHtml();
+            window.GenericDleToolbarStarter.create(cfg()).injectToolbar({ alternate: true, disabled: true });
+            expect(isDisabled()).to.be.true;
+        });
+
+        it('injects enabled by default and setDisabled toggles the live button both ways', function () {
+            document.body.innerHTML = dleHtml();
+            const starter = window.GenericDleToolbarStarter.create(cfg());
+            starter.injectToolbar({ alternate: true });
+            expect(isDisabled()).to.be.false;
+            starter.setDisabled(true);
+            expect(isDisabled()).to.be.true;
+            starter.setDisabled(false);
+            expect(isDisabled()).to.be.false;
+        });
+
+        it('keeps the disabled state across a self-healing re-inject', async function () {
+            document.body.innerHTML = dleHtml();
+            const starter = window.GenericDleToolbarStarter.create(cfg());
+            starter.injectToolbar({ alternate: true });
+            starter.setDisabled(true);
+
+            document.getElementById('my-btn').remove();                       // GWT wipes the button
+            document.querySelector('div.polarion-dle-Container').appendChild(document.createElement('span'));
+            await flushObserver();
+            rafCallbacks.forEach((cb) => cb());
+            expect(isDisabled()).to.be.true;                                  // healed AND still disabled
+        });
+
+        it('permissionCheck(): disables when it resolves false', async function () {
+            document.body.innerHTML = dleHtml();
+            window.GenericDleToolbarStarter.create(cfg({ permissionCheck: () => Promise.resolve(false) }))
+                .injectToolbar({ alternate: true });
+            expect(isDisabled()).to.be.true;                                  // disabled while pending
+            await flushPromises();
+            expect(isDisabled()).to.be.true;                                  // stays disabled — not permitted
+        });
+
+        it('permissionCheck(): enables when it resolves true', async function () {
+            document.body.innerHTML = dleHtml();
+            window.GenericDleToolbarStarter.create(cfg({ permissionCheck: () => Promise.resolve(true) }))
+                .injectToolbar({ alternate: true });
+            expect(isDisabled()).to.be.true;                                  // disabled while pending (no flicker)
+            await flushPromises();
+            expect(isDisabled()).to.be.false;                                 // enabled — permitted
+        });
+
+        it('permissionCheck(): fail-closed when it rejects', async function () {
+            document.body.innerHTML = dleHtml();
+            window.GenericDleToolbarStarter.create(cfg({ permissionCheck: () => Promise.reject(new Error('boom')) }))
+                .injectToolbar({ alternate: true });
+            await flushPromises();
+            expect(isDisabled()).to.be.true;
+        });
+
+        it('permissionCheckUrl(): enables on { permitted: true }', async function () {
+            document.body.innerHTML = dleHtml();
+            global.fetch = sinon.stub().resolves({ ok: true, json: () => Promise.resolve({ permitted: true }) });
+            try {
+                window.GenericDleToolbarStarter.create(cfg({ permissionCheckUrl: '/perm' })).injectToolbar({ alternate: true });
+                await flushPromises();
+                expect(global.fetch.calledOnceWith('/perm')).to.be.true;
+                expect(isDisabled()).to.be.false;
+            } finally {
+                delete global.fetch;
+            }
+        });
+
+        it('permissionCheckUrl(): disables on { permitted: false }', async function () {
+            document.body.innerHTML = dleHtml();
+            global.fetch = sinon.stub().resolves({ ok: true, json: () => Promise.resolve({ permitted: false }) });
+            try {
+                window.GenericDleToolbarStarter.create(cfg({ permissionCheckUrl: '/perm' })).injectToolbar({ alternate: true });
+                await flushPromises();
+                expect(isDisabled()).to.be.true;
+            } finally {
+                delete global.fetch;
+            }
+        });
+
+        it('permissionCheckUrl(): fail-closed on a non-OK response', async function () {
+            document.body.innerHTML = dleHtml();
+            global.fetch = sinon.stub().resolves({ ok: false, json: () => Promise.resolve({}) });
+            try {
+                window.GenericDleToolbarStarter.create(cfg({ permissionCheckUrl: '/perm' })).injectToolbar({ alternate: true });
+                await flushPromises();
+                expect(isDisabled()).to.be.true;
+            } finally {
+                delete global.fetch;
+            }
+        });
+
+        it('permissionCheck takes precedence over permissionCheckUrl', async function () {
+            document.body.innerHTML = dleHtml();
+            global.fetch = sinon.stub().resolves({ ok: true, json: () => Promise.resolve({ permitted: false }) });
+            try {
+                window.GenericDleToolbarStarter.create(cfg({
+                    permissionCheck: () => true,
+                    permissionCheckUrl: '/perm'
+                })).injectToolbar({ alternate: true });
+                await flushPromises();
+                expect(global.fetch.called).to.be.false;   // URL not used
+                expect(isDisabled()).to.be.false;           // function said permitted
+            } finally {
+                delete global.fetch;
+            }
+        });
+
+        it('setDisabled is a no-op (no throw) when the button is not currently in the DOM', function () {
+            document.body.innerHTML = dleHtml({ toolbar: false }); // toolbar absent → nothing injected
+            const starter = window.GenericDleToolbarStarter.create(cfg());
+            starter.injectToolbar({ alternate: true });
+            expect(document.getElementById('my-btn')).to.equal(null);
+            starter.setDisabled(true); // element missing → applyDisabled early-returns, no error
+        });
+
+        it('runs the permission check only once across re-injects', async function () {
+            document.body.innerHTML = dleHtml();
+            const check = sinon.stub().resolves(true);
+            const starter = window.GenericDleToolbarStarter.create(cfg({ permissionCheck: check }));
+            starter.injectToolbar({ alternate: true });
+            starter.injectToolbar({ alternate: true });
+            await flushPromises();
+            expect(check.calledOnce).to.be.true;
+        });
+    });
+
     it('re-injects the button when the toolbar re-renders (self-healing observer)', async function () {
         document.body.innerHTML = dleHtml();
         const starter = window.GenericDleToolbarStarter.create(cfg());

--- a/app/src/test/js/modules/dleToolbarStarterTest.js
+++ b/app/src/test/js/modules/dleToolbarStarterTest.js
@@ -292,6 +292,33 @@ describe('GenericDleToolbarStarter (dle-toolbar-starter.js)', function () {
             expect(isDisabled()).to.be.false;
         });
 
+        it('swallows keyboard/programmatic clicks while disabled (capture blocker)', function () {
+            document.body.innerHTML = dleHtml();
+            const starter = window.GenericDleToolbarStarter.create(cfg({ alternateHtml: '<button id="inner">A</button>' }));
+            starter.injectToolbar({ alternate: true, disabled: true });
+            const inner = document.getElementById('inner');
+            const onClick = sinon.spy();
+            inner.addEventListener('click', onClick);
+
+            inner.click();                          // programmatic click reaches the container blocker
+            expect(onClick.called).to.be.false;     // ...which stops it before the button handler
+
+            starter.setDisabled(false);
+            inner.click();
+            expect(onClick.calledOnce).to.be.true;  // enabled again → click passes through
+        });
+
+        it('a later injectToolbar() without disabled keeps a previously set disabled state', function () {
+            document.body.innerHTML = dleHtml();
+            const starter = window.GenericDleToolbarStarter.create(cfg());
+            starter.injectToolbar({ alternate: true });
+            starter.setDisabled(true);
+            // Extension re-injects (e.g. re-runs its bootstrap) without passing disabled.
+            document.getElementById('my-btn').remove();
+            starter.injectToolbar({ alternate: true });
+            expect(isDisabled()).to.be.true;        // merged lastParams preserved disabled
+        });
+
         it('keeps the disabled state across a self-healing re-inject', async function () {
             document.body.innerHTML = dleHtml();
             const starter = window.GenericDleToolbarStarter.create(cfg());

--- a/app/src/test/js/modules/dleToolbarStarterTest.js
+++ b/app/src/test/js/modules/dleToolbarStarterTest.js
@@ -87,6 +87,8 @@ describe('GenericDleToolbarStarter (dle-toolbar-starter.js)', function () {
         Object.keys(reg).forEach((k) => { try { reg[k].disconnect(); } catch { /* node gone */ } delete reg[k]; });
         const order = window.__genericDleToolbarOrder;
         if (order) Object.keys(order).forEach((k) => delete order[k]);
+        const owners = window.__genericDleToolbarOwners;
+        if (owners) Object.keys(owners).forEach((k) => delete owners[k]);
         // Release the shared auto-expand observer so each test starts from a clean slate.
         if (window.__genericRpeAutoExpandObserver) {
             window.__genericRpeAutoExpandObserver.disconnect();
@@ -457,6 +459,20 @@ describe('GenericDleToolbarStarter (dle-toolbar-starter.js)', function () {
             starter.injectToolbar({ alternate: true });
             expect(document.getElementById('my-btn')).to.equal(null);
             starter.setDisabled(true); // element missing → applyDisabled early-returns, no error
+        });
+
+        it('a superseded starter instance does not apply setDisabled (newer owner wins)', function () {
+            document.body.innerHTML = dleHtml();
+            const oldStarter = window.GenericDleToolbarStarter.create(cfg());
+            oldStarter.injectToolbar({ alternate: true });
+            // A newer starter for the SAME markerId is created → it becomes the owner.
+            const newStarter = window.GenericDleToolbarStarter.create(cfg());
+            newStarter.injectToolbar({ alternate: true });
+
+            oldStarter.setDisabled(true);          // stale instance → must be a no-op
+            expect(isDisabled()).to.be.false;
+            newStarter.setDisabled(true);          // current owner → applies
+            expect(isDisabled()).to.be.true;
         });
 
         it('does not apply a permission result that resolves after destroy()', async function () {

--- a/app/src/test/js/modules/dleToolbarStarterTest.js
+++ b/app/src/test/js/modules/dleToolbarStarterTest.js
@@ -325,6 +325,27 @@ describe('GenericDleToolbarStarter (dle-toolbar-starter.js)', function () {
             expect(inner.getAttribute('tabindex')).to.equal('0');   // original tabindex restored
         });
 
+        it("preserves the markup's own aria-disabled on re-enable instead of clobbering it", function () {
+            document.body.innerHTML = dleHtml();
+            const starter = window.GenericDleToolbarStarter.create(cfg({
+                alternateHtml: '<button id="inner" aria-disabled="true">A</button>' // extension owns aria-disabled
+            }));
+            starter.injectToolbar({ alternate: true, disabled: true });
+            expect(document.getElementById('inner').getAttribute('aria-disabled')).to.equal('true');
+            starter.setDisabled(false);
+            // engine restores the markup's original value, does not remove it
+            expect(document.getElementById('inner').getAttribute('aria-disabled')).to.equal('true');
+        });
+
+        it('removes an aria-disabled it added when the element had none originally', function () {
+            document.body.innerHTML = dleHtml();
+            const starter = window.GenericDleToolbarStarter.create(cfg({ alternateHtml: '<button id="inner">A</button>' }));
+            starter.injectToolbar({ alternate: true, disabled: true });
+            expect(document.getElementById('inner').getAttribute('aria-disabled')).to.equal('true');
+            starter.setDisabled(false);
+            expect(document.getElementById('inner').hasAttribute('aria-disabled')).to.be.false;
+        });
+
         it('removes a tabindex it added when the element had none originally', function () {
             document.body.innerHTML = dleHtml();
             const starter = window.GenericDleToolbarStarter.create(cfg({

--- a/app/src/test/js/modules/dleToolbarStarterTest.js
+++ b/app/src/test/js/modules/dleToolbarStarterTest.js
@@ -308,6 +308,46 @@ describe('GenericDleToolbarStarter (dle-toolbar-starter.js)', function () {
             expect(onClick.calledOnce).to.be.true;  // enabled again → click passes through
         });
 
+        it('marks inner interactive elements aria-disabled and drops them from the tab order', function () {
+            document.body.innerHTML = dleHtml();
+            const starter = window.GenericDleToolbarStarter.create(cfg({
+                alternateHtml: '<div id="inner" role="button" tabindex="0">A</div>'
+            }));
+            starter.injectToolbar({ alternate: true, disabled: true });
+            const inner = document.getElementById('inner');
+            expect(inner.getAttribute('aria-disabled')).to.equal('true');
+            expect(inner.getAttribute('tabindex')).to.equal('-1');
+
+            starter.setDisabled(false);
+            expect(inner.hasAttribute('aria-disabled')).to.be.false;
+            expect(inner.getAttribute('tabindex')).to.equal('0');   // original tabindex restored
+        });
+
+        it('removes a tabindex it added when the element had none originally', function () {
+            document.body.innerHTML = dleHtml();
+            const starter = window.GenericDleToolbarStarter.create(cfg({
+                alternateHtml: '<button id="inner">A</button>' // no tabindex to begin with
+            }));
+            starter.injectToolbar({ alternate: true, disabled: true });
+            expect(document.getElementById('inner').getAttribute('tabindex')).to.equal('-1');
+            starter.setDisabled(false);
+            expect(document.getElementById('inner').hasAttribute('tabindex')).to.be.false;
+        });
+
+        it('destroy() clears the disabled state and its click blocker from the element', function () {
+            document.body.innerHTML = dleHtml();
+            const starter = window.GenericDleToolbarStarter.create(cfg({ alternateHtml: '<button id="inner">A</button>' }));
+            starter.injectToolbar({ alternate: true, disabled: true });
+            const inner = document.getElementById('inner');
+            const onClick = sinon.spy();
+            inner.addEventListener('click', onClick);
+
+            starter.destroy();
+            expect(document.getElementById('my-btn').classList.contains('dleToolBarDisabled')).to.be.false;
+            inner.click();
+            expect(onClick.calledOnce).to.be.true;   // blocker removed → click passes
+        });
+
         it('a later injectToolbar() without disabled keeps a previously set disabled state', function () {
             document.body.innerHTML = dleHtml();
             const starter = window.GenericDleToolbarStarter.create(cfg());

--- a/app/src/test/js/modules/dleToolbarStarterTest.js
+++ b/app/src/test/js/modules/dleToolbarStarterTest.js
@@ -459,6 +459,23 @@ describe('GenericDleToolbarStarter (dle-toolbar-starter.js)', function () {
             starter.setDisabled(true); // element missing → applyDisabled early-returns, no error
         });
 
+        it('does not apply a permission result that resolves after destroy()', async function () {
+            document.body.innerHTML = dleHtml();
+            let resolveCheck;
+            const starter = window.GenericDleToolbarStarter.create(cfg({
+                permissionCheck: () => new Promise((r) => { resolveCheck = r; })
+            }));
+            starter.injectToolbar({ alternate: true });
+            await flushPromises();                 // let permissionCheck get invoked (sets resolveCheck)
+            expect(isDisabled()).to.be.true;       // disabled while pending
+
+            starter.destroy();                     // torn down before the check resolves
+            resolveCheck(true);                    // late "permitted" result
+            await flushPromises();
+            // destroy() cleared the disabled state and the late result must not re-apply anything.
+            expect(document.getElementById('my-btn').classList.contains('dleToolBarDisabled')).to.be.false;
+        });
+
         it('runs the permission check only once across re-injects', async function () {
             document.body.innerHTML = dleHtml();
             const check = sinon.stub().resolves(true);


### PR DESCRIPTION
### Proposed changes

Closes #595

Adds a **disabled** state to the shared DLE toolbar engine, for permission-gated actions — e.g. when a user isn't allowed to export, the injected toolbar button should be greyed out rather than clickable. Works the same for the Live Doc (`dleEditor`) and Live Report (`richPagePreview`) toolbars.

**Why in the engine:** the self-healing observer re-injects the button's static HTML on every GWT toolbar re-render, so disabling the DOM from outside would be wiped; and the `onclick` is baked into the extension-owned markup the engine doesn't parse. So the disabled state has to live in the engine and survive re-injection.

**API:**
- `injectToolbar({ disabled })` — stored in `lastParams`, re-applied on every self-healing re-inject. The click is blocked by a `.dleToolBarDisabled` class (`pointer-events: none`), regardless of the baked-in `onclick`.
- `create()` returns `setDisabled(bool)` to toggle the live button (and future re-injects).
- `create()` can drive a **global** permission check itself: `permissionCheckUrl` (GET → JSON `{ permitted: boolean }`) or `permissionCheck` (a function → `boolean | Promise<boolean>`, taking precedence). While pending the button is disabled (no enabled→disabled flicker); a non-OK response / error keeps it disabled (**fail-closed**); with neither configured it's enabled, as before.
- `.dleToolBarDisabled` rule added to the shared `css/dle-toolbar.css`.
- README documents both usages (engine-driven check, and manual `setDisabled`).

Responsibility split: the extension owns the backend that decides *whether* the action is permitted; generic only renders and preserves the disabled look.

Engine JS is at **100%** statement/branch/function coverage (313 tests).

### Checklist

- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation