### PR TITLE
fix: hide internal roles endpoint from the OpenAPI spec

### DIFF
--- a/app/src/main/java/ch/sbb/polarion/extension/generic/rest/controller/roles/RolesInternalController.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/rest/controller/roles/RolesInternalController.java
@@ -2,6 +2,7 @@ package ch.sbb.polarion.extension.generic.rest.controller.roles;
 
 import ch.sbb.polarion.extension.generic.rest.model.RolesInfo;
 import ch.sbb.polarion.extension.generic.service.PolarionService;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -28,6 +29,7 @@ import java.util.ArrayList;
  * {@code getExtensionControllerClasses()}.
  */
 @Singleton
+@Hidden
 @Tag(name = "Roles")
 @Path("/internal")
 public class RolesInternalController {


### PR DESCRIPTION
### Proposed changes

RolesInternalController was missing @Hidden, which every other internal controller carries. An extension that lists the roles package in the swagger plugin's resourcePackages therefore documented /internal/roles next to /api/roles, while all its other internal endpoints stayed out.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
