### PR TITLE
fix: ensure deterministic authentication-before-authorization filter …

### DIFF
--- a/app/src/main/java/ch/sbb/polarion/extension/generic/rest/GenericRestApplication.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/rest/GenericRestApplication.java
@@ -45,9 +45,10 @@ public class GenericRestApplication extends Application {
         singletons.add(JacksonFeature.withoutExceptionMappers());
         singletons.add(LifecycleBindingFeature.bindFrom(getClasses()));
         singletons.addAll(getAllExceptionMapperSingletons());
-        // Register filters with explicit, @Priority-derived binding priorities instead of adding them as bare
-        // singletons. This guarantees distinct, deterministic filter ranks and avoids the non-deterministic
-        // ordering caused by Jersey's RankedComparator tie-handling over the HashSet iteration order.
+        // Register filter singletons with explicit, @Priority-derived binding priorities instead of adding
+        // them as bare singletons, so filters with distinct priorities order deterministically instead of
+        // by HashSet iteration order. See PrioritizedFiltersFeature for the full rationale and the
+        // downstream @Priority contract.
         singletons.add(PrioritizedFiltersFeature.of(getAllFilterSingletons()));
         singletons.addAll(getAllControllerSingletons());
         return singletons;
@@ -99,6 +100,16 @@ public class GenericRestApplication extends Application {
         return Set.of();
     }
 
+    /**
+     * Request/response filter instances contributed by the extension. These are registered with an explicit,
+     * {@code @Priority}-derived binding priority (see {@link ch.sbb.polarion.extension.generic.rest.feature.PrioritizedFiltersFeature}).
+     * <p>
+     * Ordering contract: the generic {@code AuthenticationFilter} runs at {@link jakarta.ws.rs.Priorities#AUTHENTICATION}.
+     * A filter that must run <em>after</em> authentication (e.g. an authorization filter that reads the request
+     * subject) must carry a strictly larger priority — annotate it {@code @Priority(Priorities.AUTHORIZATION)}.
+     * Annotating such a filter {@code @Priority(Priorities.AUTHENTICATION)} ties it with {@code AuthenticationFilter}
+     * and makes their relative order non-deterministic.
+     */
     @NotNull
     protected Set<Object> getExtensionFilterSingletons() {
         return Set.of();

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/rest/GenericRestApplication.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/rest/GenericRestApplication.java
@@ -20,6 +20,7 @@ import ch.sbb.polarion.extension.generic.rest.exception.mapper.ObjectNotFoundExc
 import ch.sbb.polarion.extension.generic.rest.exception.mapper.NotAuthorizedExceptionMapper;
 import ch.sbb.polarion.extension.generic.rest.exception.mapper.UncaughtExceptionMapper;
 import ch.sbb.polarion.extension.generic.rest.feature.LifecycleBindingFeature;
+import ch.sbb.polarion.extension.generic.rest.feature.PrioritizedFiltersFeature;
 import ch.sbb.polarion.extension.generic.rest.filter.AuthenticationFilter;
 import ch.sbb.polarion.extension.generic.rest.filter.CorsFilter;
 import ch.sbb.polarion.extension.generic.rest.filter.LogoutFilter;
@@ -44,7 +45,10 @@ public class GenericRestApplication extends Application {
         singletons.add(JacksonFeature.withoutExceptionMappers());
         singletons.add(LifecycleBindingFeature.bindFrom(getClasses()));
         singletons.addAll(getAllExceptionMapperSingletons());
-        singletons.addAll(getAllFilterSingletons());
+        // Register filters with explicit, @Priority-derived binding priorities instead of adding them as bare
+        // singletons. This guarantees distinct, deterministic filter ranks and avoids the non-deterministic
+        // ordering caused by Jersey's RankedComparator tie-handling over the HashSet iteration order.
+        singletons.add(PrioritizedFiltersFeature.of(getAllFilterSingletons()));
         singletons.addAll(getAllControllerSingletons());
         return singletons;
     }

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/rest/feature/PrioritizedFiltersFeature.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/rest/feature/PrioritizedFiltersFeature.java
@@ -74,11 +74,21 @@ public class PrioritizedFiltersFeature implements Feature {
     }
 
     /**
-     * Reads the {@link Priority} value declared on the filter class, or {@link Priorities#USER} when the
-     * annotation is absent (the JAX-RS default for providers without an explicit priority).
+     * Reads the {@link Priority} value for the filter class, or {@link Priorities#USER} when none is declared
+     * (the JAX-RS default for providers without an explicit priority).
+     * <p>
+     * {@link Priority} is <em>not</em> {@link java.lang.annotation.Inherited}, so a subclass of an annotated
+     * filter (e.g. a downstream subclass of {@code AuthenticationFilter}) would otherwise resolve to
+     * {@link Priorities#USER} and lose its intended ordering. We therefore walk the superclass chain and use
+     * the nearest declared {@code @Priority}, giving the annotation inheritance-like semantics for filters.
      */
     static int priorityOf(Class<?> filterClass) {
-        Priority priority = filterClass.getAnnotation(Priority.class);
-        return priority != null ? priority.value() : Priorities.USER;
+        for (Class<?> type = filterClass; type != null && type != Object.class; type = type.getSuperclass()) {
+            Priority priority = type.getDeclaredAnnotation(Priority.class);
+            if (priority != null) {
+                return priority.value();
+            }
+        }
+        return Priorities.USER;
     }
 }

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/rest/feature/PrioritizedFiltersFeature.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/rest/feature/PrioritizedFiltersFeature.java
@@ -1,0 +1,70 @@
+package ch.sbb.polarion.extension.generic.rest.feature;
+
+import com.polarion.core.util.logging.Logger;
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.core.Feature;
+import jakarta.ws.rs.core.FeatureContext;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Registers request/response filters with an <em>explicit</em> binding priority read from each filter's
+ * {@link Priority} annotation (defaulting to {@link Priorities#USER} when absent).
+ * <p>
+ * Why this is needed. When filters are registered as instances via {@code Application.getSingletons()},
+ * Jersey does not reliably capture their {@code @Priority} into the provider model, so several name-bound
+ * filters can end up sharing the same default rank. Jersey's {@code RankedComparator} does <b>not</b>
+ * return {@code 0} for equal ranks (it returns {@code ±ordering}), so ties are resolved by the iteration
+ * order of the {@link java.util.HashSet} backing {@code getSingletons()} — which differs per application
+ * instance and per JVM start. The practical effect was a non-deterministic order between
+ * {@code AuthenticationFilter} (authentication) and an authorization filter: sometimes authorization ran
+ * first, found no authenticated subject, and failed.
+ * <p>
+ * Passing an explicit priority through {@link FeatureContext#register(Object, int)} bypasses the fragile
+ * annotation capture and guarantees distinct, deterministic ranks, so {@code RankedComparator} orders the
+ * filters correctly regardless of registration/iteration order.
+ */
+public class PrioritizedFiltersFeature implements Feature {
+
+    private static final Logger logger = Logger.getLogger(PrioritizedFiltersFeature.class);
+
+    private final Set<Object> filters;
+
+    private PrioritizedFiltersFeature(Set<Object> filters) {
+        this.filters = filters;
+    }
+
+    public static PrioritizedFiltersFeature of(Set<Object> filters) {
+        return new PrioritizedFiltersFeature(filters);
+    }
+
+    @Override
+    public boolean configure(FeatureContext context) {
+        // The incoming set has no defined iteration order. Distinct explicit priorities already make the
+        // final filter order deterministic (Jersey sorts by rank), so this ordering is not required for
+        // correctness; we still register in a stable (priority, class-name) order so the debug log is
+        // reproducible and any same-priority ties are registered deterministically.
+        List<Object> ordered = filters.stream()
+                .sorted(Comparator.comparingInt((Object f) -> priorityOf(f.getClass()))
+                        .thenComparing(f -> f.getClass().getName()))
+                .toList();
+        for (Object filter : ordered) {
+            int priority = priorityOf(filter.getClass());
+            context.register(filter, priority);
+            logger.debug("Registered filter " + filter.getClass().getName() + " with priority=" + priority);
+        }
+        return true;
+    }
+
+    /**
+     * Reads the {@link Priority} value declared on the filter class, or {@link Priorities#USER} when the
+     * annotation is absent (the JAX-RS default for providers without an explicit priority).
+     */
+    static int priorityOf(Class<?> filterClass) {
+        Priority priority = filterClass.getAnnotation(Priority.class);
+        return priority != null ? priority.value() : Priorities.USER;
+    }
+}

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/rest/feature/PrioritizedFiltersFeature.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/rest/feature/PrioritizedFiltersFeature.java
@@ -11,21 +11,35 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Registers request/response filters with an <em>explicit</em> binding priority read from each filter's
- * {@link Priority} annotation (defaulting to {@link Priorities#USER} when absent).
+ * Registers the request/response filter <em>instances</em> returned from {@code getSingletons()} with an
+ * explicit, {@link Priority}-derived binding priority (defaulting to {@link Priorities#USER} when the
+ * annotation is absent), via {@link FeatureContext#register(Object, int)}.
  * <p>
- * Why this is needed. When filters are registered as instances via {@code Application.getSingletons()},
- * Jersey does not reliably capture their {@code @Priority} into the provider model, so several name-bound
- * filters can end up sharing the same default rank. Jersey's {@code RankedComparator} does <b>not</b>
- * return {@code 0} for equal ranks (it returns {@code ±ordering}), so ties are resolved by the iteration
- * order of the {@link java.util.HashSet} backing {@code getSingletons()} — which differs per application
- * instance and per JVM start. The practical effect was a non-deterministic order between
- * {@code AuthenticationFilter} (authentication) and an authorization filter: sometimes authorization ran
- * first, found no authenticated subject, and failed.
+ * Why this is needed. When a filter is added as a bare instance to {@code Application.getSingletons()},
+ * its {@code @Priority} is not reliably reflected in the Jersey provider model, so several name-bound
+ * filters can end up with the same default rank. Filters that share a rank are <em>not</em> ordered by
+ * priority: in the Jersey shipped with Polarion (jersey-common 3.1.8) {@code RankedComparator} returns
+ * {@code ±ordering} rather than {@code 0} for equal ranks, and even if it returned {@code 0} the sort
+ * would merely be stable — either way ties fall back to the iteration order of the {@link java.util.HashSet}
+ * backing {@code getSingletons()}, which varies per application instance and JVM start. The observed effect
+ * was a non-deterministic order between {@code AuthenticationFilter} and a downstream authorization filter:
+ * sometimes authorization ran first, found no authenticated subject, and failed.
  * <p>
- * Passing an explicit priority through {@link FeatureContext#register(Object, int)} bypasses the fragile
- * annotation capture and guarantees distinct, deterministic ranks, so {@code RankedComparator} orders the
- * filters correctly regardless of registration/iteration order.
+ * Registering with an explicit priority makes each filter's rank <em>annotation-derived and reproducible</em>,
+ * so {@code RankedComparator} orders any two filters that carry <em>different</em> {@code @Priority} values
+ * deterministically, regardless of registration/iteration order. The guarantee is between distinct
+ * priorities only: filters without {@code @Priority} (e.g. {@code CorsFilter}, {@code LogoutFilter}) all
+ * resolve to {@link Priorities#USER} and still tie among themselves — harmless as long as their relative
+ * order does not matter (both are outside the authentication→authorization request path).
+ * <p>
+ * Scope: this only covers filters registered as <em>singletons</em>. Filters contributed as classes
+ * ({@code getClasses()}) go through Jersey's standard class-model registration and are not touched here.
+ * <p>
+ * Downstream contract: {@code AuthenticationFilter} runs at {@link Priorities#AUTHENTICATION}. An extension
+ * filter that must run <em>after</em> authentication (e.g. an authorization filter that reads the request
+ * subject) must therefore carry a strictly larger priority — annotate it {@code @Priority(Priorities.AUTHORIZATION)}.
+ * Do not annotate an authorization filter {@code @Priority(Priorities.AUTHENTICATION)}: that ties with
+ * {@code AuthenticationFilter} and reintroduces the non-deterministic ordering this class prevents.
  */
 public class PrioritizedFiltersFeature implements Feature {
 

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/rest/filter/AuthenticationFilter.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/rest/filter/AuthenticationFilter.java
@@ -7,6 +7,8 @@ import com.polarion.platform.core.PlatformContext;
 import com.polarion.platform.security.AuthenticationFailedException;
 import com.polarion.platform.security.ISecurityService;
 import com.polarion.platform.session.PolarionSingleSignOn;
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -23,6 +25,7 @@ import java.io.IOException;
 
 @Secured
 @Provider
+@Priority(Priorities.AUTHENTICATION)
 public class AuthenticationFilter implements ContainerRequestFilter {
     public static final String BEARER = "Bearer";
     public static final String USER_SUBJECT = "user_subject";

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/rest/GenericRestApplicationTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/rest/GenericRestApplicationTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.ContainerResponseFilter;
 import java.util.List;
 import java.util.Set;
 
@@ -52,8 +53,10 @@ class GenericRestApplicationTest {
     void getSingletonsRegistersFiltersThroughFeatureNotAsBareSingletons() {
         GenericRestApplication app = new GenericRestApplication();
         // Filters must be registered with explicit priorities via PrioritizedFiltersFeature, so no filter
-        // instance should leak into the singleton set directly (that path loses the @Priority ordering).
-        assertFalse(app.getSingletons().stream().anyMatch(ContainerRequestFilter.class::isInstance));
+        // instance (request or response) should leak into the singleton set directly — that path loses the
+        // @Priority ordering.
+        assertFalse(app.getSingletons().stream()
+                .anyMatch(s -> s instanceof ContainerRequestFilter || s instanceof ContainerResponseFilter));
     }
 
     @Test

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/rest/GenericRestApplicationTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/rest/GenericRestApplicationTest.java
@@ -3,6 +3,7 @@ package ch.sbb.polarion.extension.generic.rest;
 import ch.sbb.polarion.extension.generic.rest.controller.settings.NamedSettingsApiController;
 import ch.sbb.polarion.extension.generic.rest.controller.settings.NamedSettingsInternalController;
 import ch.sbb.polarion.extension.generic.rest.feature.LifecycleBindingFeature;
+import ch.sbb.polarion.extension.generic.rest.feature.PrioritizedFiltersFeature;
 import ch.sbb.polarion.extension.generic.settings.GenericNamedSettings;
 import ch.sbb.polarion.extension.generic.settings.NamedSettingsRegistry;
 import ch.sbb.polarion.extension.generic.test_extensions.PlatformContextMockExtension;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import jakarta.ws.rs.container.ContainerRequestFilter;
 import java.util.List;
 import java.util.Set;
 
@@ -38,6 +40,20 @@ class GenericRestApplicationTest {
     void getSingletonsContainsLifecycleBindingFeature() {
         GenericRestApplication app = new GenericRestApplication();
         assertTrue(app.getSingletons().stream().anyMatch(LifecycleBindingFeature.class::isInstance));
+    }
+
+    @Test
+    void getSingletonsContainsPrioritizedFiltersFeature() {
+        GenericRestApplication app = new GenericRestApplication();
+        assertTrue(app.getSingletons().stream().anyMatch(PrioritizedFiltersFeature.class::isInstance));
+    }
+
+    @Test
+    void getSingletonsRegistersFiltersThroughFeatureNotAsBareSingletons() {
+        GenericRestApplication app = new GenericRestApplication();
+        // Filters must be registered with explicit priorities via PrioritizedFiltersFeature, so no filter
+        // instance should leak into the singleton set directly (that path loses the @Priority ordering).
+        assertFalse(app.getSingletons().stream().anyMatch(ContainerRequestFilter.class::isInstance));
     }
 
     @Test

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/rest/feature/PrioritizedFiltersFeatureRuntimeTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/rest/feature/PrioritizedFiltersFeatureRuntimeTest.java
@@ -4,25 +4,35 @@ import jakarta.annotation.Priority;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.core.FeatureContext;
 import org.glassfish.jersey.model.internal.RankedComparator;
 import org.glassfish.jersey.model.internal.RankedProvider;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 /**
- * Runtime-ordering counterpart to {@link PrioritizedFiltersFeatureTest}. The mocked-{@code FeatureContext} tests only
- * assert that {@link PrioritizedFiltersFeature} <em>registers</em> filters with the right ranks; they do not prove
- * that those ranks actually place authentication before authorization once Jersey orders the provider chain.
+ * Runtime-ordering counterpart to {@link PrioritizedFiltersFeatureTest}. The mocked-{@code FeatureContext} tests
+ * assert only that {@link PrioritizedFiltersFeature} <em>registers</em> filters with the right ranks; they do not
+ * prove that those ranks actually place authentication before authorization once Jersey orders the provider chain.
  * <p>
- * Jersey orders {@link ContainerRequestFilter}s at request time with {@link RankedComparator} using
- * {@link RankedComparator.Order#ASCENDING}. This test feeds that very comparator the ranks
- * {@link PrioritizedFiltersFeature} assigns and asserts the resulting execution order, so a regression that keeps
- * registration correct but yields the wrong effective order (the original bug) is caught. Using the real Jersey
- * ordering component keeps this independent of a full {@code ApplicationHandler}, whose {@code jersey-server}
- * packages are not on this module's test classpath.
+ * This test drives {@link PrioritizedFiltersFeature#configure(FeatureContext)} for real, captures the
+ * {@code (filter, priority)} pairs it registers, and then feeds those captured ranks to the very comparator Jersey
+ * uses for request filters ({@link RankedComparator} with {@link RankedComparator.Order#ASCENDING}). It therefore
+ * catches two regressions the mock-only tests miss: (a) {@code configure} dropping the explicit priority — e.g.
+ * calling {@code register(filter)} instead of {@code register(filter, priority)} — because the captor would then
+ * find no ranked registration, and (b) a rank assignment that keeps registration correct but yields the wrong
+ * effective order. Using the real Jersey comparator keeps this independent of a full {@code ApplicationHandler},
+ * whose {@code jersey-server} packages are not on this module's test classpath.
  */
 class PrioritizedFiltersFeatureRuntimeTest {
 
@@ -54,17 +64,28 @@ class PrioritizedFiltersFeatureRuntimeTest {
     }
 
     /**
-     * Wraps the given filters with the ranks {@link PrioritizedFiltersFeature} assigns, sorts them with the same
+     * Runs the feature over the given filters, takes the ranks it actually registered, sorts them with the same
      * comparator Jersey uses for request filters, and asserts the authentication filter is ordered first regardless
      * of the incoming order.
      */
     private void assertAuthenticationRunsFirst(ContainerRequestFilter... filtersInInputOrder) {
-        List<RankedProvider<ContainerRequestFilter>> providers = new java.util.ArrayList<>();
-        for (ContainerRequestFilter filter : filtersInInputOrder) {
-            int rank = PrioritizedFiltersFeature.priorityOf(filter.getClass());
-            providers.add(new RankedProvider<>(filter, rank));
-        }
+        Set<Object> filters = new LinkedHashSet<>(List.of(filtersInInputOrder));
+        FeatureContext context = mock(FeatureContext.class);
 
+        PrioritizedFiltersFeature.of(filters).configure(context);
+
+        // Capture what the feature actually registered — this ties the assertion to configure()'s behaviour,
+        // so dropping the explicit priority would fail here (no ranked registration to capture).
+        ArgumentCaptor<Object> filterCaptor = ArgumentCaptor.forClass(Object.class);
+        ArgumentCaptor<Integer> priorityCaptor = ArgumentCaptor.forClass(Integer.class);
+        verify(context, atLeastOnce()).register(filterCaptor.capture(), priorityCaptor.capture());
+        List<Object> registeredFilters = filterCaptor.getAllValues();
+        List<Integer> registeredPriorities = priorityCaptor.getAllValues();
+
+        List<RankedProvider<ContainerRequestFilter>> providers = new ArrayList<>();
+        for (int i = 0; i < registeredFilters.size(); i++) {
+            providers.add(new RankedProvider<>((ContainerRequestFilter) registeredFilters.get(i), registeredPriorities.get(i)));
+        }
         providers.sort(new RankedComparator<>(RankedComparator.Order.ASCENDING));
 
         List<Class<?>> orderedTypes = providers.stream()

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/rest/feature/PrioritizedFiltersFeatureRuntimeTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/rest/feature/PrioritizedFiltersFeatureRuntimeTest.java
@@ -68,8 +68,8 @@ class PrioritizedFiltersFeatureRuntimeTest {
         providers.sort(new RankedComparator<>(RankedComparator.Order.ASCENDING));
 
         List<Class<?>> orderedTypes = providers.stream()
-                .map(p -> p.getProvider().getClass())
-                .collect(java.util.stream.Collectors.toList());
+                .<Class<?>>map(p -> p.getProvider().getClass())
+                .toList();
         assertEquals(List.of(AuthenticationFilterStub.class, AuthorizationFilterStub.class), orderedTypes,
                 "Jersey's RankedComparator must order the AUTHENTICATION filter before the AUTHORIZATION filter");
     }

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/rest/feature/PrioritizedFiltersFeatureRuntimeTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/rest/feature/PrioritizedFiltersFeatureRuntimeTest.java
@@ -1,0 +1,76 @@
+package ch.sbb.polarion.extension.generic.rest.feature;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import org.glassfish.jersey.model.internal.RankedComparator;
+import org.glassfish.jersey.model.internal.RankedProvider;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Runtime-ordering counterpart to {@link PrioritizedFiltersFeatureTest}. The mocked-{@code FeatureContext} tests only
+ * assert that {@link PrioritizedFiltersFeature} <em>registers</em> filters with the right ranks; they do not prove
+ * that those ranks actually place authentication before authorization once Jersey orders the provider chain.
+ * <p>
+ * Jersey orders {@link ContainerRequestFilter}s at request time with {@link RankedComparator} using
+ * {@link RankedComparator.Order#ASCENDING}. This test feeds that very comparator the ranks
+ * {@link PrioritizedFiltersFeature} assigns and asserts the resulting execution order, so a regression that keeps
+ * registration correct but yields the wrong effective order (the original bug) is caught. Using the real Jersey
+ * ordering component keeps this independent of a full {@code ApplicationHandler}, whose {@code jersey-server}
+ * packages are not on this module's test classpath.
+ */
+class PrioritizedFiltersFeatureRuntimeTest {
+
+    @Priority(Priorities.AUTHENTICATION)
+    private static class AuthenticationFilterStub implements ContainerRequestFilter {
+        @Override
+        public void filter(ContainerRequestContext requestContext) {
+            // no-op: only the declared @Priority matters for ordering
+        }
+    }
+
+    @Priority(Priorities.AUTHORIZATION)
+    private static class AuthorizationFilterStub implements ContainerRequestFilter {
+        @Override
+        public void filter(ContainerRequestContext requestContext) {
+            // no-op: only the declared @Priority matters for ordering
+        }
+    }
+
+    @Test
+    void jerseyRanksAuthenticationBeforeAuthorizationWhenAuthorizationListedFirst() {
+        // Authorization first — the exact input order that produced authorization-before-authentication before the fix.
+        assertAuthenticationRunsFirst(new AuthorizationFilterStub(), new AuthenticationFilterStub());
+    }
+
+    @Test
+    void jerseyRanksAuthenticationBeforeAuthorizationWhenAuthenticationListedFirst() {
+        assertAuthenticationRunsFirst(new AuthenticationFilterStub(), new AuthorizationFilterStub());
+    }
+
+    /**
+     * Wraps the given filters with the ranks {@link PrioritizedFiltersFeature} assigns, sorts them with the same
+     * comparator Jersey uses for request filters, and asserts the authentication filter is ordered first regardless
+     * of the incoming order.
+     */
+    private void assertAuthenticationRunsFirst(ContainerRequestFilter... filtersInInputOrder) {
+        List<RankedProvider<ContainerRequestFilter>> providers = new java.util.ArrayList<>();
+        for (ContainerRequestFilter filter : filtersInInputOrder) {
+            int rank = PrioritizedFiltersFeature.priorityOf(filter.getClass());
+            providers.add(new RankedProvider<>(filter, rank));
+        }
+
+        providers.sort(new RankedComparator<>(RankedComparator.Order.ASCENDING));
+
+        List<Class<?>> orderedTypes = providers.stream()
+                .map(p -> p.getProvider().getClass())
+                .collect(java.util.stream.Collectors.toList());
+        assertEquals(List.of(AuthenticationFilterStub.class, AuthorizationFilterStub.class), orderedTypes,
+                "Jersey's RankedComparator must order the AUTHENTICATION filter before the AUTHORIZATION filter");
+    }
+}

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/rest/feature/PrioritizedFiltersFeatureTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/rest/feature/PrioritizedFiltersFeatureTest.java
@@ -157,8 +157,6 @@ class PrioritizedFiltersFeatureTest {
 
     @Test
     void priorityOfInheritsPriorityFromAnnotatedSuperclass() {
-        // Since @Priority is not @Inherited, a plain getAnnotation(...) lookup would return USER here;
-        // this pins the superclass walk in priorityOf.
         assertEquals(Priorities.AUTHENTICATION, PrioritizedFiltersFeature.priorityOf(SubclassWithoutOwnPriority.class));
     }
 

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/rest/feature/PrioritizedFiltersFeatureTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/rest/feature/PrioritizedFiltersFeatureTest.java
@@ -1,0 +1,140 @@
+package ch.sbb.polarion.extension.generic.rest.feature;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.core.FeatureContext;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class PrioritizedFiltersFeatureTest {
+
+    @Priority(Priorities.AUTHENTICATION)
+    static class AuthenticationLikeFilter {
+    }
+
+    @Priority(Priorities.AUTHORIZATION)
+    static class AuthorizationLikeFilter {
+    }
+
+    static class UnannotatedFilter {
+    }
+
+    @Priority(Priorities.USER)
+    static class ExplicitUserFilter {
+    }
+
+    @Test
+    void configureReturnsTrue() {
+        PrioritizedFiltersFeature feature = PrioritizedFiltersFeature.of(Set.of(new AuthenticationLikeFilter()));
+        FeatureContext context = mock(FeatureContext.class);
+
+        assertTrue(feature.configure(context));
+    }
+
+    @Test
+    void eachFilterIsRegisteredWithItsAnnotatedPriority() {
+        AuthenticationLikeFilter authentication = new AuthenticationLikeFilter();
+        AuthorizationLikeFilter authorization = new AuthorizationLikeFilter();
+        PrioritizedFiltersFeature feature = PrioritizedFiltersFeature.of(Set.of(authentication, authorization));
+        FeatureContext context = mock(FeatureContext.class);
+
+        feature.configure(context);
+
+        verify(context).register(authentication, Priorities.AUTHENTICATION);
+        verify(context).register(authorization, Priorities.AUTHORIZATION);
+    }
+
+    @Test
+    void filterWithoutPriorityAnnotationIsRegisteredWithUserPriority() {
+        UnannotatedFilter filter = new UnannotatedFilter();
+        PrioritizedFiltersFeature feature = PrioritizedFiltersFeature.of(Set.of(filter));
+        FeatureContext context = mock(FeatureContext.class);
+
+        feature.configure(context);
+
+        verify(context).register(filter, Priorities.USER);
+    }
+
+    @Test
+    void filtersAreRegisteredInAscendingPriorityOrderRegardlessOfInputOrder() {
+        Object authentication = new AuthenticationLikeFilter();
+        Object authorization = new AuthorizationLikeFilter();
+        Object user = new UnannotatedFilter();
+        // Intentionally supply them in a non-priority order.
+        PrioritizedFiltersFeature feature = PrioritizedFiltersFeature.of(
+                new java.util.LinkedHashSet<>(List.of(user, authorization, authentication)));
+        FeatureContext context = mock(FeatureContext.class);
+
+        feature.configure(context);
+
+        InOrder inOrder = inOrder(context);
+        inOrder.verify(context).register(authentication, Priorities.AUTHENTICATION);
+        inOrder.verify(context).register(authorization, Priorities.AUTHORIZATION);
+        inOrder.verify(context).register(user, Priorities.USER);
+    }
+
+    @Test
+    void samePriorityFiltersAreRegisteredInDeterministicClassNameOrder() {
+        Object unannotated = new UnannotatedFilter();     // defaults to USER
+        Object explicitUser = new ExplicitUserFilter();   // explicit USER
+        PrioritizedFiltersFeature feature = PrioritizedFiltersFeature.of(
+                new java.util.LinkedHashSet<>(List.of(unannotated, explicitUser)));
+        FeatureContext context = mock(FeatureContext.class);
+
+        feature.configure(context);
+
+        // ExplicitUserFilter sorts before UnannotatedFilter by class name at equal priority.
+        InOrder inOrder = inOrder(context);
+        inOrder.verify(context).register(explicitUser, Priorities.USER);
+        inOrder.verify(context).register(unannotated, Priorities.USER);
+    }
+
+    @Test
+    void everyRegisteredFilterGetsItsOwnPositivePriority() {
+        Object authentication = new AuthenticationLikeFilter();
+        Object authorization = new AuthorizationLikeFilter();
+        Object user = new UnannotatedFilter();
+        PrioritizedFiltersFeature feature = PrioritizedFiltersFeature.of(Set.of(authentication, authorization, user));
+        FeatureContext context = mock(FeatureContext.class);
+
+        feature.configure(context);
+
+        // Each filter is registered exactly once with its own positive, distinct rank.
+        verify(context).register(authentication, Priorities.AUTHENTICATION);
+        verify(context).register(authorization, Priorities.AUTHORIZATION);
+        verify(context).register(user, Priorities.USER);
+        assertTrue(Priorities.AUTHENTICATION > 0 && Priorities.AUTHORIZATION > 0 && Priorities.USER > 0);
+        // Distinct ranks are what make the final filter order deterministic.
+        assertEquals(3, Set.of(Priorities.AUTHENTICATION, Priorities.AUTHORIZATION, Priorities.USER).size());
+    }
+
+    @Test
+    void emptyFilterSetRegistersNothing() {
+        PrioritizedFiltersFeature feature = PrioritizedFiltersFeature.of(Set.of());
+        FeatureContext context = mock(FeatureContext.class);
+
+        assertTrue(feature.configure(context));
+        verifyNoInteractions(context);
+    }
+
+    @Test
+    void priorityOfReadsAnnotatedValue() {
+        assertEquals(Priorities.AUTHENTICATION, PrioritizedFiltersFeature.priorityOf(AuthenticationLikeFilter.class));
+        assertEquals(Priorities.AUTHORIZATION, PrioritizedFiltersFeature.priorityOf(AuthorizationLikeFilter.class));
+    }
+
+    @Test
+    void priorityOfDefaultsToUserWhenAnnotationAbsent() {
+        assertEquals(Priorities.USER, PrioritizedFiltersFeature.priorityOf(UnannotatedFilter.class));
+    }
+}

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/rest/feature/PrioritizedFiltersFeatureTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/rest/feature/PrioritizedFiltersFeatureTest.java
@@ -34,6 +34,16 @@ class PrioritizedFiltersFeatureTest {
     static class ExplicitUserFilter {
     }
 
+    // Declares no @Priority of its own — its value must be resolved from the annotated superclass.
+    // @Priority is not @Inherited, so this only works via priorityOf's superclass walk.
+    static class SubclassWithoutOwnPriority extends AuthenticationLikeFilter {
+    }
+
+    // Declares its own @Priority — the nearest declared annotation must win over the inherited one.
+    @Priority(Priorities.AUTHORIZATION)
+    static class SubclassWithOwnPriority extends AuthenticationLikeFilter {
+    }
+
     @Test
     void configureReturnsTrue() {
         PrioritizedFiltersFeature feature = PrioritizedFiltersFeature.of(Set.of(new AuthenticationLikeFilter()));
@@ -143,5 +153,17 @@ class PrioritizedFiltersFeatureTest {
     @Test
     void priorityOfDefaultsToUserWhenAnnotationAbsent() {
         assertEquals(Priorities.USER, PrioritizedFiltersFeature.priorityOf(UnannotatedFilter.class));
+    }
+
+    @Test
+    void priorityOfInheritsPriorityFromAnnotatedSuperclass() {
+        // Since @Priority is not @Inherited, a plain getAnnotation(...) lookup would return USER here;
+        // this pins the superclass walk in priorityOf.
+        assertEquals(Priorities.AUTHENTICATION, PrioritizedFiltersFeature.priorityOf(SubclassWithoutOwnPriority.class));
+    }
+
+    @Test
+    void priorityOfPrefersNearestDeclaredPriorityOverInherited() {
+        assertEquals(Priorities.AUTHORIZATION, PrioritizedFiltersFeature.priorityOf(SubclassWithOwnPriority.class));
     }
 }

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/rest/feature/PrioritizedFiltersFeatureTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/rest/feature/PrioritizedFiltersFeatureTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 class PrioritizedFiltersFeatureTest {
 
@@ -70,17 +71,25 @@ class PrioritizedFiltersFeatureTest {
         Object authentication = new AuthenticationLikeFilter();
         Object authorization = new AuthorizationLikeFilter();
         Object user = new UnannotatedFilter();
-        // Intentionally supply them in a non-priority order.
-        PrioritizedFiltersFeature feature = PrioritizedFiltersFeature.of(
-                new java.util.LinkedHashSet<>(List.of(user, authorization, authentication)));
-        FeatureContext context = mock(FeatureContext.class);
+        // Every permutation of the input order must yield the same ascending-by-priority registration order.
+        List<List<Object>> inputOrders = List.of(
+                List.of(authentication, authorization, user),
+                List.of(authentication, user, authorization),
+                List.of(authorization, authentication, user),
+                List.of(authorization, user, authentication),
+                List.of(user, authentication, authorization),
+                List.of(user, authorization, authentication));
 
-        feature.configure(context);
+        for (List<Object> inputOrder : inputOrders) {
+            FeatureContext context = mock(FeatureContext.class);
 
-        InOrder inOrder = inOrder(context);
-        inOrder.verify(context).register(authentication, Priorities.AUTHENTICATION);
-        inOrder.verify(context).register(authorization, Priorities.AUTHORIZATION);
-        inOrder.verify(context).register(user, Priorities.USER);
+            PrioritizedFiltersFeature.of(new java.util.LinkedHashSet<>(inputOrder)).configure(context);
+
+            InOrder inOrder = inOrder(context);
+            inOrder.verify(context).register(authentication, Priorities.AUTHENTICATION);
+            inOrder.verify(context).register(authorization, Priorities.AUTHORIZATION);
+            inOrder.verify(context).register(user, Priorities.USER);
+        }
     }
 
     @Test
@@ -100,7 +109,7 @@ class PrioritizedFiltersFeatureTest {
     }
 
     @Test
-    void everyRegisteredFilterGetsItsOwnPositivePriority() {
+    void everyFilterIsRegisteredExactlyOnceWithItsPriority() {
         Object authentication = new AuthenticationLikeFilter();
         Object authorization = new AuthorizationLikeFilter();
         Object user = new UnannotatedFilter();
@@ -109,13 +118,11 @@ class PrioritizedFiltersFeatureTest {
 
         feature.configure(context);
 
-        // Each filter is registered exactly once with its own positive, distinct rank.
         verify(context).register(authentication, Priorities.AUTHENTICATION);
         verify(context).register(authorization, Priorities.AUTHORIZATION);
         verify(context).register(user, Priorities.USER);
-        assertTrue(Priorities.AUTHENTICATION > 0 && Priorities.AUTHORIZATION > 0 && Priorities.USER > 0);
-        // Distinct ranks are what make the final filter order deterministic.
-        assertEquals(3, Set.of(Priorities.AUTHENTICATION, Priorities.AUTHORIZATION, Priorities.USER).size());
+        // Nothing dropped, nothing registered twice: the three calls above are the only interactions.
+        verifyNoMoreInteractions(context);
     }
 
     @Test


### PR DESCRIPTION
…ordering

Refs: #646

### Proposed changes

 Problem                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
  REST request filters are registered as instances through GenericRestApplication.getSingletons(). Jersey does not reliably capture their @Priority into the provider model, so several name-bound filters end up sharing the same default rank. Jersey's RankedComparator does not return 0 for equal ranks (it returns ±ordering), so ties are resolved by the iteration order of the HashSet backing getSingletons() — which varies per application instance and per JVM start. 
  As a result, the authorization filter could run before AuthenticationFilter, find no authenticated subject, and fail an otherwise valid request intermittently. Since this is the parent project for all Polarion extensions, every downstream extension is affected.                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
  Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
  - Add PrioritizedFiltersFeature (rest/feature/) that registers each filter via FeatureContext.register(Object, int) using an explicit priority read from its @Priority annotation (defaulting to Priorities.USER). This bypasses the fragile annotation capture and guarantees distinct, deterministic ranks.                                                                                                                                                                    
  - Register filters in a stable (priority, class-name) order so the debug log is reproducible and same-priority ties are handled deterministically.                                                                                                                                                                                                                                                                                                                               
  - GenericRestApplication now registers filters through PrioritizedFiltersFeature.of(getAllFilterSingletons()) instead of adding them as bare singletons.                                                                                                                                                                                                                                                                                                                         
  - Annotate AuthenticationFilter with @Priority(Priorities.AUTHENTICATION) so it always precedes authorization.                                                                                                                                                                                                                                                                                                                                                                   
  - Add PrioritizedFiltersFeatureTest covering priority resolution, default fallback to Priorities.USER, deterministic ordering regardless of input-set order, and same-priority tie-breaking.                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
  Impact                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
  - Fixes intermittent authentication/authorization ordering failures on REST endpoints.                                                                                                                                                                                                                                                                                                                                                                                           
  - No public API changes; behavior change is limited to filter registration ordering.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
