### PR TITLE
refactor!: drop the generic/ path from GenericUiServlet

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,10 +464,10 @@ Extension UIs are React apps built on
 style, all bundled in its `style.css`. An app imports that stylesheet once; nothing is fetched from
 this webapp at runtime.
 
-`GenericUiServlet` still serves `/polarion/<extension>/ui/…`, and the split is unchanged: a path under
-`generic/` is read as an entry of `generic.app.jar`, everything else from the extension's own webapp.
-What that jar no longer carries is shared JavaScript, CSS or images, so a `generic/{js,css,images}/…`
-request answers 404.
+`GenericUiServlet` serves `/polarion/<extension>/ui/…` from the extension's own webapp, and nothing
+else. Until 16.0.0 a path under `generic/` took a second route: the servlet read it as an entry of
+`generic.app.jar`, which is how the shared assets above were delivered. That route is gone with them,
+so such a request is now looked up in the extension's webapp like any other and answers 404.
 
 #### Configuration pane styling
 

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/GenericUiServlet.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/GenericUiServlet.java
@@ -11,20 +11,14 @@ import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serial;
-import java.net.URISyntaxException;
 import java.net.URL;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 
 public abstract class GenericUiServlet extends HttpServlet {
 
@@ -70,11 +64,7 @@ public abstract class GenericUiServlet extends HttpServlet {
     protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
         String resourceUri = getInternalResourcePath(request.getRequestURI());
         try {
-            if (resourceUri.startsWith("generic/")) {
-                serveGenericResource(response, resourceUri.substring("generic/".length()));
-            } else {
-                serveResource(response, "/" + resourceUri);
-            }
+            serveResource(response, "/" + resourceUri);
         } catch (IOException e) {
             logger.error("Cannot copy resource '" + resourceUri + "': " + e.getMessage(), e);
             throw e;
@@ -133,45 +123,6 @@ public abstract class GenericUiServlet extends HttpServlet {
             throw new IllegalArgumentException("Path traversal not allowed");
         }
         return RESOURCE_ROOT.relativize(resolved).toString().replace('\\', '/');
-    }
-
-    @VisibleForTesting
-    void serveGenericResource(@NotNull HttpServletResponse response, @NotNull String uri) throws IOException {
-        File resolvedJarFile = resolveJarFile(getCodeLocation());
-        try (ZipFile zipFile = new ZipFile(resolvedJarFile)) {
-            final ZipEntry zipEntry = zipFile.getEntry(uri);
-            if (zipEntry == null) {
-                response.sendError(HttpServletResponse.SC_NOT_FOUND);
-                return;
-            }
-            try (InputStream inputStream = zipFile.getInputStream(zipEntry)) {
-                if (inputStream == null) {
-                    response.sendError(HttpServletResponse.SC_NOT_FOUND);
-                } else {
-                    try (ServletOutputStream outputStream = response.getOutputStream()) {
-                        setContentType(uri, response);
-                        IOUtils.copy(inputStream, outputStream);
-                    }
-                }
-            }
-        }
-    }
-
-    @VisibleForTesting
-    @NotNull URL getCodeLocation() {
-        return GenericUiServlet.class.getProtectionDomain().getCodeSource().getLocation();
-    }
-
-    @VisibleForTesting
-    static @NotNull File resolveJarFile(@NotNull URL location) {
-        try {
-            return new File(location.toURI());
-        } catch (URISyntaxException e) {
-            // CodeSource.getLocation() may return a URL with unencoded characters
-            // (e.g. literal spaces from a Windows username). URI.toURI() rejects
-            // those, so fall back to decoding the raw path.
-            return new File(URLDecoder.decode(location.getPath(), StandardCharsets.UTF_8));
-        }
     }
 
     @VisibleForTesting

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/GenericUiServlet.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/GenericUiServlet.java
@@ -14,7 +14,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serial;
-import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/GenericUiServletTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/GenericUiServletTest.java
@@ -3,30 +3,23 @@ package ch.sbb.polarion.extension.generic;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.io.TempDir;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.WriteListener;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.Serial;
 import java.net.URI;
 import java.net.URL;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -94,15 +87,13 @@ class GenericUiServletTest {
         exception = assertThrows(IllegalArgumentException.class, () -> callServlet("/polarion/testServletName/ui/evil.exe"));
         assertEquals("Unsupported file type", exception.getMessage());
 
-        // generic resource
+        // the generic/ prefix is no longer a route: it is served from the extension's own webapp
         TestServlet servlet = callServlet("/polarion/testServletName/ui/generic/genericUri/someImage.gif");
-        verify(servlet, times(1)).serveGenericResource(any(), eq("genericUri/someImage.gif"));
-        verify(servlet, times(0)).serveResource(any(), any());
+        verify(servlet, times(1)).serveResource(any(), eq("/generic/genericUri/someImage.gif"));
 
         // regular resource
         servlet = callServlet("/polarion/testServletName/ui/regularUri/someStyle.css");
-        verify(servlet, times(0)).serveGenericResource(any(), any());
-        verify(servlet, times(1)).serveResource(any(), any());
+        verify(servlet, times(1)).serveResource(any(), eq("/regularUri/someStyle.css"));
     }
 
     @Test
@@ -140,7 +131,6 @@ class GenericUiServletTest {
         // and must be served normally.
         TestServlet servlet = callServlet("/polarion/testServletName/ui/_next/static/chunks/page..a1b2c3.js");
         verify(servlet, times(1)).serveResource(any(), eq("/_next/static/chunks/page..a1b2c3.js"));
-        verify(servlet, times(0)).serveGenericResource(any(), any());
 
         servlet = callServlet("/polarion/testServletName/ui/asset..v2.css");
         verify(servlet, times(1)).serveResource(any(), eq("/asset..v2.css"));
@@ -254,93 +244,12 @@ class GenericUiServletTest {
         assertEquals("bar.css", GenericUiServlet.sanitizeResourcePath("foo%2f..%2fbar.css"));
     }
 
-    @Test
-    @SneakyThrows
-    void testResolveJarFileWithRegularPath() {
-        URL location = URI.create("file:/tmp/some-extension.jar").toURL();
-        File resolved = GenericUiServlet.resolveJarFile(location);
-        assertEquals(new File("/tmp/some-extension.jar"), resolved);
-    }
-
-    @Test
-    @SneakyThrows
-    void testResolveJarFileWithPercentEncodedSpace() {
-        URL location = URI.create("file:/tmp/dir%20with%20space/some-extension.jar").toURL();
-        File resolved = GenericUiServlet.resolveJarFile(location);
-        assertEquals(new File("/tmp/dir with space/some-extension.jar"), resolved);
-    }
-
-    @Test
-    @SneakyThrows
-    @SuppressWarnings("deprecation") // URI.create rejects unencoded characters; the test
-    // intentionally constructs a URL like the one CodeSource.getLocation() returns on
-    // Windows when the username contains spaces — that is the bug being reproduced.
-    void testResolveJarFileWithLiteralSpace() {
-        URL location = new URL("file:/C:/Users/test folder with spaces/workspace/some-extension.jar");
-        File resolved = GenericUiServlet.resolveJarFile(location);
-        // Compare File objects rather than the raw path string: File.getPath() canonicalizes
-        // "/C:/..." differently per OS (Windows strips the leading slash before the drive letter,
-        // Unix keeps it). Both sides go through the same normalization, so this holds on either.
-        assertEquals(new File("/C:/Users/test folder with spaces/workspace/some-extension.jar"), resolved);
-    }
-
-    @Test
-    @SneakyThrows
-    void testServeGenericResourceServesEntryFromJar(@TempDir Path tempDir) {
-        // Test the full serveGenericResource flow against a real ZIP — covers the
-        // resolveJarFile(getCodeLocation()) wiring inside the try-with-resources.
-        // Includes a literal space in the path to mirror the original failure mode.
-        Path dirWithSpace = Files.createDirectory(tempDir.resolve("dir with space"));
-        Path jarPath = dirWithSpace.resolve("fake-extension.jar");
-        byte[] payload = "console.log('hi');".getBytes();
-        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(jarPath))) {
-            zos.putNextEntry(new ZipEntry("genericUri/file.js"));
-            zos.write(payload);
-            zos.closeEntry();
-        }
-
-        TestServlet servlet = new TestServlet("testServletName", jarPath.toUri().toURL());
-        HttpServletResponse response = mock(HttpServletResponse.class);
-        ByteArrayOutputStream captured = new ByteArrayOutputStream();
-        when(response.getOutputStream()).thenReturn(new CapturingServletOutputStream(captured));
-
-        servlet.serveGenericResource(response, "genericUri/file.js");
-
-        verify(response).setContentType("text/javascript");
-        assertArrayEquals(payload, captured.toByteArray());
-        verify(response, never()).sendError(anyInt());
-    }
-
-    @Test
-    @SneakyThrows
-    void testServeGenericResourceSends404ForMissingEntry(@TempDir Path tempDir) {
-        // A path absent from the JAR must yield 404. ZipFile.getEntry returns null for it and
-        // ZipFile.getInputStream(null) throws NullPointerException, so the entry has to be checked
-        // before it is opened, otherwise the servlet answers 500.
-        Path jarPath = tempDir.resolve("fake-extension.jar");
-        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(jarPath))) {
-            zos.putNextEntry(new ZipEntry("genericUri/file.js"));
-            zos.write("console.log('hi');".getBytes());
-            zos.closeEntry();
-        }
-
-        TestServlet servlet = new TestServlet("testServletName", jarPath.toUri().toURL());
-        HttpServletResponse response = mock(HttpServletResponse.class);
-
-        servlet.serveGenericResource(response, "genericUri/does-not-exist.js");
-
-        verify(response).sendError(HttpServletResponse.SC_NOT_FOUND);
-        verify(response, never()).setContentType(anyString());
-        verify(response, never()).getOutputStream();
-    }
-
     @SneakyThrows
     private TestServlet callServlet(String uri) {
         TestServlet spy = spy(new TestServlet("testServletName"));
         HttpServletRequest request = mock(HttpServletRequest.class);
         HttpServletResponse response = mock(HttpServletResponse.class);
         when(request.getRequestURI()).thenReturn(uri);
-        lenient().doNothing().when(spy).serveGenericResource(any(), any());
         lenient().doNothing().when(spy).serveResource(any(), any());
         spy.service(request, response);
         return spy;
@@ -351,20 +260,8 @@ class GenericUiServletTest {
         @Serial
         private static final long serialVersionUID = 7300367869059799910L;
 
-        private final URL codeLocationOverride;
-
         protected TestServlet(String webAppName) {
-            this(webAppName, null);
-        }
-
-        protected TestServlet(String webAppName, URL codeLocationOverride) {
             super(webAppName);
-            this.codeLocationOverride = codeLocationOverride;
-        }
-
-        @Override
-        URL getCodeLocation() {
-            return codeLocationOverride != null ? codeLocationOverride : super.getCodeLocation();
         }
     }
 

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/GenericUiServletTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/GenericUiServletTest.java
@@ -3,19 +3,13 @@ package ch.sbb.polarion.extension.generic;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import jakarta.servlet.ServletOutputStream;
-import jakarta.servlet.WriteListener;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.ByteArrayOutputStream;
 import java.io.Serial;
-import java.net.URI;
-import java.net.URL;
-import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -265,26 +259,4 @@ class GenericUiServletTest {
         }
     }
 
-    private static final class CapturingServletOutputStream extends ServletOutputStream {
-        private final ByteArrayOutputStream sink;
-
-        CapturingServletOutputStream(ByteArrayOutputStream sink) {
-            this.sink = sink;
-        }
-
-        @Override
-        public boolean isReady() {
-            return true;
-        }
-
-        @Override
-        public void setWriteListener(WriteListener writeListener) {
-            // not needed for blocking writes in tests
-        }
-
-        @Override
-        public void write(int b) {
-            sink.write(b);
-        }
-    }
 }


### PR DESCRIPTION
Closes #674. Follow-up to #671, which removed the files this route existed to serve.

## What goes

In `GenericUiServlet`:

- the `resourceUri.startsWith("generic/")` branch in `service`
- `serveGenericResource`, `resolveJarFile`, `getCodeLocation`
- seven imports left without a user: `ZipFile`, `ZipEntry`, `File`, `URL`, `URLDecoder`,
  `URISyntaxException`, `StandardCharsets`

Nothing else changes: `getInternalResourcePath`, `sanitizeResourcePath` and `serveResource` are
untouched, and so is every path-traversal check around them.

## Why it is safe

After #671 the jar holds classes, `META-INF/MANIFEST.MF` and the two Swagger pages.
`getInternalResourcePath` rejects any extension outside `ALLOWED_FILE_TYPES`, so `.class` and `.MF`
were never reachable through this route anyway. That left `swagger_ui.html` and
`swagger_unavailable.html`, and `SwaggerController` serves both from the classpath itself
(`getClass().getResourceAsStream("/swagger_ui.html")`), not through the servlet.

No extension requests anything under `ui/generic/`: checked across all 71 working copies on their
default branches. The last two references were configuration only, and both are handled separately -
`pat-generator`'s `/ui/generic/*` authentication exemption in its test webapp, and a `diff-tool.st`
system test that still asserted the prefix is public.

## Tests

The routing behaviour is pinned rather than dropped: the routing test now asserts that
`/polarion/testServletName/ui/generic/genericUri/someImage.gif` reaches `serveResource` with
`/generic/genericUri/someImage.gif`, so the prefix demonstrably goes to the extension's own webapp.
The traversal tests, including `ui/generic/../../escape.html`, are unchanged.

Five tests go with the code they covered: three around `resolveJarFile`, and two around
`serveGenericResource`. One of those two, `testServeGenericResourceSends404ForMissingEntry`, was the
regression guard for #648 (a null `ZipEntry` passed to `ZipFile.getInputStream` surfaced as 500).
That guard is not being weakened - the code path it guarded no longer exists.

`mvn clean verify` passes on JDK 21; `GenericUiServletTest` runs 59 tests.

## Breaking

`/polarion/<extension>/ui/generic/*` is no longer a route into `generic.app.jar`. Such a request is
answered from the extension's own webapp, which is a 404 for these paths.