### PR TITLE
chore: drop the dead markdown2html token parameter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,6 @@
         <markdown2html-maven-plugin.extensionContextAdminHtml>${project.basedir}/src/main/resources/webapp/${maven-jar-plugin.Extension-Context}-app/html</markdown2html-maven-plugin.extensionContextAdminHtml>
         <markdown2html-maven-plugin.outputFileName>about.html</markdown2html-maven-plugin.outputFileName>
         <markdown2html-maven-plugin.outputFile>${markdown2html-maven-plugin.extensionContextAdminHtml}/${markdown2html-maven-plugin.outputFileName}</markdown2html-maven-plugin.outputFile>
-        <markdown2html-maven-plugin.tokenEnvVarName>GITHUB_TOKEN</markdown2html-maven-plugin.tokenEnvVarName>
         <!-- A broken README.md -> about.html conversion fails the build instead of shipping an empty
              About page. The default was lenient while the conversion called the GitHub API and failed
              without a token; markdown2html renders locally since 1.7.x, so strictness costs nothing. -->
@@ -1065,7 +1064,6 @@
                     <configuration>
                         <inputFile>${markdown2html-maven-plugin.inputFile}</inputFile>
                         <outputFile>${markdown2html-maven-plugin.outputFile}</outputFile>
-                        <tokenEnvVarName>${markdown2html-maven-plugin.tokenEnvVarName}</tokenEnvVarName>
                         <failOnError>${markdown2html-maven-plugin.failOnError}</failOnError>
                         <generateHeadingIds>${markdown2html-maven-plugin.generateHeadingIds}</generateHeadingIds>
                         <excludeChapters>


### PR DESCRIPTION
### Proposed changes

markdown2html renders locally since 1.7.x, so the plugin ignores tokenEnvVarName and logs two deprecation warnings per module for passing it. Nothing else reads the property.

pdf-exporter, docx-exporter, cucumber and excel-importer still set it in their own poms; those declarations turn inert and can go on the next touch of those files.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
