### PR TITLE
fix: GenericUiServlet returns 500 instead of 404 for a missing generi…

### DIFF
--- a/app/src/main/java/ch/sbb/polarion/extension/generic/GenericUiServlet.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/GenericUiServlet.java
@@ -140,6 +140,12 @@ public abstract class GenericUiServlet extends HttpServlet {
         File resolvedJarFile = resolveJarFile(getCodeLocation());
         try (ZipFile zipFile = new ZipFile(resolvedJarFile)) {
             final ZipEntry zipEntry = zipFile.getEntry(uri);
+            if (zipEntry == null) {
+                // A missing entry must be answered here: ZipFile.getInputStream(null) throws
+                // NullPointerException, which would surface as 500 instead of 404.
+                response.sendError(HttpServletResponse.SC_NOT_FOUND);
+                return;
+            }
             try (InputStream inputStream = zipFile.getInputStream(zipEntry)) {
                 if (inputStream == null) {
                     response.sendError(HttpServletResponse.SC_NOT_FOUND);

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/GenericUiServlet.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/GenericUiServlet.java
@@ -141,8 +141,6 @@ public abstract class GenericUiServlet extends HttpServlet {
         try (ZipFile zipFile = new ZipFile(resolvedJarFile)) {
             final ZipEntry zipEntry = zipFile.getEntry(uri);
             if (zipEntry == null) {
-                // A missing entry must be answered here: ZipFile.getInputStream(null) throws
-                // NullPointerException, which would surface as 500 instead of 404.
                 response.sendError(HttpServletResponse.SC_NOT_FOUND);
                 return;
             }

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/GenericUiServletTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/GenericUiServletTest.java
@@ -311,6 +311,29 @@ class GenericUiServletTest {
         verify(response, never()).sendError(anyInt());
     }
 
+    @Test
+    @SneakyThrows
+    void testServeGenericResourceSends404ForMissingEntry(@TempDir Path tempDir) {
+        // A path absent from the JAR must yield 404. ZipFile.getEntry returns null for it and
+        // ZipFile.getInputStream(null) throws NullPointerException, so the entry has to be checked
+        // before it is opened, otherwise the servlet answers 500.
+        Path jarPath = tempDir.resolve("fake-extension.jar");
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(jarPath))) {
+            zos.putNextEntry(new ZipEntry("genericUri/file.js"));
+            zos.write("console.log('hi');".getBytes());
+            zos.closeEntry();
+        }
+
+        TestServlet servlet = new TestServlet("testServletName", jarPath.toUri().toURL());
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        servlet.serveGenericResource(response, "genericUri/does-not-exist.js");
+
+        verify(response).sendError(HttpServletResponse.SC_NOT_FOUND);
+        verify(response, never()).setContentType(anyString());
+        verify(response, never()).getOutputStream();
+    }
+
     @SneakyThrows
     private TestServlet callServlet(String uri) {
         TestServlet spy = spy(new TestServlet("testServletName"));


### PR DESCRIPTION
…c resource

Refs: #648

### Proposed changes

We must return proper error code when a resource is missing.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
