### PR TITLE
chore!: default markdown2html failOnError to true

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,10 @@
         <markdown2html-maven-plugin.outputFileName>about.html</markdown2html-maven-plugin.outputFileName>
         <markdown2html-maven-plugin.outputFile>${markdown2html-maven-plugin.extensionContextAdminHtml}/${markdown2html-maven-plugin.outputFileName}</markdown2html-maven-plugin.outputFile>
         <markdown2html-maven-plugin.tokenEnvVarName>GITHUB_TOKEN</markdown2html-maven-plugin.tokenEnvVarName>
-        <markdown2html-maven-plugin.failOnError>false</markdown2html-maven-plugin.failOnError>
+        <!-- A broken README.md -> about.html conversion fails the build instead of shipping an empty
+             About page. The default was lenient while the conversion called the GitHub API and failed
+             without a token; markdown2html renders locally since 1.7.x, so strictness costs nothing. -->
+        <markdown2html-maven-plugin.failOnError>true</markdown2html-maven-plugin.failOnError>
         <markdown2html-maven-plugin.generateHeadingIds>true</markdown2html-maven-plugin.generateHeadingIds>
 
         <!-- exclude rest controllers from coverage report -->


### PR DESCRIPTION
### Proposed changes

A broken README.md to about.html conversion now fails the build for every consumer, not only where an extension opts in. The default was lenient because the conversion called the GitHub API and failed without a token; markdown2html renders locally since 1.7.x, so the leniency buys nothing.

BREAKING CHANGE: a consumer that does not override markdown2html-maven-plugin.failOnError starts failing its build on a conversion error that was silent before.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
