### PR TITLE
feat: add LuceneUtils for assembling Lucene queries

### DIFF
--- a/app/src/main/java/ch/sbb/polarion/extension/generic/util/LuceneUtils.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/util/LuceneUtils.java
@@ -34,8 +34,21 @@ public class LuceneUtils {
     private static final String CHARACTERS_TO_ESCAPE = "\\+-!(){}[]^\"~:*?";
 
     /**
-     * Escapes a value for use as a term in a Lucene query. A value containing a space becomes a quoted
-     * phrase, which is how Polarion itself passes such a value to the index.
+     * The characters Lucene's query parser skips between tokens, as its grammar declares them in {@code SKIP}.
+     * Each of them ends an unquoted term, so a value containing any one of them has to become a phrase for the
+     * same reason a value containing a space does.
+     * <p>
+     * Polarion quotes on the plain space alone, so this set is the second place where this class is
+     * deliberately stricter than {@code LuceneQueryPart.escape}. Measured against a live index: with
+     * {@code id:X} matching one work item, {@code id:X<tab>Execute} matches two, and so do the newline and
+     * the ideographic space, because the trailing token becomes a term of the default field. Quoting the value
+     * confines it, and a quoted value still matches a stored value that genuinely contains the whitespace.
+     */
+    private static final char[] QUERY_WHITESPACE = {' ', '\t', '\n', '\r', '\u3000'};
+
+    /**
+     * Escapes a value for use as a term in a Lucene query. A value containing whitespace becomes a quoted
+     * phrase, which is how Polarion itself passes a value containing a space to the index.
      *
      * @param value the value to escape
      * @return the escaped value, ready to be concatenated after a field name and a colon
@@ -46,7 +59,16 @@ public class LuceneUtils {
             escaped = escaped.replace(String.valueOf(character), "\\" + character);
         }
         escaped = escaped.replace("&&", "\\&&").replace("||", "\\||");
-        return escaped.contains(" ") ? "\"" + escaped + "\"" : escaped;
+        return containsQueryWhitespace(escaped) ? "\"" + escaped + "\"" : escaped;
+    }
+
+    private static boolean containsQueryWhitespace(@NotNull String value) {
+        for (char whitespace : QUERY_WHITESPACE) {
+            if (value.indexOf(whitespace) >= 0) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/app/src/main/java/ch/sbb/polarion/extension/generic/util/LuceneUtils.java
+++ b/app/src/main/java/ch/sbb/polarion/extension/generic/util/LuceneUtils.java
@@ -1,0 +1,121 @@
+package ch.sbb.polarion.extension.generic.util;
+
+import com.polarion.alm.projects.model.IUniqueObject;
+import lombok.experimental.UtilityClass;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Assembles Lucene queries for Polarion's search APIs.
+ * <p>
+ * Every value placed into a query goes through {@link #escapeValue(String)}. An unescaped value fails in
+ * one of three ways: it silently stops matching what the caller meant, it makes the query unparseable, or,
+ * when it carries a wildcard, it matches a whole family of entities instead of one.
+ */
+@UtilityClass
+public class LuceneUtils {
+
+    public static final String PROJECT_ID_FIELD = IUniqueObject.KEY_PROJECT + ".id";
+
+    /**
+     * The characters Polarion escapes in {@code com.polarion.alm.shared.tracker.query.LuceneQueryPart.escape},
+     * plus the two wildcards. Polarion leaves {@code *} and {@code ?} alone so that a user can type a wildcard
+     * on purpose in its query builder; a value arriving from a request or an uploaded file has to match
+     * literally, so both are escaped here.
+     * <p>
+     * The backslash comes first: it has to be doubled before the escapes added below introduce their own.
+     */
+    private static final String CHARACTERS_TO_ESCAPE = "\\+-!(){}[]^\"~:*?";
+
+    /**
+     * Escapes a value for use as a term in a Lucene query. A value containing a space becomes a quoted
+     * phrase, which is how Polarion itself passes such a value to the index.
+     *
+     * @param value the value to escape
+     * @return the escaped value, ready to be concatenated after a field name and a colon
+     */
+    public static @NotNull String escapeValue(@NotNull String value) {
+        String escaped = value;
+        for (char character : CHARACTERS_TO_ESCAPE.toCharArray()) {
+            escaped = escaped.replace(String.valueOf(character), "\\" + character);
+        }
+        escaped = escaped.replace("&&", "\\&&").replace("||", "\\||");
+        return escaped.contains(" ") ? "\"" + escaped + "\"" : escaped;
+    }
+
+    /**
+     * A single {@code field:value} term with the value escaped. The field is a field name rather than a
+     * value, so it is used as it is.
+     *
+     * @param field the field name
+     * @param value the value to match
+     * @return the term
+     */
+    public static @NotNull String term(@NotNull String field, @NotNull String value) {
+        return field + ":" + escapeValue(value);
+    }
+
+    /**
+     * The {@code project.id} term restricting a query to one project. Several Polarion search methods are
+     * repository wide and are restricted this way rather than by their arguments.
+     *
+     * @param projectId the project to restrict to
+     * @return the term
+     */
+    public static @NotNull String projectTerm(@NotNull String projectId) {
+        return term(PROJECT_ID_FIELD, projectId);
+    }
+
+    /**
+     * One field matched against any of several values, each escaped. Null and blank values are left out.
+     * <p>
+     * The terms are joined but not parenthesized, because {@link #and(String...)} parenthesizes every part
+     * it combines: grouping here as well would only produce a second pair of brackets.
+     *
+     * @param field  the field name
+     * @param values the values to match, any of which may be null
+     * @return the alternative, or null when no usable value was given
+     */
+    public static @Nullable String anyOf(@NotNull String field, @Nullable Collection<String> values) {
+        if (values == null) {
+            return null;
+        }
+        List<String> terms = values.stream()
+                .filter(Objects::nonNull)
+                .filter(value -> !value.isBlank())
+                .map(value -> term(field, value))
+                .toList();
+        return terms.isEmpty() ? null : String.join(" OR ", terms);
+    }
+
+    /**
+     * Combines query parts into a conjunction, leaving out the parts that are null or blank. Each part is
+     * parenthesized whenever there is more than one, because a part may be a free-form query the caller did
+     * not build: {@code a OR b} combined unparenthesized would no longer be a restriction.
+     *
+     * @param parts the parts to combine, any of which may be null
+     * @return the combined query, or an empty string when no usable part was given
+     */
+    public static @NotNull String and(@Nullable String... parts) {
+        if (parts == null) {
+            return "";
+        }
+        List<String> usableParts = Arrays.stream(parts)
+                .filter(Objects::nonNull)
+                .filter(part -> !part.isBlank())
+                .toList();
+        if (usableParts.isEmpty()) {
+            return "";
+        }
+        if (usableParts.size() == 1) {
+            return usableParts.get(0);
+        }
+        return usableParts.stream().collect(Collectors.joining(") AND (", "(", ")"));
+    }
+}

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/util/LuceneUtilsPolarionParityTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/util/LuceneUtilsPolarionParityTest.java
@@ -1,0 +1,43 @@
+package ch.sbb.polarion.extension.generic.util;
+
+import com.polarion.alm.shared.tracker.query.LuceneQueryPart;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Pins {@link LuceneUtils#escapeValue(String)} to Polarion's own escaping instead of leaving the character
+ * list to be reviewed by eye. A Polarion upgrade that changes the rules fails here.
+ * <p>
+ * The two wildcards are left out of the comparison on purpose: Polarion protects them from escaping so that
+ * a wildcard typed into its query builder survives, which is the one place this class deliberately differs.
+ * {@link LuceneUtilsTest} covers that difference.
+ */
+class LuceneUtilsPolarionParityTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "T123",
+            "",
+            "T-123",
+            "+A",
+            "A(B)",
+            "A{B}",
+            "A[B]",
+            "A^B",
+            "A~B",
+            "A!B",
+            "a:b",
+            "a\"b",
+            "a&&b",
+            "a||b",
+            "a\\b",
+            "ABC 123",
+            "+A -B",
+            "a\\-b"
+    })
+    void testEscapingMatchesPolarion(String value) {
+        assertEquals(LuceneQueryPart.escape(value), LuceneUtils.escapeValue(value));
+    }
+}

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/util/LuceneUtilsPolarionParityTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/util/LuceneUtilsPolarionParityTest.java
@@ -1,43 +1,80 @@
 package ch.sbb.polarion.extension.generic.util;
 
 import com.polarion.alm.shared.tracker.query.LuceneQueryPart;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * Pins {@link LuceneUtils#escapeValue(String)} to Polarion's own escaping instead of leaving the character
  * list to be reviewed by eye. A Polarion upgrade that changes the rules fails here.
  * <p>
- * The two wildcards are left out of the comparison on purpose: Polarion protects them from escaping so that
- * a wildcard typed into its query builder survives, which is the one place this class deliberately differs.
- * {@link LuceneUtilsTest} covers that difference.
+ * The character range is generated rather than listed, so the test also covers the direction a hand-written
+ * list cannot: a character Polarion escapes and this class does not. Both intentional divergences are pinned
+ * by their own tests below, so neither can be introduced silently and neither reads as an omission.
  */
 class LuceneUtilsPolarionParityTest {
 
+    private static final char WILDCARD_ANY = '*';
+    private static final char WILDCARD_ONE = '?';
+
+    @ParameterizedTest
+    @MethodSource("everyPrintableCharacter")
+    void testEscapingMatchesPolarionForEveryPrintableCharacter(String value) {
+        assertEquals(LuceneQueryPart.escape(value), LuceneUtils.escapeValue(value));
+    }
+
+    static Stream<String> everyPrintableCharacter() {
+        // The wildcards are a documented divergence and have their own test.
+        return IntStream.rangeClosed(0x20, 0x7E)
+                .filter(character -> character != WILDCARD_ANY && character != WILDCARD_ONE)
+                .mapToObj(character -> "a" + (char) character + "b");
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {
-            "T123",
             "",
-            "T-123",
-            "+A",
-            "A(B)",
-            "A{B}",
-            "A[B]",
-            "A^B",
-            "A~B",
-            "A!B",
-            "a:b",
-            "a\"b",
+            "T123",
+            "a\\b",
+            "a\\-b",
             "a&&b",
             "a||b",
-            "a\\b",
             "ABC 123",
-            "+A -B",
-            "a\\-b"
+            "+A -B"
     })
-    void testEscapingMatchesPolarion(String value) {
+    void testEscapingMatchesPolarionForValuesTheRangeCannotExpress(String value) {
         assertEquals(LuceneQueryPart.escape(value), LuceneUtils.escapeValue(value));
+    }
+
+    @Test
+    void testWildcardsAreTheFirstIntentionalDivergence() {
+        // Polarion protects these so a wildcard typed into its query builder survives. A value arriving from
+        // a request or an uploaded file has to match literally, so this class escapes them.
+        assertEquals("a*b", LuceneQueryPart.escape("a*b"));
+        assertEquals("a\\*b", LuceneUtils.escapeValue("a*b"));
+        assertEquals("a?b", LuceneQueryPart.escape("a?b"));
+        assertEquals("a\\?b", LuceneUtils.escapeValue("a?b"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"a\tb", "a\nb", "a\rb", "a　b"})
+    void testNonSpaceWhitespaceIsTheSecondIntentionalDivergence(String value) {
+        // Polarion quotes on the plain space alone, which leaves the other characters its parser skips free to
+        // end the term. This class quotes on all of them, so the two disagree here by design.
+        assertNotEquals(LuceneQueryPart.escape(value), LuceneUtils.escapeValue(value));
+        assertEquals("\"" + value + "\"", LuceneUtils.escapeValue(value));
+    }
+
+    @Test
+    void testTheSpaceItselfStillAgreesWithPolarion() {
+        assertEquals(LuceneQueryPart.escape("a b"), LuceneUtils.escapeValue("a b"));
+        assertEquals("\"a b\"", LuceneUtils.escapeValue("a b"));
     }
 }

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/util/LuceneUtilsTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/util/LuceneUtilsTest.java
@@ -1,0 +1,132 @@
+package ch.sbb.polarion.extension.generic.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class LuceneUtilsTest {
+
+    @Test
+    void testValueWithoutSpecialCharactersStaysAsItIs() {
+        assertEquals("T123", LuceneUtils.escapeValue("T123"));
+        assertEquals("", LuceneUtils.escapeValue(""));
+    }
+
+    @Test
+    void testSpaceTurnsTheValueIntoAPhrase() {
+        assertEquals("\"ABC 123\"", LuceneUtils.escapeValue("ABC 123"));
+    }
+
+    @Test
+    void testMetaCharactersAreEscaped() {
+        assertEquals("T\\-123", LuceneUtils.escapeValue("T-123"));
+        assertEquals("\\+A", LuceneUtils.escapeValue("+A"));
+        assertEquals("A\\(B\\)", LuceneUtils.escapeValue("A(B)"));
+        assertEquals("A\\{B\\}", LuceneUtils.escapeValue("A{B}"));
+        assertEquals("A\\[B\\]", LuceneUtils.escapeValue("A[B]"));
+        assertEquals("A\\^B", LuceneUtils.escapeValue("A^B"));
+        assertEquals("A\\~B", LuceneUtils.escapeValue("A~B"));
+        assertEquals("A\\!B", LuceneUtils.escapeValue("A!B"));
+        assertEquals("a\\:b", LuceneUtils.escapeValue("a:b"));
+        assertEquals("a\\\"b", LuceneUtils.escapeValue("a\"b"));
+    }
+
+    @Test
+    void testBooleanOperatorsAreEscaped() {
+        assertEquals("a\\&&b", LuceneUtils.escapeValue("a&&b"));
+        assertEquals("a\\||b", LuceneUtils.escapeValue("a||b"));
+    }
+
+    @Test
+    void testBackslashIsEscapedBeforeTheEscapesAdded() {
+        // A single backslash comes out doubled. Escaping it last would also double the backslashes this
+        // method introduced for the other characters.
+        assertEquals("a\\\\b", LuceneUtils.escapeValue("a\\b"));
+        assertEquals("a\\\\\\-b", LuceneUtils.escapeValue("a\\-b"));
+    }
+
+    @Test
+    void testWildcardsAreEscaped() {
+        assertEquals("AB\\*", LuceneUtils.escapeValue("AB*"));
+        assertEquals("A\\?B", LuceneUtils.escapeValue("A?B"));
+    }
+
+    @Test
+    void testMetaCharactersInsideAPhrase() {
+        assertEquals("\"\\+A \\-B\"", LuceneUtils.escapeValue("+A -B"));
+    }
+
+    @Test
+    void testTerm() {
+        assertEquals("title:\"a title\"", LuceneUtils.term("title", "a title"));
+        assertEquals("id:T\\-1", LuceneUtils.term("id", "T-1"));
+    }
+
+    @Test
+    void testProjectTerm() {
+        assertEquals("project.id:elibrary", LuceneUtils.projectTerm("elibrary"));
+        // The project id reaches this from a request in several places, so it is escaped like any value.
+        assertEquals("project.id:\"x\\\" OR project.id\\:other\"", LuceneUtils.projectTerm("x\" OR project.id:other"));
+    }
+
+    @Test
+    void testAnyOf() {
+        assertEquals("id:T\\-1", LuceneUtils.anyOf("id", List.of("T-1")));
+        // Not parenthesized here: and(...) brackets every part it combines.
+        assertEquals("id:T\\-1 OR id:T\\-2", LuceneUtils.anyOf("id", List.of("T-1", "T-2")));
+    }
+
+    @Test
+    void testAnyOfWithoutUsableValues() {
+        assertNull(LuceneUtils.anyOf("id", null));
+        assertNull(LuceneUtils.anyOf("id", List.of()));
+        assertNull(LuceneUtils.anyOf("id", Arrays.asList(null, "", "  ")));
+    }
+
+    @Test
+    void testAnyOfSkipsUnusableValues() {
+        assertEquals("id:T\\-1", LuceneUtils.anyOf("id", Arrays.asList(null, "T-1", "")));
+    }
+
+    @Test
+    void testAnd() {
+        assertEquals("project.id:elibrary", LuceneUtils.and("project.id:elibrary"));
+        assertEquals("(project.id:elibrary) AND (type:testcase)", LuceneUtils.and("project.id:elibrary", "type:testcase"));
+    }
+
+    @Test
+    void testAndParenthesizesEveryPart() {
+        // The second part is a free-form query the caller did not build. Combined unparenthesized it would
+        // read as "project.id:elibrary AND a OR b", which is no longer restricted to the project.
+        assertEquals("(project.id:elibrary) AND (a OR b)", LuceneUtils.and("project.id:elibrary", "a OR b"));
+    }
+
+    @Test
+    void testAndWithoutUsableParts() {
+        assertEquals("", LuceneUtils.and());
+        assertEquals("", LuceneUtils.and((String[]) null));
+        assertEquals("", LuceneUtils.and(null, "", "  "));
+    }
+
+    @Test
+    void testAndSkipsUnusableParts() {
+        assertEquals("project.id:elibrary", LuceneUtils.and(null, "project.id:elibrary", ""));
+    }
+
+    @Test
+    void testAnyOfCombinesWithAnd() {
+        String query = LuceneUtils.and(LuceneUtils.projectTerm("elibrary"), LuceneUtils.anyOf("customField", Set.of("A B")));
+        assertEquals("(project.id:elibrary) AND (customField:\"A B\")", query);
+    }
+
+    @Test
+    void testSeveralValuesCombineWithAndWithoutDoubleBrackets() {
+        String query = LuceneUtils.and(LuceneUtils.projectTerm("elibrary"), LuceneUtils.anyOf("id", List.of("T-1", "T-2")));
+        assertEquals("(project.id:elibrary) AND (id:T\\-1 OR id:T\\-2)", query);
+    }
+}

--- a/app/src/test/java/ch/sbb/polarion/extension/generic/util/LuceneUtilsTest.java
+++ b/app/src/test/java/ch/sbb/polarion/extension/generic/util/LuceneUtilsTest.java
@@ -23,6 +23,16 @@ class LuceneUtilsTest {
     }
 
     @Test
+    void testEveryWhitespaceLuceneSkipsTurnsTheValueIntoAPhrase() {
+        // Each of these ends an unquoted term in Lucene's grammar, so each one has to quote the value. Left
+        // unquoted, the trailing token becomes a term of the default field and widens the query.
+        assertEquals("\"ABC\t123\"", LuceneUtils.escapeValue("ABC\t123"));
+        assertEquals("\"ABC\n123\"", LuceneUtils.escapeValue("ABC\n123"));
+        assertEquals("\"ABC\r123\"", LuceneUtils.escapeValue("ABC\r123"));
+        assertEquals("\"ABC　123\"", LuceneUtils.escapeValue("ABC　123"));
+    }
+
+    @Test
     void testMetaCharactersAreEscaped() {
         assertEquals("T\\-123", LuceneUtils.escapeValue("T-123"));
         assertEquals("\\+A", LuceneUtils.escapeValue("+A"));


### PR DESCRIPTION
Closes the API proposed in #690.

## What

`util/LuceneUtils`, alongside `ScopeUtils` and the other `*Utils` classes:

| Method | Purpose |
|---|---|
| `escapeValue(String)` | escape a value for use as a term, quoting it when it contains a space |
| `term(String, String)` | `field:escapedValue` |
| `projectTerm(String)` | the `project.id:` restriction, field name from `IUniqueObject.KEY_PROJECT` |
| `anyOf(String, Collection<String>)` | one field against several values, null and blank skipped, `null` when nothing is usable |
| `and(String...)` | conjunction, blank parts dropped |

Not `ScopeUtils`, deliberately: that class owns Polarion's *scope* strings (`project/elibrary/`), a different concept from a Lucene `project.id:` term, and two meanings of "scope" in one utility is how the wrong one gets picked.

## Two deltas against the issue

- **`term(String, String)` was added**, which #690 did not list. `projectTerm` and `anyOf` both need it and callers do too.
- **`and(...)` parenthesizes every part when there are two or more**, where #690 said "the compound ones". Deciding which part is compound needs a guess about the caller's string, and guessing is what the missing escapes were. `(project.id:x) AND (type:y)` carries a redundant bracket pair and is correct by construction; a part that is a free-form query such as `a OR b` combined without brackets silently stops being a restriction.

## The escaping is checked, not eyeballed

`com.polarion.alm.shared.tracker.query` is exported without an `x-friends` restriction and this project already depends on that bundle, so `LuceneQueryPart.escape` is callable. `LuceneUtilsPolarionParityTest` asserts `escapeValue(v) == LuceneQueryPart.escape(v)` for 18 values containing no wildcard. A platform upgrade that changes the rules fails the build rather than drifting.

The wildcards are the one intentional divergence: Polarion protects `*` and `?` via `encodeForParsing` so a wildcard typed into its query builder survives, whereas a value arriving from a request or an uploaded file has to match literally. `LuceneUtilsTest` covers that difference so it does not read as an omission.

## Tested

Full suite: 509 tests, 0 failures. 35 of those are the two new classes.

Beyond unit tests, the helper was exercised end to end against a live Polarion index while adapting six extensions to it locally, including a check that escaping `-` does not stop a work item id from matching, which is the case with the widest blast radius.

## Note for reviewers

`and(...)` is safe to call with a purely negative part such as `NOT type:heading`. That was measured against a live index: `(NOT type:generic) AND (id:X)` and `NOT type:generic AND id:X` return the same result, standalone and inside a conjunction. An earlier draft of this change warned against it in the javadoc; the warning was wrong and is not present.