### PR TITLE
feat: expose rich text detection on FieldMetadata

### DIFF
--- a/app/src/main/java/ch/sbb/polarion/extension/generic/fields/model/FieldMetadata.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/fields/model/FieldMetadata.java
@@ -1,5 +1,6 @@
 package ch.sbb.polarion.extension.generic.fields.model;
 
+import ch.sbb.polarion.extension.generic.fields.FieldType;
 import com.polarion.platform.persistence.model.IPrototype;
 import com.polarion.subterra.base.data.model.ICustomField;
 import com.polarion.subterra.base.data.model.IType;
@@ -58,6 +59,33 @@ public class FieldMetadata implements Comparable<FieldMetadata>{
                 .required(customField.isRequired())
                 .multi(customField.isMulti())
                 .build();
+    }
+
+    /**
+     * Tells whether Polarion treats this field as a rich text field.
+     * <p>
+     * Polarion regards a Text field as rich text unless it is a custom field which doesn't declare the 'html' subtype.
+     * Built-in Text fields like 'description' declare no subtype at all, so they are rich text too. This mirrors
+     * {@code com.polarion.alm.tracker.internal.TypeHelper#isRichText(IType)} for built-in fields and
+     * {@code #isRichTextCustomField(IType)} for custom ones, which Polarion dispatches by {@code isKeyDefined(fieldId)},
+     * the same predicate {@link #fromPrototype(IPrototype, String)} uses to set {@link #custom}.
+     * </p>
+     * Written as plain text, such a field looks unchanged in Polarion but loses its formatting in follow-up operations
+     * like a ReqIF export.
+     *
+     * @return true if a value of this field must be stored as {@code text/html}, false if as {@code text/plain}
+     */
+    public boolean isRichText() {
+        return FieldType.RICH.getType().equals(type) || (FieldType.TEXT.getType().equals(type) && !custom);
+    }
+
+    /**
+     * Tells whether this field holds a text value, no matter whether it is rich text or plain text.
+     *
+     * @return true if a value of this field must be stored as a {@link com.polarion.core.util.types.Text} instance
+     */
+    public boolean isTextType() {
+        return FieldType.TEXT.getType().equals(type) || FieldType.RICH.getType().equals(type);
     }
 
     @Override

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/fields/model/FieldMetadataTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/fields/model/FieldMetadataTest.java
@@ -1,11 +1,16 @@
 package ch.sbb.polarion.extension.generic.fields.model;
 
+import com.polarion.core.util.types.Text;
 import com.polarion.platform.persistence.model.IPrototype;
 import com.polarion.subterra.base.data.model.ICustomField;
+import com.polarion.subterra.base.data.model.IType;
+import com.polarion.subterra.base.data.model.internal.PrimitiveType;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -19,5 +24,42 @@ class FieldMetadataTest {
         // field metadata are the same when their ID's same
         assertEquals(FieldMetadata.fromPrototype(mock(IPrototype.class), "testFieldId"), FieldMetadata.fromCustomField(customField));
         assertNotEquals(FieldMetadata.fromPrototype(mock(IPrototype.class), "testFieldId2"), FieldMetadata.fromCustomField(customField));
+    }
+
+    @Test
+    void testIsRichTextForBuiltInFields() {
+        // a built-in Text field declares no subtype at all, still Polarion treats it as rich text
+        assertTrue(builtInField("description", new PrimitiveType(Text.class.getName())).isRichText());
+        assertTrue(builtInField("description", new PrimitiveType(Text.class.getName(), "html")).isRichText());
+        assertFalse(builtInField("title", new PrimitiveType(String.class.getName())).isRichText());
+    }
+
+    @Test
+    void testIsRichTextForCustomFields() {
+        // a custom field is rich text only if it declares the 'html' subtype
+        assertTrue(customField("customRichText", new PrimitiveType(Text.class.getName(), "html")).isRichText());
+        assertFalse(customField("customPlainText", new PrimitiveType(Text.class.getName())).isRichText());
+        assertFalse(customField("customString", new PrimitiveType(String.class.getName())).isRichText());
+    }
+
+    @Test
+    void testIsTextType() {
+        assertTrue(builtInField("description", new PrimitiveType(Text.class.getName())).isTextType());
+        assertTrue(customField("customRichText", new PrimitiveType(Text.class.getName(), "html")).isTextType());
+        assertFalse(customField("customString", new PrimitiveType(String.class.getName())).isTextType());
+    }
+
+    private FieldMetadata builtInField(String fieldId, IType type) {
+        IPrototype prototype = mock(IPrototype.class);
+        when(prototype.getKeyType(fieldId)).thenReturn(type);
+        when(prototype.isKeyDefined(fieldId)).thenReturn(true);
+        return FieldMetadata.fromPrototype(prototype, fieldId);
+    }
+
+    private FieldMetadata customField(String fieldId, IType type) {
+        ICustomField customField = mock(ICustomField.class);
+        when(customField.getId()).thenReturn(fieldId);
+        when(customField.getType()).thenReturn(type);
+        return FieldMetadata.fromCustomField(customField);
     }
 }


### PR DESCRIPTION
Refs: #643

### Proposed changes

We have to add some extra methods into FieldMetadata to handle rich text detection easier.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
