### PR TITLE
feat: share the role-based authorization pieces

### DIFF
--- a/app/src/main/java/ch/sbb/polarion/extension/generic/rest/controller/roles/RolesApiController.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/rest/controller/roles/RolesApiController.java
@@ -1,0 +1,24 @@
+package ch.sbb.polarion.extension.generic.rest.controller.roles;
+
+import ch.sbb.polarion.extension.generic.rest.filter.Secured;
+import ch.sbb.polarion.extension.generic.rest.model.RolesInfo;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.Path;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Token-authenticated twin of {@link RolesInternalController}, following the same Api/Internal pairing
+ * the settings controllers use: the same endpoint under {@code /api}, executed with elevated rights,
+ * because a token caller has no Polarion session to read the security service with.
+ */
+@Singleton
+@Secured
+@Path("/api")
+public class RolesApiController extends RolesInternalController {
+
+    @Override
+    public @NotNull RolesInfo getRoles(@Nullable String scope) {
+        return polarionService.callPrivileged(() -> super.getRoles(scope));
+    }
+}

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/rest/controller/roles/RolesApiController.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/rest/controller/roles/RolesApiController.java
@@ -2,6 +2,7 @@ package ch.sbb.polarion.extension.generic.rest.controller.roles;
 
 import ch.sbb.polarion.extension.generic.rest.filter.Secured;
 import ch.sbb.polarion.extension.generic.rest.model.RolesInfo;
+import ch.sbb.polarion.extension.generic.service.PolarionService;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.Path;
 import org.jetbrains.annotations.NotNull;
@@ -16,6 +17,14 @@ import org.jetbrains.annotations.Nullable;
 @Secured
 @Path("/api")
 public class RolesApiController extends RolesInternalController {
+
+    public RolesApiController() {
+        super();
+    }
+
+    public RolesApiController(PolarionService polarionService) {
+        super(polarionService);
+    }
 
     @Override
     public @NotNull RolesInfo getRoles(@Nullable String scope) {

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/rest/controller/roles/RolesInternalController.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/rest/controller/roles/RolesInternalController.java
@@ -1,0 +1,55 @@
+package ch.sbb.polarion.extension.generic.rest.controller.roles;
+
+import ch.sbb.polarion.extension.generic.rest.model.RolesInfo;
+import ch.sbb.polarion.extension.generic.service.PolarionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+
+/**
+ * Lists the roles an administration page can offer as checkboxes.
+ * <p>
+ * Not part of the controllers every extension gets: only the few that store "who may do X" as role
+ * names need it, and adding an endpoint to all of them would change their REST surface for nothing. An
+ * extension opts in by naming this class (and {@link RolesApiController}) in its REST application's
+ * {@code getExtensionControllerClasses()}.
+ */
+@Singleton
+@Tag(name = "Roles")
+@Path("/internal")
+public class RolesInternalController {
+
+    protected final PolarionService polarionService;
+
+    public RolesInternalController() {
+        this(new PolarionService());
+    }
+
+    public RolesInternalController(PolarionService polarionService) {
+        this.polarionService = polarionService;
+    }
+
+    @GET
+    @Path("/roles")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Get the global and project roles available in the specified scope",
+            responses = @ApiResponse(responseCode = "200",
+                    description = "Successfully retrieved the available roles",
+                    content = @Content(schema = @Schema(implementation = RolesInfo.class))))
+    public @NotNull RolesInfo getRoles(@Parameter(description = "Scope, e.g. project/<projectId>/ (empty for global scope)") @QueryParam("scope") @Nullable String scope) {
+        return new RolesInfo(new ArrayList<>(polarionService.getGlobalRoles()), new ArrayList<>(polarionService.getProjectRoles(scope)));
+    }
+}

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/rest/model/RolesInfo.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/rest/model/RolesInfo.java
@@ -1,0 +1,23 @@
+package ch.sbb.polarion.extension.generic.rest.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Roles available to grant in a given scope")
+public class RolesInfo {
+
+    @Schema(description = "Roles defined for the whole repository", requiredMode = Schema.RequiredMode.REQUIRED)
+    private List<String> globalRoles;
+
+    @Schema(description = "Roles defined for the project of the scope; empty in global scope", requiredMode = Schema.RequiredMode.REQUIRED)
+    private List<String> projectRoles;
+}

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/service/PolarionService.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/service/PolarionService.java
@@ -9,6 +9,7 @@ import ch.sbb.polarion.extension.generic.util.AssigneeUtils;
 import ch.sbb.polarion.extension.generic.util.EnumUtils;
 import ch.sbb.polarion.extension.generic.util.ObjectUtils;
 import ch.sbb.polarion.extension.generic.util.RequestContextUtil;
+import ch.sbb.polarion.extension.generic.util.ScopeUtils;
 import com.polarion.alm.projects.IProjectService;
 import com.polarion.alm.projects.model.IProject;
 import com.polarion.alm.shared.api.model.baselinecollection.BaselineCollectionReference;
@@ -282,6 +283,25 @@ public class PolarionService {
                     return null;
                 }
         );
+    }
+
+    /** Roles defined for the whole repository. */
+    @NotNull
+    public Collection<String> getGlobalRoles() {
+        return securityService.getGlobalRoles();
+    }
+
+    /**
+     * Roles defined for the project the scope points at. A scope naming no project - the global scope -
+     * has none, which is a normal state and not an error.
+     */
+    @NotNull
+    public Collection<String> getProjectRoles(@Nullable String scope) {
+        String projectId = ScopeUtils.getProjectFromScope(scope == null ? "" : scope);
+        if (projectId == null) {
+            return Set.of();
+        }
+        return securityService.getContextRoles(getProject(projectId).getContextId());
     }
 
     public String getPolarionProductName() {

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/settings/AuthorizationModel.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/settings/AuthorizationModel.java
@@ -60,7 +60,9 @@ public class AuthorizationModel extends SettingsModel {
 
     @NotNull
     protected List<String> deserializeRoles(@NotNull String what, @NotNull String serializedString) {
-        final String roles = deserializeEntry(what, serializedString);
+        // Default to empty: the two-argument overload answers null when the block is absent, which a
+        // legacy or hand-edited setting may well be, and splitting that would fail the whole load.
+        final String roles = deserializeEntry(what, serializedString, "");
         // Trim first, then drop the blanks: filtering before trimming let an entry of spaces through
         // as an empty string, which is not a role and can never match one.
         return Arrays.stream(roles.split(",")).map(String::trim).filter(s -> !StringUtils.isEmpty(s)).toList();

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/settings/AuthorizationModel.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/settings/AuthorizationModel.java
@@ -68,12 +68,16 @@ public class AuthorizationModel extends SettingsModel {
         return Arrays.stream(roles.split(",")).map(String::trim).filter(s -> !StringUtils.isEmpty(s)).toList();
     }
 
-    /** Every granted role, global and project, in one list - what a permission check usually wants. */
+    /**
+     * Every granted role, global and project, in one list - what a permission check usually wants.
+     * Either list is null on a model that was never populated, or built from JSON that omitted it; an
+     * omitted list grants nothing rather than failing the check.
+     */
     @JsonIgnore
     public List<String> getAllRoles() {
         List<String> roles = new ArrayList<>();
-        roles.addAll(getGlobalRoles());
-        roles.addAll(getProjectRoles());
+        roles.addAll(globalRoles == null ? List.of() : globalRoles);
+        roles.addAll(projectRoles == null ? List.of() : projectRoles);
         return roles;
     }
 }

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/settings/AuthorizationModel.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/settings/AuthorizationModel.java
@@ -1,0 +1,75 @@
+package ch.sbb.polarion.extension.generic.settings;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.polarion.core.util.StringUtils;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A setting that stores "who is allowed to do this" as two lists of role names - the shape several
+ * extensions had each written for themselves.
+ * <p>
+ * The stored format is unchanged and is keyed by entry name ({@code globalRoles} / {@code projectRoles}),
+ * not by class, so settings written by an extension's own copy of this model deserialize here as they
+ * are.
+ * <p>
+ * The setting's <em>name</em> stays with the extension: subclass {@link GenericNamedSettings} with
+ * whatever feature name it stores under. One extension may well have several - api-extender keeps
+ * project custom fields and global records apart this way.
+ */
+@Getter
+@EqualsAndHashCode(callSuper = true)
+public class AuthorizationModel extends SettingsModel {
+
+    public static final String GLOBAL_ROLES = "globalRoles";
+    public static final String PROJECT_ROLES = "projectRoles";
+
+    protected List<String> globalRoles;
+    protected List<String> projectRoles;
+
+    public void setGlobalRoles(String... roles) {
+        globalRoles = List.of(roles);
+    }
+
+    public void setProjectRoles(String... roles) {
+        projectRoles = List.of(roles);
+    }
+
+    @Override
+    protected String serializeModelData() {
+        return serializeEntry(GLOBAL_ROLES, serializeRoles(globalRoles)) +
+                serializeEntry(PROJECT_ROLES, serializeRoles(projectRoles));
+    }
+
+    @Override
+    protected void deserializeModelData(String serializedString) {
+        globalRoles = deserializeRoles(GLOBAL_ROLES, serializedString);
+        projectRoles = deserializeRoles(PROJECT_ROLES, serializedString);
+    }
+
+    @NotNull
+    protected String serializeRoles(@Nullable List<String> roles) {
+        return roles == null ? "" : String.join(",", roles);
+    }
+
+    @NotNull
+    protected List<String> deserializeRoles(@NotNull String what, @NotNull String serializedString) {
+        final String roles = deserializeEntry(what, serializedString);
+        return Arrays.stream(roles.split(",")).filter(s -> !StringUtils.isEmpty(s)).map(String::trim).toList();
+    }
+
+    /** Every granted role, global and project, in one list - what a permission check usually wants. */
+    @JsonIgnore
+    public List<String> getAllRoles() {
+        List<String> roles = new ArrayList<>();
+        roles.addAll(getGlobalRoles());
+        roles.addAll(getProjectRoles());
+        return roles;
+    }
+}

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/settings/AuthorizationModel.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/settings/AuthorizationModel.java
@@ -61,7 +61,9 @@ public class AuthorizationModel extends SettingsModel {
     @NotNull
     protected List<String> deserializeRoles(@NotNull String what, @NotNull String serializedString) {
         final String roles = deserializeEntry(what, serializedString);
-        return Arrays.stream(roles.split(",")).filter(s -> !StringUtils.isEmpty(s)).map(String::trim).toList();
+        // Trim first, then drop the blanks: filtering before trimming let an entry of spaces through
+        // as an empty string, which is not a role and can never match one.
+        return Arrays.stream(roles.split(",")).map(String::trim).filter(s -> !StringUtils.isEmpty(s)).toList();
     }
 
     /** Every granted role, global and project, in one list - what a permission check usually wants. */

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/rest/controller/roles/RolesControllerTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/rest/controller/roles/RolesControllerTest.java
@@ -2,6 +2,7 @@ package ch.sbb.polarion.extension.generic.rest.controller.roles;
 
 import ch.sbb.polarion.extension.generic.rest.model.RolesInfo;
 import ch.sbb.polarion.extension.generic.service.PolarionService;
+import ch.sbb.polarion.extension.generic.test_extensions.PlatformContextMockExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,16 +11,17 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.Callable;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-/**
- * The api twin, {@link RolesApiController}, is four lines of delegation and has no test of its own -
- * neither does the settings pair it follows, and it offers no injecting constructor to build one with.
- */
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({MockitoExtension.class, PlatformContextMockExtension.class})
 class RolesControllerTest {
 
     private static final String SCOPE = "project/project_id/";
@@ -29,7 +31,8 @@ class RolesControllerTest {
 
     @BeforeEach
     void init() {
-        when(polarionService.getGlobalRoles()).thenReturn(List.of("admin"));
+        // lenient: the constructor test uses neither the service nor this stub.
+        lenient().when(polarionService.getGlobalRoles()).thenReturn(List.of("admin"));
     }
 
     @Test
@@ -50,5 +53,28 @@ class RolesControllerTest {
 
         assertEquals(List.of("admin"), roles.getGlobalRoles());
         assertTrue(roles.getProjectRoles().isEmpty());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testGetRolesThroughTheApiVariant() {
+        // A token caller has no Polarion session, so the api variant elevates before reading the
+        // security service - the same pairing the settings controllers use.
+        when(polarionService.getProjectRoles(SCOPE)).thenReturn(Set.of("project_admin"));
+        when(polarionService.callPrivileged(any(Callable.class)))
+                .thenAnswer(invocation -> ((Callable<Object>) invocation.getArgument(0)).call());
+
+        RolesInfo roles = new RolesApiController(polarionService).getRoles(SCOPE);
+
+        assertEquals(List.of("admin"), roles.getGlobalRoles());
+        assertEquals(List.of("project_admin"), roles.getProjectRoles());
+        verify(polarionService).callPrivileged(any(Callable.class));
+    }
+
+    @Test
+    void testDefaultConstructors() {
+        // The constructors Polarion itself uses: they build their own PolarionService from the platform.
+        assertNotNull(new RolesInternalController());
+        assertNotNull(new RolesApiController());
     }
 }

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/rest/controller/roles/RolesControllerTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/rest/controller/roles/RolesControllerTest.java
@@ -1,0 +1,54 @@
+package ch.sbb.polarion.extension.generic.rest.controller.roles;
+
+import ch.sbb.polarion.extension.generic.rest.model.RolesInfo;
+import ch.sbb.polarion.extension.generic.service.PolarionService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+/**
+ * The api twin, {@link RolesApiController}, is four lines of delegation and has no test of its own -
+ * neither does the settings pair it follows, and it offers no injecting constructor to build one with.
+ */
+@ExtendWith(MockitoExtension.class)
+class RolesControllerTest {
+
+    private static final String SCOPE = "project/project_id/";
+
+    @Mock
+    private PolarionService polarionService;
+
+    @BeforeEach
+    void init() {
+        when(polarionService.getGlobalRoles()).thenReturn(List.of("admin"));
+    }
+
+    @Test
+    void testGetRoles() {
+        when(polarionService.getProjectRoles(SCOPE)).thenReturn(Set.of("project_admin"));
+
+        RolesInfo roles = new RolesInternalController(polarionService).getRoles(SCOPE);
+
+        assertEquals(List.of("admin"), roles.getGlobalRoles());
+        assertEquals(List.of("project_admin"), roles.getProjectRoles());
+    }
+
+    @Test
+    void testGetRolesWithoutProjectScope() {
+        when(polarionService.getProjectRoles(null)).thenReturn(Set.of());
+
+        RolesInfo roles = new RolesInternalController(polarionService).getRoles(null);
+
+        assertEquals(List.of("admin"), roles.getGlobalRoles());
+        assertTrue(roles.getProjectRoles().isEmpty());
+    }
+}

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/service/PolarionServiceTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/service/PolarionServiceTest.java
@@ -27,6 +27,7 @@ import com.polarion.platform.persistence.IEnumeration;
 import com.polarion.platform.persistence.model.IPObject;
 import com.polarion.platform.persistence.model.IPrototype;
 import com.polarion.platform.persistence.spi.EnumOption;
+import com.polarion.platform.security.ISecurityService;
 import com.polarion.subterra.base.data.identification.IContextId;
 import com.polarion.subterra.base.data.identification.IObjectId;
 import com.polarion.subterra.base.data.model.ICustomField;
@@ -70,6 +71,9 @@ public class PolarionServiceTest {
     private IProjectService projectService;
 
     @Mock
+    private ISecurityService securityService;
+
+    @Mock
     private ITrackerService trackerService;
 
     @Mock
@@ -85,7 +89,32 @@ public class PolarionServiceTest {
 
     @BeforeEach
     void init() {
-        polarionService = TestUtils.mockPolarionService(trackerService, projectService, null, platformService, null);
+        polarionService = TestUtils.mockPolarionService(trackerService, projectService, securityService, platformService, null);
+    }
+
+    @Test
+    void testGetGlobalRoles() {
+        when(securityService.getGlobalRoles()).thenReturn(List.of("admin", "user"));
+
+        assertEquals(List.of("admin", "user"), List.copyOf(polarionService.getGlobalRoles()));
+    }
+
+    @Test
+    void testGetProjectRoles() {
+        IProject project = mockProject(Boolean.TRUE);
+        IContextId contextId = mock(IContextId.class);
+        when(project.getContextId()).thenReturn(contextId);
+        when(securityService.getContextRoles(contextId)).thenReturn(Set.of("project_admin"));
+
+        assertEquals(Set.of("project_admin"), Set.copyOf(polarionService.getProjectRoles("project/" + PROJECT_ID + "/")));
+    }
+
+    @Test
+    void testGetProjectRolesWithoutProjectScope() {
+        // The global scope names no project, which is a normal state - not an error.
+        assertTrue(polarionService.getProjectRoles("").isEmpty());
+        assertTrue(polarionService.getProjectRoles(null).isEmpty());
+        assertTrue(polarionService.getProjectRoles("no-project-here").isEmpty());
     }
 
     @Test

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/settings/AuthorizationModelTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/settings/AuthorizationModelTest.java
@@ -82,4 +82,16 @@ class AuthorizationModelTest {
         assertTrue(model.getProjectRoles().isEmpty());
         assertTrue(model.getAllRoles().isEmpty());
     }
+
+    @Test
+    void testGetAllRolesWhenNeverPopulated() {
+        // A model straight from the constructor, or built from JSON that omitted a list, has nulls;
+        // aggregating them must grant nothing rather than throw.
+        assertTrue(new AuthorizationModel().getAllRoles().isEmpty());
+
+        AuthorizationModel onlyGlobal = new AuthorizationModel();
+        onlyGlobal.setGlobalRoles("admin");
+
+        assertEquals(List.of("admin"), onlyGlobal.getAllRoles());
+    }
 }

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/settings/AuthorizationModelTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/settings/AuthorizationModelTest.java
@@ -1,0 +1,72 @@
+package ch.sbb.polarion.extension.generic.settings;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AuthorizationModelTest {
+
+    @Test
+    void testSerializeAndDeserialize() {
+        AuthorizationModel model = new AuthorizationModel();
+        model.setGlobalRoles("admin", "user");
+        model.setProjectRoles("project_admin");
+
+        String serialized = model.serialize();
+        assertTrue(serialized.contains(AuthorizationModel.GLOBAL_ROLES));
+        assertTrue(serialized.contains(AuthorizationModel.PROJECT_ROLES));
+
+        AuthorizationModel deserialized = new AuthorizationModel();
+        deserialized.deserialize(serialized);
+
+        assertEquals(List.of("admin", "user"), deserialized.getGlobalRoles());
+        assertEquals(List.of("project_admin"), deserialized.getProjectRoles());
+    }
+
+    @Test
+    void testDeserializeEmptyRoles() {
+        AuthorizationModel model = new AuthorizationModel();
+        model.setGlobalRoles();
+        model.setProjectRoles();
+
+        AuthorizationModel deserialized = new AuthorizationModel();
+        deserialized.deserialize(model.serialize());
+
+        assertTrue(deserialized.getGlobalRoles().isEmpty());
+        assertTrue(deserialized.getProjectRoles().isEmpty());
+    }
+
+    @Test
+    void testSerializeRolesNotSet() {
+        // A model that was never populated must still serialize; the entries are simply left out.
+        AuthorizationModel model = new AuthorizationModel();
+
+        String serialized = model.serialize();
+
+        assertTrue(serialized.contains(AuthorizationModel.GLOBAL_ROLES));
+        assertTrue(serialized.contains(AuthorizationModel.PROJECT_ROLES));
+    }
+
+    @Test
+    void testGetAllRoles() {
+        AuthorizationModel model = new AuthorizationModel();
+        model.setGlobalRoles("admin");
+        model.setProjectRoles("project_admin", "lead");
+
+        assertEquals(List.of("admin", "project_admin", "lead"), model.getAllRoles());
+    }
+
+    @Test
+    void testDeserializeIgnoresBlankEntries() {
+        AuthorizationModel model = new AuthorizationModel();
+
+        model.deserializeModelData(model.serializeEntry(AuthorizationModel.GLOBAL_ROLES, "admin, ,user")
+                + model.serializeEntry(AuthorizationModel.PROJECT_ROLES, ""));
+
+        assertEquals(List.of("admin", "user"), model.getGlobalRoles());
+        assertTrue(model.getProjectRoles().isEmpty());
+    }
+}

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/settings/AuthorizationModelTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/settings/AuthorizationModelTest.java
@@ -69,4 +69,17 @@ class AuthorizationModelTest {
         assertEquals(List.of("admin", "user"), model.getGlobalRoles());
         assertTrue(model.getProjectRoles().isEmpty());
     }
+
+    @Test
+    void testDeserializeMissingEntries() {
+        // A setting written before the roles existed, or edited by hand, has no such block at all; it
+        // must read as "nothing granted" rather than failing the whole load.
+        AuthorizationModel model = new AuthorizationModel();
+
+        model.deserialize(model.serializeEntry(SettingsModel.NAME, "Default"));
+
+        assertTrue(model.getGlobalRoles().isEmpty());
+        assertTrue(model.getProjectRoles().isEmpty());
+        assertTrue(model.getAllRoles().isEmpty());
+    }
 }

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/util/TestUtils.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/util/TestUtils.java
@@ -49,6 +49,9 @@ public class TestUtils {
         lenient().doCallRealMethod().when(polarionService).setFieldValue(any(),any(), any());
         lenient().doCallRealMethod().when(polarionService).setFieldValue(any(),any(), any(), any());
 
+        lenient().when(polarionService.getGlobalRoles()).thenCallRealMethod();
+        lenient().when(polarionService.getProjectRoles(any())).thenCallRealMethod();
+
         lenient().when(polarionService.getPolarionProductName()).thenCallRealMethod();
         lenient().when(polarionService.getPolarionVersion()).thenCallRealMethod();
 


### PR DESCRIPTION
### Proposed changes

Three extensions - xml-repair, api-extender and diff-tool - each carry their own byte-identical copy of the code that resolves which roles exist in a scope, and two of them also carry the endpoint that serves them to an administration page. diff-tool is about to add a third of each as it converts to React.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
