### PR TITLE
feat: let a build ignore an npm user config it cannot fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,9 @@
                                  non-docker command (the test:docker wrapper forwards no extra args). -->
         <jsTestCommand>run test:coverage:docker</jsTestCommand>
         <jsTestExtraArgs> </jsTestExtraArgs>
+        <!-- Which npm user config the build reads. The default is npm's own, so setting it changes
+             nothing; -DnpmIgnoreUserConfig (profile below) points it at an empty file instead. -->
+        <npm.userconfig>${user.home}/.npmrc</npm.userconfig>
     </properties>
 
     <profiles>
@@ -351,6 +354,11 @@
                         <version>${frontend-maven-plugin.version}</version>
                         <configuration>
                             <workingDirectory>${vite.sources.root}</workingDirectory>
+                            <!-- Every npm invocation validates the user config, not just the ones that
+                                 fetch, so this belongs on the plugin rather than on one execution. -->
+                            <environmentVariables>
+                                <NPM_CONFIG_USERCONFIG>${npm.userconfig}</NPM_CONFIG_USERCONFIG>
+                            </environmentVariables>
                         </configuration>
                         <executions>
                             <execution>
@@ -440,6 +448,28 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+
+        <!-- Activate with -DnpmIgnoreUserConfig to run npm with an empty user config.
+             For CI agents whose npm configuration the build cannot fix and must not inherit: the ESTA
+             agents still carry the npm 6-era `email` and `always-auth` keys, which npm 12 rejects
+             outright (ERR_INVALID_AUTH) before it fetches anything, and each agent is a container
+             recreated per run, so there is nothing to repair in place.
+
+             Nothing is lost by ignoring it: every lockfile entry resolves from the public registry,
+             which is also what npm falls back to with no configuration, so no token and no scope
+             mapping applies. Never make this the default - on a developer machine it would silently
+             discard their own registry, proxy and auth settings. -->
+        <profile>
+            <id>npm-ignore-user-config</id>
+            <activation>
+                <property>
+                    <name>npmIgnoreUserConfig</name>
+                </property>
+            </activation>
+            <properties>
+                <npm.userconfig>/dev/null</npm.userconfig>
+            </properties>
         </profile>
 
         <!-- Run the ui/ tests natively instead of in the pinned Playwright Docker image. Needed where

--- a/pom.xml
+++ b/pom.xml
@@ -191,9 +191,6 @@
                                  non-docker command (the test:docker wrapper forwards no extra args). -->
         <jsTestCommand>run test:coverage:docker</jsTestCommand>
         <jsTestExtraArgs> </jsTestExtraArgs>
-        <!-- Which npm user config the build reads. The default is npm's own, so setting it changes
-             nothing; -DnpmIgnoreUserConfig (profile below) points it at an empty file instead. -->
-        <npm.userconfig>${user.home}/.npmrc</npm.userconfig>
     </properties>
 
     <profiles>
@@ -354,11 +351,6 @@
                         <version>${frontend-maven-plugin.version}</version>
                         <configuration>
                             <workingDirectory>${vite.sources.root}</workingDirectory>
-                            <!-- Every npm invocation validates the user config, not just the ones that
-                                 fetch, so this belongs on the plugin rather than on one execution. -->
-                            <environmentVariables>
-                                <NPM_CONFIG_USERCONFIG>${npm.userconfig}</NPM_CONFIG_USERCONFIG>
-                            </environmentVariables>
                         </configuration>
                         <executions>
                             <execution>
@@ -467,9 +459,24 @@
                     <name>npmIgnoreUserConfig</name>
                 </property>
             </activation>
-            <properties>
-                <npm.userconfig>/dev/null</npm.userconfig>
-            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.eirslett</groupId>
+                        <artifactId>frontend-maven-plugin</artifactId>
+                        <configuration>
+                            <!-- On the plugin, not on one execution: every npm invocation validates the
+                                 user config, not just the ones that fetch. Set here rather than in the
+                                 base configuration so that a build without the flag does not touch the
+                                 environment at all - an NPM_CONFIG_USERCONFIG set outside Maven keeps
+                                 working, which an unconditional override would silently discard. -->
+                            <environmentVariables>
+                                <NPM_CONFIG_USERCONFIG>/dev/null</NPM_CONFIG_USERCONFIG>
+                            </environmentVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
 
         <!-- Run the ui/ tests natively instead of in the pinned Playwright Docker image. Needed where


### PR DESCRIPTION
## The problem

Every extension with a `ui/` stopped building on our CI the moment generic 15.8.1 provisioned npm 12:

```
npm error code ERR_INVALID_AUTH
npm error Invalid auth configuration found: `email` must be renamed to
          `//<registry>/:email` in user config
```

The build agents' npm user config still carries `email` and `always-auth` — npm 6-era keys that npm 11 tolerated and **npm 12 rejects outright, before fetching anything**. The bump surfaced a pre-existing misconfiguration rather than creating one.

It cannot be repaired from a build: each agent is a **container recreated per run**.

## The fix

`-DnpmIgnoreUserConfig` runs npm with an empty user config for the whole build.

Nothing is lost by ignoring it: every lockfile entry resolves from the public registry, which is also what npm falls back to with no configuration at all — so no token and no scope mapping applies.

Two deliberate choices:

- **Set inside the profile, not in the base configuration.** Without the flag the build sets **no** environment variable at all. Setting it unconditionally — even to what the default would have been — would override an `NPM_CONFIG_USERCONFIG` chosen outside Maven, which is a standard npm mechanism. Thanks to @greptileai for catching exactly that in the first revision.
- **On the plugin, not on one execution.** Every npm invocation validates the user config, not just the ones that fetch. Proven the hard way on a real CI run: passing the flag to `npm ci` alone let that step install 237 packages successfully, and the build then died one step later in `npm run build`.

Never the default: on a developer machine the same switch would silently discard their registry, proxy and auth settings.

## Verified

`help:effective-pom` on a consuming extension:

| | `NPM_CONFIG_USERCONFIG` | `workingDirectory` |
|---|---|---|
| no flag | absent | intact |
| `-DnpmIgnoreUserConfig` | `/dev/null` | intact |

`mvn clean install -P install-to-local-polarion` on that extension, green in all three modes: no flag, with the flag, and with `NPM_CONFIG_USERCONFIG` set externally in the environment.

Consumers opt in by adding the flag to their pipeline's build parameters, next to `-DjsTestsNoDocker -DinstallPlaywrightNoDeps`.