### PR TITLE
chore: drop the unused exec-maven-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,6 @@
         <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
         <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
         <maven-dependency-plugin.version>3.11.0</maven-dependency-plugin.version>
-        <exec-maven-plugin.version>3.3.0</exec-maven-plugin.version>
         <pre-commit-run-maven-plugin.version>1.0.0</pre-commit-run-maven-plugin.version>
         <swagger-maven-plugin.version>2.2.52</swagger-maven-plugin.version>
         <sonar-maven-plugin.version>5.7.0.6970</sonar-maven-plugin.version>


### PR DESCRIPTION
### Proposed changes

`exec-maven-plugin.version` is declared but no pom in this repository - neither this one nor the `app` module - declares `exec-maven-plugin`, so the property has never resolved anywhere. Two consumers (pdf-exporter, docx-exporter) carried a copy of it for the same reason: none. Removed here; their copies go in their own PRs.

Full build green: 469 tests.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
