### PR TITLE
feat: add /internal/disclaimer endpoint

### DIFF
--- a/app/src/main/java/ch/sbb/polarion/extension/generic/rest/controller/info/ExtensionInfoInternalController.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/rest/controller/info/ExtensionInfoInternalController.java
@@ -119,6 +119,15 @@ public class ExtensionInfoInternalController {
         return readHtmlFile("user-guide.html");
     }
 
+    @GET
+    @Path("/disclaimer")
+    @Produces(MediaType.TEXT_HTML)
+    @Operation(summary = "Returns the build-generated DISCLAIMER help article shown on the Usage Disclaimer page",
+            responses = @ApiResponse(description = "HTML help article"))
+    public String getDisclaimer() {
+        return readHtmlFile("disclaimer.html");
+    }
+
     /**
      * Webapp contexts searched for the build-generated HTML help articles, in order. Extensions whose
      * administration UI is a React app keep them under {@code -app}; those still on the JSP admin UI

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/rest/controller/info/ExtensionInfoInternalControllerTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/rest/controller/info/ExtensionInfoInternalControllerTest.java
@@ -11,7 +11,7 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 /**
- * The help articles (about.html / user-guide.html) are generated at build time into an extension's
+ * The help articles (about.html / user-guide.html / disclaimer.html) are generated at build time into an extension's
  * webapp resources and read back from the classpath. Extensions with a React administration UI keep
  * them under {@code <ext>-app}, the ones still on the JSP admin UI under {@code <ext>-admin}; both
  * must work. The fixtures live in src/test/resources/webapp/.
@@ -53,6 +53,20 @@ class ExtensionInfoInternalControllerTest {
     void readsTheUserGuideTheSameWay() {
         try (MockedStatic<ExtensionInfo> ignored = mockExtensionContext("react-ext")) {
             assertThat(controller.getUserGuide()).contains("react app user guide");
+        }
+    }
+
+    @Test
+    void readsTheDisclaimerTheSameWay() {
+        try (MockedStatic<ExtensionInfo> ignored = mockExtensionContext("react-ext")) {
+            assertThat(controller.getDisclaimer()).contains("react app disclaimer");
+        }
+    }
+
+    @Test
+    void returnsEmptyWhenTheExtensionHasNoDisclaimer() {
+        try (MockedStatic<ExtensionInfo> ignored = mockExtensionContext("legacy-ext")) {
+            assertThat(controller.getDisclaimer()).isEmpty();
         }
     }
 

--- a/app/src/test/resources/webapp/react-ext-app/html/disclaimer.html
+++ b/app/src/test/resources/webapp/react-ext-app/html/disclaimer.html
@@ -1,0 +1,1 @@
+<h1>react app disclaimer</h1>


### PR DESCRIPTION
Closes #624

Serves the build-generated `DISCLAIMER` article the same way `/readme` and `/user-guide` are served.

## Changes

- `ExtensionInfoInternalController.getDisclaimer()` - `GET /internal/disclaimer`, `text/html`, returns `readHtmlFile("disclaimer.html")`.
- Same contract as the other two articles: an empty string when the extension ships no disclaimer, so a consumer can tell "not generated" from "not applicable".
- Tests: reads the article from the `-app` webapp, and returns empty for an extension without a disclaimer. New fixture `react-ext-app/html/disclaimer.html`.

## Effect

react-sbb-polarion can carry a shared Usage Disclaimer page next to `About` and `UserGuide`. pdf-exporter and docx-exporter drop their static `.../ui/html/disclaimer.html` fetch and its dev-proxy entry.
